### PR TITLE
feat: add CI check for files changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Options:
   -a, --ast              Print the AST of the input file
   -p, --pretty-doc       Print the pretty document
   -i, --inplace          Format the file in place
+      --check            Run in 'check' mode. Exits with 0 if input is formatted correctly. Exits with 1 if formatting is required
   -h, --help             Print help
   -V, --version          Print version
 ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,6 +25,9 @@ pub struct CliArguments {
     pub inplace: bool,
     #[clap(subcommand)]
     pub command: Option<Command>,
+    /// Run in 'check' mode. Exits with 0 if input is formatted correctly. Exits with 1 if formatting is required.
+    #[clap(long, default_value = "false")]
+    pub check: bool,
 }
 
 #[derive(Debug, Subcommand, Clone)]


### PR DESCRIPTION
This PR adds support for CI-related return value policy.

In `--check` mode, typstyle returns 0 (success) only if:
1. ALL files are formatted correctly, and
2. ALL files are unchanged (properly projected).

Otherwise, typstyle will return 1 if, for example:
1. Any failure occurs in formatting any file, or
2. Any file is changed (not well formatted).

This change will not affect the previous return policy when `--check` is not used.