### PR TITLE
feat: put single var closure's body in a new line when closure body is multiline

### DIFF
--- a/tests/assets/unit/code/show-closure-paren-complex.typ
+++ b/tests/assets/unit/code/show-closure-paren-complex.typ
@@ -1,0 +1,6 @@
+#show raw.where(block: false): it => if it.text.starts-with("<") and it.text.ends-with(">") {
+    set text(1.2em)
+    doc-style.show-type(it.text.slice(1, -1))
+  } else { 
+    it 
+  }

--- a/tests/assets/unit/code/show-closure-paren.typ
+++ b/tests/assets/unit/code/show-closure-paren.typ
@@ -1,0 +1,16 @@
+#show raw: it => it.text.ends-with(">")
+
+#show raw: it => (
+  it.text.ends-with(">")
+)
+
+#show raw: it => if true {
+      set text(1.2em)
+    } else {
+      it
+    }
+
+
+#show raw: it => {
+  it
+}

--- a/tests/assets/unit/code/single-arg-closure.typ
+++ b/tests/assets/unit/code/single-arg-closure.typ
@@ -1,0 +1,8 @@
+#{
+  let row_len = 10
+  let hlines = ((h: 1, y: 1), (h: 2, y: 2))
+  let new_hlines = range(0, row_len + 1).filter(y => hlines.filter(h => h.y == y)
+      .len() == 0
+  )
+  new_hlines
+}

--- a/tests/snapshots/assets__check_file@cetz-manual.typ-120.snap
+++ b/tests/snapshots/assets__check_file@cetz-manual.typ-120.snap
@@ -27,9 +27,11 @@ input_file: tests/assets/cetz-manual.typ
 
 #set terms(indent: 1em)
 #set par(justify: true)
-#set heading(numbering: (..num) => if num.pos().len() < 4 {
-  numbering("1.1", ..num)
-})
+#set heading(numbering: (..num) => (
+  if num.pos().len() < 4 {
+    numbering("1.1", ..num)
+  }
+))
 #show link: set text(blue)
 
 // Outline
@@ -59,12 +61,14 @@ This is the minimal starting point:
   ```]
 Note that draw functions are imported inside the scope of the `canvas` block. This is recommended as some draw functions override Typst's function's such as `line`.
 
-#show raw.where(block: false): it => if it.text.starts-with("<") and it.text.ends-with(">") {
-  set text(1.2em)
-  doc-style.show-type(it.text.slice(1, -1))
-} else {
-  it
-}
+#show raw.where(block: false): it => (
+  if it.text.starts-with("<") and it.text.ends-with(">") {
+    set text(1.2em)
+    doc-style.show-type(it.text.slice(1, -1))
+  } else {
+    it
+  }
+)
 
 == CeTZ Unique Argument Types
 Many CeTZ functions expect data in certain formats which we will call types. Note that these are actually made up of Typst primitives.

--- a/tests/snapshots/assets__check_file@cetz-manual.typ-40.snap
+++ b/tests/snapshots/assets__check_file@cetz-manual.typ-40.snap
@@ -27,11 +27,11 @@ input_file: tests/assets/cetz-manual.typ
 
 #set terms(indent: 1em)
 #set par(justify: true)
-#set heading(numbering: (
-  ..num,
-) => if num.pos().len() < 4 {
-  numbering("1.1", ..num)
-})
+#set heading(numbering: (..num) => (
+  if num.pos().len() < 4 {
+    numbering("1.1", ..num)
+  }
+))
 #show link: set text(blue)
 
 // Outline
@@ -67,14 +67,16 @@ This is the minimal starting point:
   ```]
 Note that draw functions are imported inside the scope of the `canvas` block. This is recommended as some draw functions override Typst's function's such as `line`.
 
-#show raw.where(block: false): it => if it.text.starts-with("<") and it.text.ends-with(">") {
-  set text(1.2em)
-  doc-style.show-type(
-    it.text.slice(1, -1),
-  )
-} else {
-  it
-}
+#show raw.where(block: false): it => (
+  if it.text.starts-with("<") and it.text.ends-with(">") {
+    set text(1.2em)
+    doc-style.show-type(
+      it.text.slice(1, -1),
+    )
+  } else {
+    it
+  }
+)
 
 == CeTZ Unique Argument Types
 Many CeTZ functions expect data in certain formats which we will call types. Note that these are actually made up of Typst primitives.

--- a/tests/snapshots/assets__check_file@cetz-manual.typ-80.snap
+++ b/tests/snapshots/assets__check_file@cetz-manual.typ-80.snap
@@ -27,9 +27,11 @@ input_file: tests/assets/cetz-manual.typ
 
 #set terms(indent: 1em)
 #set par(justify: true)
-#set heading(numbering: (..num) => if num.pos().len() < 4 {
-  numbering("1.1", ..num)
-})
+#set heading(numbering: (..num) => (
+  if num.pos().len() < 4 {
+    numbering("1.1", ..num)
+  }
+))
 #show link: set text(blue)
 
 // Outline
@@ -59,12 +61,14 @@ This is the minimal starting point:
   ```]
 Note that draw functions are imported inside the scope of the `canvas` block. This is recommended as some draw functions override Typst's function's such as `line`.
 
-#show raw.where(block: false): it => if it.text.starts-with("<") and it.text.ends-with(">") {
-  set text(1.2em)
-  doc-style.show-type(it.text.slice(1, -1))
-} else {
-  it
-}
+#show raw.where(block: false): it => (
+  if it.text.starts-with("<") and it.text.ends-with(">") {
+    set text(1.2em)
+    doc-style.show-type(it.text.slice(1, -1))
+  } else {
+    it
+  }
+)
 
 == CeTZ Unique Argument Types
 Many CeTZ functions expect data in certain formats which we will call types. Note that these are actually made up of Typst primitives.

--- a/tests/snapshots/assets__check_file@tablex.typ-120.snap
+++ b/tests/snapshots/assets__check_file@tablex.typ-120.snap
@@ -1338,9 +1338,9 @@ input_file: tests/assets/tablex.typ
   let auto_sizes = ()
   let new_columns = columns
 
-  let all-frac-columns = columns.enumerate().filter(i-col => type(
-    i-col.at(1),
-  ) == _fraction-type).map(i-col => i-col.at(0))
+  let all-frac-columns = columns.enumerate().filter(i-col => (
+    type(i-col.at(1)) == _fraction-type
+  )).map(i-col => i-col.at(0))
   for (i, col) in columns.enumerate() {
     if col == auto {
       // max cell width
@@ -1368,8 +1368,8 @@ input_file: tests/assets/tablex.typ
           // `fit-spans.x == true` (it requests to not expand
           // columns).
           if last-auto-col == i and this-cell-can-expand-columns {
-            let cell-spans-all-frac-columns = pcell.colspan > 1 and all-frac-columns.len() > 0 and all-frac-columns.all(i => pcell.x <= i and i < (
-              pcell.x + pcell.colspan
+            let cell-spans-all-frac-columns = pcell.colspan > 1 and all-frac-columns.len() > 0 and all-frac-columns.all(i => (
+              pcell.x <= i and i < (pcell.x + pcell.colspan)
             ))
             if cell-spans-all-frac-columns and page-width != 0pt and not is-infinite-len(page-width) {
               // HEURISTIC (only effective when the page width isn't 'auto' / infinite):

--- a/tests/snapshots/assets__check_file@tablex.typ-40.snap
+++ b/tests/snapshots/assets__check_file@tablex.typ-40.snap
@@ -54,10 +54,9 @@ input_file: tests/assets/tablex.typ
 #let calc-mod = if typst-calc-rem-supported {
   calc.rem
 } else {
-  (
-    a,
-    b,
-  ) => calc.floor(a) - calc.floor(b * calc.floor(a / b))
+  (a, b) => (
+    calc.floor(a) - calc.floor(b * calc.floor(a / b))
+  )
 }
 
 // Returns the sign of the operand.
@@ -101,14 +100,15 @@ input_file: tests/assets/tablex.typ
       message: "Tablex error:" + error-prefix + " 'fit-spans', if a dictionary, must not be empty.",
     )
     assert(
-      fit-spans.keys().all(k => k in (
-        "x",
-        "y",
+      fit-spans.keys().all(k => (
+        k in ("x", "y")
       )),
       message: "Tablex error:" + error-prefix + " 'fit-spans', if a dictionary, must only have the keys x and y.",
     )
     assert(
-      fit-spans.values().all(v => type(v) == _bool-type),
+      fit-spans.values().all(v => (
+        type(v) == _bool-type
+      )),
       message: "Tablex error:" + error-prefix + " keys 'x' and 'y' in the 'fit-spans' dictionary must be booleans (true/false).",
     )
     for key in ("x", "y") {
@@ -312,7 +312,9 @@ input_file: tests/assets/tablex.typ
   let len = 0
 
   // maximum explicit 'y' specified
-  let max_explicit_y = items.filter(c => c.y != auto).fold(
+  let max_explicit_y = items.filter(c => (
+    c.y != auto
+  )).fold(
     0,
     (acc, cell) => {
       if (
@@ -1642,9 +1644,9 @@ input_file: tests/assets/tablex.typ
   remaining: 0pt,
   gutter: none,
 ) = {
-  let frac-tracks = tracks.enumerate().filter(t => type(
-    t.at(1),
-  ) == _fraction-type)
+  let frac-tracks = tracks.enumerate().filter(t => (
+    type(t.at(1)) == _fraction-type
+  ))
 
   let amount-frac = frac-tracks.fold(
     0,
@@ -1786,9 +1788,9 @@ input_file: tests/assets/tablex.typ
   let auto_sizes = ()
   let new_columns = columns
 
-  let all-frac-columns = columns.enumerate().filter(i-col => type(
-    i-col.at(1),
-  ) == _fraction-type).map(i-col => i-col.at(0))
+  let all-frac-columns = columns.enumerate().filter(i-col => (
+    type(i-col.at(1)) == _fraction-type
+  )).map(i-col => i-col.at(0))
   for (i, col) in columns.enumerate() {
     if col == auto {
       // max cell width
@@ -1825,8 +1827,10 @@ input_file: tests/assets/tablex.typ
           // `fit-spans.x == true` (it requests to not expand
           // columns).
           if last-auto-col == i and this-cell-can-expand-columns {
-            let cell-spans-all-frac-columns = pcell.colspan > 1 and all-frac-columns.len() > 0 and all-frac-columns.all(i => pcell.x <= i and i < (
-              pcell.x + pcell.colspan
+            let cell-spans-all-frac-columns = pcell.colspan > 1 and all-frac-columns.len() > 0 and all-frac-columns.all(i => (
+              pcell.x <= i and i < (
+                pcell.x + pcell.colspan
+              )
             ))
             if cell-spans-all-frac-columns and page-width != 0pt and not is-infinite-len(page-width) {
               // HEURISTIC (only effective when the page width isn't 'auto' / infinite):
@@ -3138,8 +3142,8 @@ input_file: tests/assets/tablex.typ
         // page turned => add header
         if page_turned and at_top and not is-header {
           if repeat-header != false {
-            header-pages-state.update(l => l + (
-              page,
+            header-pages-state.update(l => (
+              l + (page,)
             ))
             if (
               repeat-header == true
@@ -3298,7 +3302,9 @@ input_file: tests/assets/tablex.typ
         // otherwise they'd repeat on every page), then
         // we draw its hlines for the header, below it.
         let hlines = if not header-hlines-have-priority and not is-header and start-y == header_last_y + 1 {
-          let hlines_below_header = first-row-group.row_group.hlines.filter(h => h.y == header_last_y + 1)
+          let hlines_below_header = first-row-group.row_group.hlines.filter(h => (
+            h.y == header_last_y + 1
+          ))
 
           hlines + hlines_below_header
         } else {
@@ -3543,11 +3549,15 @@ input_file: tests/assets/tablex.typ
           box: cell_box,
         ))
 
-        let hlines = hlines.filter(h => this_row_group.hlines.filter(
-          is-same-hline.with(h),
-        ).len() == 0)
+        let hlines = hlines.filter(h => (
+          this_row_group.hlines.filter(
+            is-same-hline.with(h),
+          ).len() == 0
+        ))
 
-        let vlines = vlines.filter(v => v not in this_row_group.vlines)
+        let vlines = vlines.filter(v => (
+          v not in this_row_group.vlines
+        ))
 
         this_row_group.hlines += hlines
         this_row_group.vlines += vlines
@@ -3714,14 +3724,22 @@ input_file: tests/assets/tablex.typ
     new_hlines = range(
       0,
       row_len + 1,
-    ).filter(y => hlines.filter(h => h.y == y).len() == 0).map(y => hlinex(y: y))
+    ).filter(y => (
+      hlines.filter(h => (
+        h.y == y
+      )).len() == 0
+    )).map(y => hlinex(y: y))
   }
 
   if auto-vlines {
     new_vlines = range(
       0,
       col_len + 1,
-    ).filter(x => vlines.filter(v => v.x == x).len() == 0).map(x => vlinex(x: x))
+    ).filter(x => (
+      vlines.filter(v => (
+        v.x == x
+      )).len() == 0
+    )).map(x => vlinex(x: x))
   }
 
   (
@@ -4020,7 +4038,9 @@ input_file: tests/assets/tablex.typ
     _array-type,
   ) {
     panic("Tablex error: 'repeat-header' must be a boolean (true - always repeat the header, false - never), an integer (amount of pages for which to repeat the header), or an array of integers (relative pages in which the header should repeat).")
-  } else if type(repeat-header) == _array-type and repeat-header.any(i => type(i) != _int-type) {
+  } else if type(repeat-header) == _array-type and repeat-header.any(i => (
+    type(i) != _int-type
+  )) {
     panic("Tablex error: 'repeat-header' cannot be an array of anything other than integers!")
   }
 

--- a/tests/snapshots/assets__check_file@tablex.typ-80.snap
+++ b/tests/snapshots/assets__check_file@tablex.typ-80.snap
@@ -1306,9 +1306,9 @@ input_file: tests/assets/tablex.typ
 // Calculate the size of fraction tracks (cols/rows) (1fr, 2fr, ...),
 // based on the remaining sizes (after fixed-size and auto columns)
 #let determine-frac-tracks(tracks, remaining: 0pt, gutter: none) = {
-  let frac-tracks = tracks.enumerate().filter(t => type(
-    t.at(1),
-  ) == _fraction-type)
+  let frac-tracks = tracks.enumerate().filter(t => (
+    type(t.at(1)) == _fraction-type
+  ))
 
   let amount-frac = frac-tracks.fold(0, (acc, el) => acc + (el.at(1) / 1fr))
 
@@ -1410,9 +1410,9 @@ input_file: tests/assets/tablex.typ
   let auto_sizes = ()
   let new_columns = columns
 
-  let all-frac-columns = columns.enumerate().filter(i-col => type(
-    i-col.at(1),
-  ) == _fraction-type).map(i-col => i-col.at(0))
+  let all-frac-columns = columns.enumerate().filter(i-col => (
+    type(i-col.at(1)) == _fraction-type
+  )).map(i-col => i-col.at(0))
   for (i, col) in columns.enumerate() {
     if col == auto {
       // max cell width
@@ -1443,8 +1443,8 @@ input_file: tests/assets/tablex.typ
           // `fit-spans.x == true` (it requests to not expand
           // columns).
           if last-auto-col == i and this-cell-can-expand-columns {
-            let cell-spans-all-frac-columns = pcell.colspan > 1 and all-frac-columns.len() > 0 and all-frac-columns.all(i => pcell.x <= i and i < (
-              pcell.x + pcell.colspan
+            let cell-spans-all-frac-columns = pcell.colspan > 1 and all-frac-columns.len() > 0 and all-frac-columns.all(i => (
+              pcell.x <= i and i < (pcell.x + pcell.colspan)
             ))
             if cell-spans-all-frac-columns and page-width != 0pt and not is-infinite-len(page-width) {
               // HEURISTIC (only effective when the page width isn't 'auto' / infinite):
@@ -2651,7 +2651,9 @@ input_file: tests/assets/tablex.typ
         // otherwise they'd repeat on every page), then
         // we draw its hlines for the header, below it.
         let hlines = if not header-hlines-have-priority and not is-header and start-y == header_last_y + 1 {
-          let hlines_below_header = first-row-group.row_group.hlines.filter(h => h.y == header_last_y + 1)
+          let hlines_below_header = first-row-group.row_group.hlines.filter(h => (
+            h.y == header_last_y + 1
+          ))
 
           hlines + hlines_below_header
         } else {
@@ -2837,9 +2839,9 @@ input_file: tests/assets/tablex.typ
 
         this_row_group.rows.last().push((cell: cell, box: cell_box))
 
-        let hlines = hlines.filter(h => this_row_group.hlines.filter(
-          is-same-hline.with(h),
-        ).len() == 0)
+        let hlines = hlines.filter(h => (
+          this_row_group.hlines.filter(is-same-hline.with(h)).len() == 0
+        ))
 
         let vlines = vlines.filter(v => v not in this_row_group.vlines)
 
@@ -2975,17 +2977,15 @@ input_file: tests/assets/tablex.typ
   let new_vlines = ()
 
   if auto-hlines {
-    new_hlines = range(
-      0,
-      row_len + 1,
-    ).filter(y => hlines.filter(h => h.y == y).len() == 0).map(y => hlinex(y: y))
+    new_hlines = range(0, row_len + 1).filter(y => (
+      hlines.filter(h => h.y == y).len() == 0
+    )).map(y => hlinex(y: y))
   }
 
   if auto-vlines {
-    new_vlines = range(
-      0,
-      col_len + 1,
-    ).filter(x => vlines.filter(v => v.x == x).len() == 0).map(x => vlinex(x: x))
+    new_vlines = range(0, col_len + 1).filter(x => (
+      vlines.filter(v => v.x == x).len() == 0
+    )).map(x => vlinex(x: x))
   }
 
   (new_hlines: new_hlines, new_vlines: new_vlines)
@@ -3212,7 +3212,9 @@ input_file: tests/assets/tablex.typ
 
   if type(repeat-header) not in (_bool-type, _int-type, _array-type) {
     panic("Tablex error: 'repeat-header' must be a boolean (true - always repeat the header, false - never), an integer (amount of pages for which to repeat the header), or an array of integers (relative pages in which the header should repeat).")
-  } else if type(repeat-header) == _array-type and repeat-header.any(i => type(i) != _int-type) {
+  } else if type(repeat-header) == _array-type and repeat-header.any(i => (
+    type(i) != _int-type
+  )) {
     panic("Tablex error: 'repeat-header' cannot be an array of anything other than integers!")
   }
 

--- a/tests/snapshots/assets__check_file@unit-code-show-closure-paren-complex.typ-120.snap
+++ b/tests/snapshots/assets__check_file@unit-code-show-closure-paren-complex.typ-120.snap
@@ -1,0 +1,13 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/code/show-closure-paren-complex.typ
+---
+#show raw.where(block: false): it => (
+  if it.text.starts-with("<") and it.text.ends-with(">") {
+    set text(1.2em)
+    doc-style.show-type(it.text.slice(1, -1))
+  } else {
+    it
+  }
+)

--- a/tests/snapshots/assets__check_file@unit-code-show-closure-paren-complex.typ-40.snap
+++ b/tests/snapshots/assets__check_file@unit-code-show-closure-paren-complex.typ-40.snap
@@ -1,0 +1,15 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/code/show-closure-paren-complex.typ
+---
+#show raw.where(block: false): it => (
+  if it.text.starts-with("<") and it.text.ends-with(">") {
+    set text(1.2em)
+    doc-style.show-type(
+      it.text.slice(1, -1),
+    )
+  } else {
+    it
+  }
+)

--- a/tests/snapshots/assets__check_file@unit-code-show-closure-paren-complex.typ-80.snap
+++ b/tests/snapshots/assets__check_file@unit-code-show-closure-paren-complex.typ-80.snap
@@ -1,0 +1,13 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/code/show-closure-paren-complex.typ
+---
+#show raw.where(block: false): it => (
+  if it.text.starts-with("<") and it.text.ends-with(">") {
+    set text(1.2em)
+    doc-style.show-type(it.text.slice(1, -1))
+  } else {
+    it
+  }
+)

--- a/tests/snapshots/assets__check_file@unit-code-show-closure-paren.typ-120.snap
+++ b/tests/snapshots/assets__check_file@unit-code-show-closure-paren.typ-120.snap
@@ -1,0 +1,21 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/code/show-closure-paren.typ
+---
+#show raw: it => it.text.ends-with(">")
+
+#show raw: it => (it.text.ends-with(">"))
+
+#show raw: it => (
+  if true {
+    set text(1.2em)
+  } else {
+    it
+  }
+)
+
+
+#show raw: it => {
+  it
+}

--- a/tests/snapshots/assets__check_file@unit-code-show-closure-paren.typ-40.snap
+++ b/tests/snapshots/assets__check_file@unit-code-show-closure-paren.typ-40.snap
@@ -1,0 +1,23 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/code/show-closure-paren.typ
+---
+#show raw: it => it.text.ends-with(">")
+
+#show raw: it => (
+  it.text.ends-with(">")
+)
+
+#show raw: it => (
+  if true {
+    set text(1.2em)
+  } else {
+    it
+  }
+)
+
+
+#show raw: it => {
+  it
+}

--- a/tests/snapshots/assets__check_file@unit-code-show-closure-paren.typ-80.snap
+++ b/tests/snapshots/assets__check_file@unit-code-show-closure-paren.typ-80.snap
@@ -1,0 +1,21 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/code/show-closure-paren.typ
+---
+#show raw: it => it.text.ends-with(">")
+
+#show raw: it => (it.text.ends-with(">"))
+
+#show raw: it => (
+  if true {
+    set text(1.2em)
+  } else {
+    it
+  }
+)
+
+
+#show raw: it => {
+  it
+}

--- a/tests/snapshots/assets__check_file@unit-code-single-arg-closure.typ-120.snap
+++ b/tests/snapshots/assets__check_file@unit-code-single-arg-closure.typ-120.snap
@@ -1,0 +1,11 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/code/single-arg-closure.typ
+---
+#{
+  let row_len = 10
+  let hlines = ((h: 1, y: 1), (h: 2, y: 2))
+  let new_hlines = range(0, row_len + 1).filter(y => hlines.filter(h => h.y == y).len() == 0)
+  new_hlines
+}

--- a/tests/snapshots/assets__check_file@unit-code-single-arg-closure.typ-40.snap
+++ b/tests/snapshots/assets__check_file@unit-code-single-arg-closure.typ-40.snap
@@ -1,0 +1,21 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/code/single-arg-closure.typ
+---
+#{
+  let row_len = 10
+  let hlines = (
+    (h: 1, y: 1),
+    (h: 2, y: 2),
+  )
+  let new_hlines = range(
+    0,
+    row_len + 1,
+  ).filter(y => (
+    hlines.filter(h => (
+      h.y == y
+    )).len() == 0
+  ))
+  new_hlines
+}

--- a/tests/snapshots/assets__check_file@unit-code-single-arg-closure.typ-80.snap
+++ b/tests/snapshots/assets__check_file@unit-code-single-arg-closure.typ-80.snap
@@ -1,0 +1,13 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/code/single-arg-closure.typ
+---
+#{
+  let row_len = 10
+  let hlines = ((h: 1, y: 1), (h: 2, y: 2))
+  let new_hlines = range(0, row_len + 1).filter(y => (
+    hlines.filter(h => h.y == y).len() == 0
+  ))
+  new_hlines
+}

--- a/tests/snapshots/assets__check_file@unit-grid-colspan.typ-120.snap
+++ b/tests/snapshots/assets__check_file@unit-grid-colspan.typ-120.snap
@@ -14,22 +14,25 @@ input_file: tests/assets/unit/grid/colspan.typ
 
 #table(
   columns: 6 * (1fr,),
-  align: (x, y) => if x == 0 or y == 0 {
-    left
-  } else {
-    center
-  },
-  stroke: (
-    x,
-    y,
-  ) => (
+  align: (x, y) => (
+    if x == 0 or y == 0 {
+      left
+    } else {
+      center
+    }
+  ),
+  stroke: (x, y) => (
+    (
     // Separate black cells with white strokes.
     left: if y == 0 and x > 0 { white } else { black },
     rest: black,
+  )
   ),
-  fill: (_, y) => if y == 0 {
-    black
-  },
+  fill: (_, y) => (
+    if y == 0 {
+      black
+    }
+  ),
 
   table.header(
     [Team member],
@@ -56,9 +59,11 @@ input_file: tests/assets/unit/grid/colspan.typ
   columns: 4 * (1fr,),
 
   [a], [b], [c], [d],
-  fill: (_, y) => if y == 0 {
-    black
-  },
+  fill: (_, y) => (
+    if y == 0 {
+      black
+    }
+  ),
   table.cell(rowspan: 2)[aa], table.cell(colspan: 2)[bc], [d],
   [b], table.cell(colspan: 2)[cd],
 )

--- a/tests/snapshots/assets__check_file@unit-grid-colspan.typ-40.snap
+++ b/tests/snapshots/assets__check_file@unit-grid-colspan.typ-40.snap
@@ -14,22 +14,25 @@ input_file: tests/assets/unit/grid/colspan.typ
 
 #table(
   columns: 6 * (1fr,),
-  align: (x, y) => if x == 0 or y == 0 {
-    left
-  } else {
-    center
-  },
-  stroke: (
-    x,
-    y,
-  ) => (
+  align: (x, y) => (
+    if x == 0 or y == 0 {
+      left
+    } else {
+      center
+    }
+  ),
+  stroke: (x, y) => (
+    (
     // Separate black cells with white strokes.
     left: if y == 0 and x > 0 { white } else { black },
     rest: black,
+  )
   ),
-  fill: (_, y) => if y == 0 {
-    black
-  },
+  fill: (_, y) => (
+    if y == 0 {
+      black
+    }
+  ),
 
   table.header(
     [Team member],
@@ -56,9 +59,11 @@ input_file: tests/assets/unit/grid/colspan.typ
   columns: 4 * (1fr,),
 
   [a], [b], [c], [d],
-  fill: (_, y) => if y == 0 {
-    black
-  },
+  fill: (_, y) => (
+    if y == 0 {
+      black
+    }
+  ),
   table.cell(rowspan: 2)[aa], table.cell(colspan: 2)[bc], [d],
   [b], table.cell(colspan: 2)[cd],
 )

--- a/tests/snapshots/assets__check_file@unit-grid-colspan.typ-80.snap
+++ b/tests/snapshots/assets__check_file@unit-grid-colspan.typ-80.snap
@@ -14,22 +14,25 @@ input_file: tests/assets/unit/grid/colspan.typ
 
 #table(
   columns: 6 * (1fr,),
-  align: (x, y) => if x == 0 or y == 0 {
-    left
-  } else {
-    center
-  },
-  stroke: (
-    x,
-    y,
-  ) => (
+  align: (x, y) => (
+    if x == 0 or y == 0 {
+      left
+    } else {
+      center
+    }
+  ),
+  stroke: (x, y) => (
+    (
     // Separate black cells with white strokes.
     left: if y == 0 and x > 0 { white } else { black },
     rest: black,
+  )
   ),
-  fill: (_, y) => if y == 0 {
-    black
-  },
+  fill: (_, y) => (
+    if y == 0 {
+      black
+    }
+  ),
 
   table.header(
     [Team member],
@@ -56,9 +59,11 @@ input_file: tests/assets/unit/grid/colspan.typ
   columns: 4 * (1fr,),
 
   [a], [b], [c], [d],
-  fill: (_, y) => if y == 0 {
-    black
-  },
+  fill: (_, y) => (
+    if y == 0 {
+      black
+    }
+  ),
   table.cell(rowspan: 2)[aa], table.cell(colspan: 2)[bc], [d],
   [b], table.cell(colspan: 2)[cd],
 )


### PR DESCRIPTION
The surrounding parens are required because currently typst doesn't allow closure body presenting in new line

```
#let f = a =>
  a + 1
#f(1)
```

```
Error: expected expression
   ╭─[/main.typ:8:14]
   │
 8 │ #let f = a =>
───╯

```