### PR TITLE
feat: keep table content almost as is if cannot be formatted

### DIFF
--- a/src/pretty/func_call.rs
+++ b/src/pretty/func_call.rs
@@ -1,0 +1,113 @@
+use pretty::BoxDoc;
+use typst_syntax::{ast::*, SyntaxKind};
+
+use crate::{
+    util::{comma_seprated_items, FoldStyle},
+    PrettyPrinter,
+};
+
+use super::{
+    table,
+    util::{self, get_parenthesized_args},
+};
+
+impl PrettyPrinter {
+    pub(super) fn convert_func_call<'a>(&'a self, func_call: FuncCall<'a>) -> BoxDoc<'a, ()> {
+        let mut doc = BoxDoc::nil().append(self.convert_expr(func_call.callee()));
+        if let Some(res) = self.check_disabled(func_call.args().to_untyped()) {
+            return doc.append(res);
+        }
+        let has_parenthesized_args = util::has_parenthesized_args(func_call);
+        if let Some(cols) = table::is_formatable_table(func_call) {
+            doc = doc.append(self.convert_table(func_call, cols));
+        } else if has_parenthesized_args {
+            doc = doc.append(self.convert_parenthesized_args(func_call.args()));
+        };
+        doc.append(self.convert_additional_args(func_call.args(), has_parenthesized_args))
+    }
+
+    pub(super) fn convert_parenthesized_args<'a>(&'a self, args: Args<'a>) -> BoxDoc<'a, ()> {
+        let (args, prefer_tighter, is_multiline) = self.convert_parenthesized_args_impl(args);
+        let doc = if prefer_tighter {
+            BoxDoc::text("(")
+                .append(args.into_iter().next().unwrap_or_else(BoxDoc::nil))
+                .append(BoxDoc::text(")"))
+        } else {
+            comma_seprated_items(
+                args.into_iter(),
+                if is_multiline {
+                    FoldStyle::Never
+                } else {
+                    FoldStyle::Fit
+                },
+            )
+        };
+        doc
+    }
+
+    fn convert_parenthesized_args_impl<'a>(
+        &'a self,
+        args: Args<'a>,
+    ) -> (Vec<BoxDoc<'a, ()>>, bool, bool) {
+        let node = args.to_untyped();
+        let mut last_arg = None;
+        let mut is_multiline = false;
+        for node in node
+            .children()
+            .take_while(|node| node.kind() != SyntaxKind::RightParen)
+        {
+            if let Some(space) = node.cast::<Space>() {
+                is_multiline = is_multiline || space.to_untyped().text().contains('\n');
+                break;
+            }
+        }
+        let args: Vec<BoxDoc<'a, ()>> = get_parenthesized_args(args)
+            .map(|arg| {
+                last_arg = Some(arg);
+                is_multiline = is_multiline
+                    || self
+                        .attr_map
+                        .get(arg.to_untyped())
+                        .map_or(false, |attr| attr.is_multiline_flavor());
+                self.convert_arg(arg)
+            })
+            .collect();
+        // We prefer tighter style if...
+        // 1. There are no arguments
+        // 2. There is only one argument and it is not a function call
+        let prefer_tighter = args.is_empty()
+            || (args.len() == 1 && {
+                let arg = last_arg.unwrap();
+                let rhs = match arg {
+                    Arg::Pos(p) => p,
+                    Arg::Named(n) => n.expr(),
+                    Arg::Spread(s) => s.expr(),
+                };
+                !matches!(rhs, Expr::FuncCall(..))
+            });
+        (args, prefer_tighter, is_multiline)
+    }
+
+    fn convert_additional_args<'a>(&'a self, args: Args<'a>, has_paren: bool) -> BoxDoc<'a, ()> {
+        let node = args.to_untyped();
+        let args = node
+            .children()
+            .skip_while(|node| {
+                if has_paren {
+                    node.kind() != SyntaxKind::RightParen
+                } else {
+                    node.kind() != SyntaxKind::ContentBlock
+                }
+            })
+            .filter_map(|node| node.cast::<'_, Arg>());
+        BoxDoc::concat(args.map(|arg| self.convert_arg(arg))).group()
+    }
+
+    pub(super) fn convert_arg<'a>(&'a self, arg: Arg<'a>) -> BoxDoc<'a, ()> {
+        match arg {
+            Arg::Pos(p) => self.convert_expr(p),
+            Arg::Named(n) => self.convert_named(n),
+            Arg::Spread(s) => self.convert_spread(s),
+        }
+    }
+}

--- a/src/pretty/func_call.rs
+++ b/src/pretty/func_call.rs
@@ -1,15 +1,26 @@
 use pretty::BoxDoc;
-use typst_syntax::{ast::*, SyntaxKind};
+use typst_syntax::{ast::*, SyntaxKind, SyntaxNode};
 
 use crate::{
+    pretty::trivia,
     util::{comma_seprated_items, FoldStyle},
     PrettyPrinter,
 };
 
 use super::{
     table,
-    util::{self, get_parenthesized_args},
+    util::{self, get_parenthesized_args, get_parenthesized_args_untyped},
 };
+
+#[derive(Debug)]
+pub(super) enum ParenthesizedFuncCallArg<'a> {
+    Argument(Arg<'a>),
+    Comma,
+    Space,
+    Newline(usize),
+    LineComment(&'a SyntaxNode),
+    BlockComment(&'a SyntaxNode),
+}
 
 impl PrettyPrinter {
     pub(super) fn convert_func_call<'a>(&'a self, func_call: FuncCall<'a>) -> BoxDoc<'a, ()> {
@@ -18,8 +29,12 @@ impl PrettyPrinter {
             return doc.append(res);
         }
         let has_parenthesized_args = util::has_parenthesized_args(func_call);
-        if let Some(cols) = table::is_formatable_table(func_call) {
-            doc = doc.append(self.convert_table(func_call, cols));
+        if table::is_table(func_call) {
+            if let Some(cols) = table::is_formatable_table(func_call) {
+                doc = doc.append(self.convert_table(func_call, cols));
+            } else if has_parenthesized_args {
+                doc = doc.append(self.convert_parenthesized_args_as_is(func_call.args()));
+            }
         } else if has_parenthesized_args {
             doc = doc.append(self.convert_parenthesized_args(func_call.args()));
         };
@@ -43,6 +58,36 @@ impl PrettyPrinter {
             )
         };
         doc
+    }
+
+    pub(super) fn convert_parenthesized_args_as_is<'a>(&'a self, args: Args<'a>) -> BoxDoc<'a, ()> {
+        let args = parse_args(args);
+        let mut inner = BoxDoc::nil();
+        for arg in args {
+            match arg {
+                ParenthesizedFuncCallArg::Argument(arg) => {
+                    inner = inner.append(self.convert_arg(arg));
+                }
+                ParenthesizedFuncCallArg::Comma => {
+                    inner = inner.append(BoxDoc::text(","));
+                }
+                ParenthesizedFuncCallArg::Space => {
+                    inner = inner.append(BoxDoc::space());
+                }
+                ParenthesizedFuncCallArg::Newline(count) => {
+                    for _ in 0..count {
+                        inner = inner.append(BoxDoc::hardline());
+                    }
+                }
+                ParenthesizedFuncCallArg::LineComment(comment)
+                | ParenthesizedFuncCallArg::BlockComment(comment) => {
+                    inner = inner.append(trivia(comment));
+                }
+            }
+        }
+        BoxDoc::text("(")
+            .append(inner.nest(2))
+            .append(BoxDoc::text(")"))
     }
 
     fn convert_parenthesized_args_impl<'a>(
@@ -110,4 +155,36 @@ impl PrettyPrinter {
             Arg::Spread(s) => self.convert_spread(s),
         }
     }
+}
+
+fn parse_args(args: Args<'_>) -> Vec<ParenthesizedFuncCallArg<'_>> {
+    let mut res = Vec::new();
+    for node in get_parenthesized_args_untyped(args) {
+        match node.kind() {
+            SyntaxKind::Comma => {
+                res.push(ParenthesizedFuncCallArg::Comma);
+            }
+            SyntaxKind::Space => {
+                let text = node.text();
+                let newline_count = text.chars().filter(|&c| c == '\n').count();
+                if newline_count > 0 {
+                    res.push(ParenthesizedFuncCallArg::Newline(newline_count));
+                } else {
+                    res.push(ParenthesizedFuncCallArg::Space);
+                }
+            }
+            SyntaxKind::LineComment => {
+                res.push(ParenthesizedFuncCallArg::LineComment(node));
+            }
+            SyntaxKind::BlockComment => {
+                res.push(ParenthesizedFuncCallArg::BlockComment(node));
+            }
+            _ => {
+                res.push(ParenthesizedFuncCallArg::Argument(
+                    node.cast::<Arg>().unwrap(),
+                ));
+            }
+        }
+    }
+    res
 }

--- a/src/pretty/mod.rs
+++ b/src/pretty/mod.rs
@@ -8,6 +8,7 @@ use typst_syntax::{ast, ast::*, SyntaxKind, SyntaxNode};
 use crate::attr::Attributes;
 use crate::util::{comma_seprated_items, pretty_items, FoldStyle};
 
+mod func_call;
 mod table;
 mod util;
 
@@ -627,108 +628,6 @@ impl PrettyPrinter {
         // TODO: typst doesn't support this
         // left.append(multiline_right.flat_alt(singleline_right))
         left.append(singleline_right)
-    }
-
-    fn convert_func_call<'a>(&'a self, func_call: FuncCall<'a>) -> BoxDoc<'a, ()> {
-        let mut doc = BoxDoc::nil().append(self.convert_expr(func_call.callee()));
-        if let Some(res) = self.check_disabled(func_call.args().to_untyped()) {
-            return doc.append(res);
-        }
-        let has_parenthesized_args = util::has_parenthesized_args(func_call);
-        if let Some(cols) = table::is_formatable_table(func_call) {
-            doc = doc.append(self.convert_table(func_call, cols));
-        } else if has_parenthesized_args {
-            doc = doc.append(self.convert_parenthesized_args(func_call.args()));
-        };
-        doc.append(self.convert_additional_args(func_call.args(), has_parenthesized_args))
-    }
-
-    fn convert_parenthesized_args<'a>(&'a self, args: Args<'a>) -> BoxDoc<'a, ()> {
-        let (args, prefer_tighter, is_multiline) = self.convert_parenthesized_args_impl(args);
-        let doc = if prefer_tighter {
-            BoxDoc::text("(")
-                .append(args.into_iter().next().unwrap_or_else(BoxDoc::nil))
-                .append(BoxDoc::text(")"))
-        } else {
-            comma_seprated_items(
-                args.into_iter(),
-                if is_multiline {
-                    FoldStyle::Never
-                } else {
-                    FoldStyle::Fit
-                },
-            )
-        };
-        doc
-    }
-
-    fn convert_parenthesized_args_impl<'a>(
-        &'a self,
-        args: Args<'a>,
-    ) -> (Vec<BoxDoc<'a, ()>>, bool, bool) {
-        let node = args.to_untyped();
-        let mut last_arg = None;
-        let mut is_multiline = false;
-        for node in node
-            .children()
-            .take_while(|node| node.kind() != SyntaxKind::RightParen)
-        {
-            if let Some(space) = node.cast::<Space>() {
-                is_multiline = is_multiline || space.to_untyped().text().contains('\n');
-                break;
-            }
-        }
-        let args: Vec<BoxDoc<'a, ()>> = node
-            .children()
-            .take_while(|node| node.kind() != SyntaxKind::RightParen)
-            .filter_map(|node| node.cast::<'_, Arg>())
-            .map(|arg| {
-                last_arg = Some(arg);
-                is_multiline = is_multiline
-                    || self
-                        .attr_map
-                        .get(arg.to_untyped())
-                        .map_or(false, |attr| attr.is_multiline_flavor());
-                self.convert_arg(arg)
-            })
-            .collect();
-        // We prefer tighter style if...
-        // 1. There are no arguments
-        // 2. There is only one argument and it is not a function call
-        let prefer_tighter = args.is_empty()
-            || (args.len() == 1 && {
-                let arg = last_arg.unwrap();
-                let rhs = match arg {
-                    Arg::Pos(p) => p,
-                    Arg::Named(n) => n.expr(),
-                    Arg::Spread(s) => s.expr(),
-                };
-                !matches!(rhs, Expr::FuncCall(..))
-            });
-        (args, prefer_tighter, is_multiline)
-    }
-
-    fn convert_additional_args<'a>(&'a self, args: Args<'a>, has_paren: bool) -> BoxDoc<'a, ()> {
-        let node = args.to_untyped();
-        let args = node
-            .children()
-            .skip_while(|node| {
-                if has_paren {
-                    node.kind() != SyntaxKind::RightParen
-                } else {
-                    node.kind() != SyntaxKind::ContentBlock
-                }
-            })
-            .filter_map(|node| node.cast::<'_, Arg>());
-        BoxDoc::concat(args.map(|arg| self.convert_arg(arg))).group()
-    }
-
-    fn convert_arg<'a>(&'a self, arg: Arg<'a>) -> BoxDoc<'a, ()> {
-        match arg {
-            Arg::Pos(p) => self.convert_expr(p),
-            Arg::Named(n) => self.convert_named(n),
-            Arg::Spread(s) => self.convert_spread(s),
-        }
     }
 
     fn convert_closure<'a>(&'a self, closure: Closure<'a>) -> BoxDoc<'a, ()> {

--- a/src/pretty/table.rs
+++ b/src/pretty/table.rs
@@ -104,7 +104,7 @@ impl PrettyPrinter {
     }
 }
 
-fn is_table(node: FuncCall<'_>) -> bool {
+pub fn is_table(node: FuncCall<'_>) -> bool {
     indent_func_name(node) == Some("table") || indent_func_name(node) == Some("grid")
 }
 

--- a/src/pretty/util.rs
+++ b/src/pretty/util.rs
@@ -1,4 +1,4 @@
-use typst_syntax::{ast::*, SyntaxKind};
+use typst_syntax::{ast::*, SyntaxKind, SyntaxNode};
 
 pub(super) fn indent_func_name(node: FuncCall<'_>) -> Option<&str> {
     node.callee()
@@ -18,13 +18,16 @@ pub(super) fn has_parenthesized_args(node: FuncCall<'_>) -> bool {
         .any(|node| matches!(node.kind(), SyntaxKind::LeftParen | SyntaxKind::RightParen))
 }
 
-pub(super) fn get_parenthesized_args(node: Args<'_>) -> impl Iterator<Item = Arg<'_>> {
-    node
-        .to_untyped()
+pub(super) fn get_parenthesized_args_untyped(node: Args<'_>) -> impl Iterator<Item = &SyntaxNode> {
+    node.to_untyped()
         .children()
         .skip_while(|node| node.kind() != SyntaxKind::LeftParen)
+        .skip(1)
         .take_while(|node| node.kind() != SyntaxKind::RightParen)
-        .filter_map(|node| node.cast::<Arg>())
+}
+
+pub(super) fn get_parenthesized_args(node: Args<'_>) -> impl Iterator<Item = Arg<'_>> {
+    get_parenthesized_args_untyped(node).filter_map(|node| node.cast::<Arg>())
 }
 
 #[allow(unused)]

--- a/src/pretty/util.rs
+++ b/src/pretty/util.rs
@@ -18,6 +18,15 @@ pub(super) fn has_parenthesized_args(node: FuncCall<'_>) -> bool {
         .any(|node| matches!(node.kind(), SyntaxKind::LeftParen | SyntaxKind::RightParen))
 }
 
+pub(super) fn get_parenthesized_args(node: Args<'_>) -> impl Iterator<Item = Arg<'_>> {
+    node
+        .to_untyped()
+        .children()
+        .skip_while(|node| node.kind() != SyntaxKind::LeftParen)
+        .take_while(|node| node.kind() != SyntaxKind::RightParen)
+        .filter_map(|node| node.cast::<Arg>())
+}
+
 #[allow(unused)]
 pub(super) fn has_additional_args(node: FuncCall<'_>) -> bool {
     let has_paren_args = has_parenthesized_args(node);

--- a/tests/assets/unit/grid/colspan.typ
+++ b/tests/assets/unit/grid/colspan.typ
@@ -1,0 +1,48 @@
+#let ofi = [Office]
+#let rem = [_Remote_]
+#let lea = [*On leave*]
+
+#show table.cell.where(y: 0): set text(
+  fill: white,
+  weight: "bold",
+)
+
+#table(
+  columns: 6 * (1fr,),
+  align: (x, y) => if x == 0 or y == 0 { left } else { center },
+  stroke: (x, y) => (
+    // Separate black cells with white strokes.
+    left: if y == 0 and x > 0 { white } else { black },
+    rest: black,
+  ),
+  fill: (_, y) => if y == 0 { black },
+
+  table.header(
+    [Team member],
+    [Monday],
+    [Tuesday],
+    [Wednesday],
+    [Thursday],
+    [Friday]
+  ),
+  [Evelyn Archer],
+    table.cell(colspan: 2, ofi),
+    table.cell(colspan: 2, rem),
+    ofi,
+  [Lila Montgomery],
+    table.cell(colspan: 5, lea),
+  [Nolan Pearce],
+    rem,
+    table.cell(colspan: 2, ofi),
+    rem,
+    ofi,
+)
+
+#table(
+  columns: 4 * (1fr,),
+  
+  [a], [b], [c], [d],
+  fill: (_, y) => if y == 0 { black },
+  table.cell(rowspan: 2)[aa], table.cell(colspan: 2)[bc], [d],
+  [b], table.cell(colspan: 2)[cd],
+)

--- a/tests/snapshots/assets__check_file@cetz-manual.typ-120.snap
+++ b/tests/snapshots/assets__check_file@cetz-manual.typ-120.snap
@@ -230,9 +230,7 @@ Marks are arrow tips that can be added to the end of path based elements that su
 #figure(
   table(
     columns: 3,
-    [*Name*],
-    [*Shorthand*],
-    [*Shape*],
+    [*Name*], [*Shorthand*], [*Shape*],
     ..(
       for (name, item) in cetz.mark-shapes.marks {
         let name-to-mnemonic = (:)
@@ -251,7 +249,7 @@ Marks are arrow tips that can be added to the end of path based elements that su
           cetz.canvas(cetz.draw.line((), (1, 0), mark: (end: name))),
         )
       }
-    ),
+    )
   ),
   caption: [Mark symbols],
 )

--- a/tests/snapshots/assets__check_file@cetz-manual.typ-40.snap
+++ b/tests/snapshots/assets__check_file@cetz-manual.typ-40.snap
@@ -252,9 +252,7 @@ Marks are arrow tips that can be added to the end of path based elements that su
 #figure(
   table(
     columns: 3,
-    [*Name*],
-    [*Shorthand*],
-    [*Shape*],
+    [*Name*], [*Shorthand*], [*Shape*],
     ..(
       for (
         name,
@@ -294,7 +292,7 @@ Marks are arrow tips that can be added to the end of path based elements that su
           ),
         )
       }
-    ),
+    )
   ),
   caption: [Mark symbols],
 )

--- a/tests/snapshots/assets__check_file@cetz-manual.typ-80.snap
+++ b/tests/snapshots/assets__check_file@cetz-manual.typ-80.snap
@@ -235,9 +235,7 @@ Marks are arrow tips that can be added to the end of path based elements that su
 #figure(
   table(
     columns: 3,
-    [*Name*],
-    [*Shorthand*],
-    [*Shape*],
+    [*Name*], [*Shorthand*], [*Shape*],
     ..(
       for (name, item) in cetz.mark-shapes.marks {
         let name-to-mnemonic = (:)
@@ -256,7 +254,7 @@ Marks are arrow tips that can be added to the end of path based elements that su
           cetz.canvas(cetz.draw.line((), (1, 0), mark: (end: name))),
         )
       }
-    ),
+    )
   ),
   caption: [Mark symbols],
 )

--- a/tests/snapshots/assets__check_file@tablex.typ-40.snap
+++ b/tests/snapshots/assets__check_file@tablex.typ-40.snap
@@ -4371,11 +4371,9 @@ input_file: tests/assets/tablex.typ
       table-id: table_id,
     )
 
-    grid(
-      columns: (auto,),
-      rows: auto,
-      ..row_groups,
-    )
+    grid(columns: (
+        auto,
+      ), rows: auto, ..row_groups)
   })))
 }
 

--- a/tests/snapshots/assets__check_file@undergraduate-math.typ-120.snap
+++ b/tests/snapshots/assets__check_file@undergraduate-math.typ-120.snap
@@ -125,7 +125,7 @@ Your document should contain at least this.
   "",
   ```
   -- document body here --
-  ```,
+  ```
 )
 
 = Common constructs

--- a/tests/snapshots/assets__check_file@undergraduate-math.typ-40.snap
+++ b/tests/snapshots/assets__check_file@undergraduate-math.typ-40.snap
@@ -170,7 +170,7 @@ Your document should contain at least this.
   "",
   ```
   -- document body here --
-  ```,
+  ```
 )
 
 = Common constructs

--- a/tests/snapshots/assets__check_file@undergraduate-math.typ-80.snap
+++ b/tests/snapshots/assets__check_file@undergraduate-math.typ-80.snap
@@ -125,7 +125,7 @@ Your document should contain at least this.
   "",
   ```
   -- document body here --
-  ```,
+  ```
 )
 
 = Common constructs

--- a/tests/snapshots/assets__check_file@unit-code-func-call-flavor.typ-120.snap
+++ b/tests/snapshots/assets__check_file@unit-code-func-call-flavor.typ-120.snap
@@ -3,8 +3,6 @@ source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/unit/code/func-call-flavor.typ
 ---
-#table(
-  stroke: none,
+#table(stroke: none,
   [arg1],
-  [arg2],
-)
+  [arg2])

--- a/tests/snapshots/assets__check_file@unit-code-func-call-flavor.typ-40.snap
+++ b/tests/snapshots/assets__check_file@unit-code-func-call-flavor.typ-40.snap
@@ -3,8 +3,6 @@ source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/unit/code/func-call-flavor.typ
 ---
-#table(
-  stroke: none,
+#table(stroke: none,
   [arg1],
-  [arg2],
-)
+  [arg2])

--- a/tests/snapshots/assets__check_file@unit-code-func-call-flavor.typ-80.snap
+++ b/tests/snapshots/assets__check_file@unit-code-func-call-flavor.typ-80.snap
@@ -3,8 +3,6 @@ source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/unit/code/func-call-flavor.typ
 ---
-#table(
-  stroke: none,
+#table(stroke: none,
   [arg1],
-  [arg2],
-)
+  [arg2])

--- a/tests/snapshots/assets__check_file@unit-grid-cell.typ-120.snap
+++ b/tests/snapshots/assets__check_file@unit-grid-cell.typ-120.snap
@@ -11,11 +11,9 @@ input_file: tests/assets/unit/grid/cell.typ
     [Supercritical °C],
   ),
   [Hydrochloric Acid],
-  [12.0],
-  [92.1],
+  [12.0], [92.1],
   [Sodium Myreth Sulfate],
-  [16.6],
-  [104],
+  [16.6], [104],
   [Potassium Hydroxide],
   table.cell(colspan: 2)[24.7],
 )

--- a/tests/snapshots/assets__check_file@unit-grid-cell.typ-40.snap
+++ b/tests/snapshots/assets__check_file@unit-grid-cell.typ-40.snap
@@ -11,11 +11,9 @@ input_file: tests/assets/unit/grid/cell.typ
     [Supercritical °C],
   ),
   [Hydrochloric Acid],
-  [12.0],
-  [92.1],
+  [12.0], [92.1],
   [Sodium Myreth Sulfate],
-  [16.6],
-  [104],
+  [16.6], [104],
   [Potassium Hydroxide],
   table.cell(colspan: 2)[24.7],
 )

--- a/tests/snapshots/assets__check_file@unit-grid-cell.typ-80.snap
+++ b/tests/snapshots/assets__check_file@unit-grid-cell.typ-80.snap
@@ -11,11 +11,9 @@ input_file: tests/assets/unit/grid/cell.typ
     [Supercritical °C],
   ),
   [Hydrochloric Acid],
-  [12.0],
-  [92.1],
+  [12.0], [92.1],
   [Sodium Myreth Sulfate],
-  [16.6],
-  [104],
+  [16.6], [104],
   [Potassium Hydroxide],
   table.cell(colspan: 2)[24.7],
 )

--- a/tests/snapshots/assets__check_file@unit-grid-colspan.typ-120.snap
+++ b/tests/snapshots/assets__check_file@unit-grid-colspan.typ-120.snap
@@ -1,0 +1,64 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/grid/colspan.typ
+---
+#let ofi = [Office]
+#let rem = [_Remote_]
+#let lea = [*On leave*]
+
+#show table.cell.where(y: 0): set text(
+  fill: white,
+  weight: "bold",
+)
+
+#table(
+  columns: 6 * (1fr,),
+  align: (x, y) => if x == 0 or y == 0 {
+    left
+  } else {
+    center
+  },
+  stroke: (
+    x,
+    y,
+  ) => (
+    // Separate black cells with white strokes.
+    left: if y == 0 and x > 0 { white } else { black },
+    rest: black,
+  ),
+  fill: (_, y) => if y == 0 {
+    black
+  },
+
+  table.header(
+    [Team member],
+    [Monday],
+    [Tuesday],
+    [Wednesday],
+    [Thursday],
+    [Friday],
+  ),
+  [Evelyn Archer],
+  table.cell(colspan: 2, ofi),
+  table.cell(colspan: 2, rem),
+  ofi,
+  [Lila Montgomery],
+  table.cell(colspan: 5, lea),
+  [Nolan Pearce],
+  rem,
+  table.cell(colspan: 2, ofi),
+  rem,
+  ofi,
+)
+
+#table(
+  columns: 4 * (1fr,),
+
+  [a], [b], [c], [d],
+  fill: (_, y) => if y == 0 {
+    black
+  },
+  table.cell(rowspan: 2)[aa], table.cell(colspan: 2)[bc], [d],
+  [b], table.cell(colspan: 2)[cd],
+)

--- a/tests/snapshots/assets__check_file@unit-grid-colspan.typ-40.snap
+++ b/tests/snapshots/assets__check_file@unit-grid-colspan.typ-40.snap
@@ -1,0 +1,64 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/grid/colspan.typ
+---
+#let ofi = [Office]
+#let rem = [_Remote_]
+#let lea = [*On leave*]
+
+#show table.cell.where(y: 0): set text(
+  fill: white,
+  weight: "bold",
+)
+
+#table(
+  columns: 6 * (1fr,),
+  align: (x, y) => if x == 0 or y == 0 {
+    left
+  } else {
+    center
+  },
+  stroke: (
+    x,
+    y,
+  ) => (
+    // Separate black cells with white strokes.
+    left: if y == 0 and x > 0 { white } else { black },
+    rest: black,
+  ),
+  fill: (_, y) => if y == 0 {
+    black
+  },
+
+  table.header(
+    [Team member],
+    [Monday],
+    [Tuesday],
+    [Wednesday],
+    [Thursday],
+    [Friday],
+  ),
+  [Evelyn Archer],
+  table.cell(colspan: 2, ofi),
+  table.cell(colspan: 2, rem),
+  ofi,
+  [Lila Montgomery],
+  table.cell(colspan: 5, lea),
+  [Nolan Pearce],
+  rem,
+  table.cell(colspan: 2, ofi),
+  rem,
+  ofi,
+)
+
+#table(
+  columns: 4 * (1fr,),
+
+  [a], [b], [c], [d],
+  fill: (_, y) => if y == 0 {
+    black
+  },
+  table.cell(rowspan: 2)[aa], table.cell(colspan: 2)[bc], [d],
+  [b], table.cell(colspan: 2)[cd],
+)

--- a/tests/snapshots/assets__check_file@unit-grid-colspan.typ-80.snap
+++ b/tests/snapshots/assets__check_file@unit-grid-colspan.typ-80.snap
@@ -1,0 +1,64 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/grid/colspan.typ
+---
+#let ofi = [Office]
+#let rem = [_Remote_]
+#let lea = [*On leave*]
+
+#show table.cell.where(y: 0): set text(
+  fill: white,
+  weight: "bold",
+)
+
+#table(
+  columns: 6 * (1fr,),
+  align: (x, y) => if x == 0 or y == 0 {
+    left
+  } else {
+    center
+  },
+  stroke: (
+    x,
+    y,
+  ) => (
+    // Separate black cells with white strokes.
+    left: if y == 0 and x > 0 { white } else { black },
+    rest: black,
+  ),
+  fill: (_, y) => if y == 0 {
+    black
+  },
+
+  table.header(
+    [Team member],
+    [Monday],
+    [Tuesday],
+    [Wednesday],
+    [Thursday],
+    [Friday],
+  ),
+  [Evelyn Archer],
+  table.cell(colspan: 2, ofi),
+  table.cell(colspan: 2, rem),
+  ofi,
+  [Lila Montgomery],
+  table.cell(colspan: 5, lea),
+  [Nolan Pearce],
+  rem,
+  table.cell(colspan: 2, ofi),
+  rem,
+  ofi,
+)
+
+#table(
+  columns: 4 * (1fr,),
+
+  [a], [b], [c], [d],
+  fill: (_, y) => if y == 0 {
+    black
+  },
+  table.cell(rowspan: 2)[aa], table.cell(colspan: 2)[bc], [d],
+  [b], table.cell(colspan: 2)[cd],
+)

--- a/tests/snapshots/assets__check_file@unit-markup-content-raw.typ-120.snap
+++ b/tests/snapshots/assets__check_file@unit-markup-content-raw.typ-120.snap
@@ -5,9 +5,11 @@ input_file: tests/assets/unit/markup/content-raw.typ
 ---
 #align(
   center,
-  table([
-    ```
-    underbrace(x + y, |A|)
-    ```
-  ]),
+  table(
+    [
+      ```
+      underbrace(x + y, |A|)
+      ```
+    ],
+  ),
 )

--- a/tests/snapshots/assets__check_file@unit-markup-content-raw.typ-40.snap
+++ b/tests/snapshots/assets__check_file@unit-markup-content-raw.typ-40.snap
@@ -5,9 +5,11 @@ input_file: tests/assets/unit/markup/content-raw.typ
 ---
 #align(
   center,
-  table([
-    ```
-    underbrace(x + y, |A|)
-    ```
-  ]),
+  table(
+    [
+      ```
+      underbrace(x + y, |A|)
+      ```
+    ],
+  ),
 )

--- a/tests/snapshots/assets__check_file@unit-markup-content-raw.typ-80.snap
+++ b/tests/snapshots/assets__check_file@unit-markup-content-raw.typ-80.snap
@@ -5,9 +5,11 @@ input_file: tests/assets/unit/markup/content-raw.typ
 ---
 #align(
   center,
-  table([
-    ```
-    underbrace(x + y, |A|)
-    ```
-  ]),
+  table(
+    [
+      ```
+      underbrace(x + y, |A|)
+      ```
+    ],
+  ),
 )


### PR DESCRIPTION
This pr keeps call to `table` almost as is when typstyle fails to format it into a rectangle shape. Specifically, this pr will:

1. parse args in `table` to `Vec<OneOf<arg, comment, comma, newline>>`
2. format each arg
3. concat them back

This is useful because currently typstyle cannot further recognize complex col/rowspan and spread patterns. We may simply respect user's decision. Note that previously it will typically put each arg in a line. And that can be frustrating for users.

This PR also make it easier for correctly formating array/dict/funccall with comments and extra newlines.