### PR TITLE
feat(build): allow disabling git info collection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,8 +66,6 @@ anyhow = "1"
 vergen = { version = "8.3.1", features = [
   "build",
   "cargo",
-  "git",
-  "git2",
   "rustc",
 ] }
 
@@ -85,9 +83,10 @@ harness = false
 
 [features]
 
-default = ["cli", "wasm"]
+default = ["cli", "wasm", "git-info"]
 cli = ["clap", "once_cell", "walkdir"]
 wasm = ["wasm-bindgen"]
+git-info = ["vergen/git", "vergen/git2"]
 
 [profile.test]
 opt-level = 3

--- a/build.rs
+++ b/build.rs
@@ -3,12 +3,13 @@ use vergen::EmitBuilder;
 
 fn main() -> Result<()> {
     // Emit the instructions
-    EmitBuilder::builder()
-        .all_cargo()
-        .build_timestamp()
-        .git_sha(false)
-        .git_describe(true, true, None)
-        .all_rustc()
-        .emit()?;
+    let mut builder = EmitBuilder::builder();
+
+    builder.all_cargo().build_timestamp().all_rustc();
+
+    #[cfg(feature = "git-info")]
+    builder.git_sha(false).git_describe(true, true, None);
+
+    builder.emit()?;
     Ok(())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -64,7 +64,7 @@ Cargo Target Triple: {}
 ",
         env!("CARGO_PKG_VERSION"),
         env!("VERGEN_BUILD_TIMESTAMP"),
-        env!("VERGEN_GIT_DESCRIBE"),
+        option_env!("VERGEN_GIT_DESCRIBE").unwrap_or(NONE),
         option_env!("VERGEN_GIT_SHA").unwrap_or(NONE),
         option_env!("VERGEN_GIT_COMMIT_TIMESTAMP").unwrap_or(NONE),
         option_env!("VERGEN_GIT_BRANCH").unwrap_or(NONE),


### PR DESCRIPTION
When packaging for linux, some distros (e.g. Void Linux) do not use git to obtain package source, but download source archives directly. That makes any git repository info unavailable and currently requires either adding unnecessary libgit2 dependency or patching the code out.

This change allows using `--no-default-features --features=cli,wasm` to disable the git portion if needed.