### PR TITLE
fix: the last line of block comment doesn't converge

### DIFF
--- a/src/pretty/func_call.rs
+++ b/src/pretty/func_call.rs
@@ -2,7 +2,7 @@ use itertools::Itertools;
 use pretty::BoxDoc;
 use typst_syntax::{ast::*, SyntaxKind, SyntaxNode};
 
-use crate::{pretty::trivia, util::FoldStyle, PrettyPrinter};
+use crate::{util::FoldStyle, PrettyPrinter};
 
 use super::{
     table,
@@ -76,7 +76,7 @@ impl<'a> ParenthesizedFuncCallArg<'a> {
                 inner
             }
             ParenthesizedFuncCallArg::LineComment(comment)
-            | ParenthesizedFuncCallArg::BlockComment(comment) => trivia(comment),
+            | ParenthesizedFuncCallArg::BlockComment(comment) => super::comment(comment),
         }
     }
 }

--- a/tests/assets/unit/comment/comment-convergence.typ
+++ b/tests/assets/unit/comment/comment-convergence.typ
@@ -1,0 +1,22 @@
+#[
+  /* bar
+  */
+]
+
+-   /* bar
+   */ 123
+
+- /* bar
+   */
+
+#[
+  /* Somebody write this up:
+   - 1000 participants.
+   - 2x2 data design. */
+]
+
+#[
+  // Somebody write this up:
+  //  - 1000 participants.
+  //  - 2x2 data design.
+]

--- a/tests/snapshots/assets__check_file@unit-comment-block-comment.typ-0.snap
+++ b/tests/snapshots/assets__check_file@unit-comment-block-comment.typ-0.snap
@@ -5,8 +5,8 @@ input_file: tests/assets/unit/comment/block-comment.typ
 ---
 Our study design is as follows:
 /* Somebody write this up:
-   - 1000 participants.
-   - 2x2 data design. */
+- 1000 participants.
+- 2x2 data design. */
 
 #if draw-edge == auto {
   draw-edge = (

--- a/tests/snapshots/assets__check_file@unit-comment-block-comment.typ-120.snap
+++ b/tests/snapshots/assets__check_file@unit-comment-block-comment.typ-120.snap
@@ -5,8 +5,8 @@ input_file: tests/assets/unit/comment/block-comment.typ
 ---
 Our study design is as follows:
 /* Somebody write this up:
-   - 1000 participants.
-   - 2x2 data design. */
+- 1000 participants.
+- 2x2 data design. */
 
 #if draw-edge == auto {
   draw-edge = (

--- a/tests/snapshots/assets__check_file@unit-comment-block-comment.typ-40.snap
+++ b/tests/snapshots/assets__check_file@unit-comment-block-comment.typ-40.snap
@@ -5,8 +5,8 @@ input_file: tests/assets/unit/comment/block-comment.typ
 ---
 Our study design is as follows:
 /* Somebody write this up:
-   - 1000 participants.
-   - 2x2 data design. */
+- 1000 participants.
+- 2x2 data design. */
 
 #if draw-edge == auto {
   draw-edge = (

--- a/tests/snapshots/assets__check_file@unit-comment-block-comment.typ-80.snap
+++ b/tests/snapshots/assets__check_file@unit-comment-block-comment.typ-80.snap
@@ -5,8 +5,8 @@ input_file: tests/assets/unit/comment/block-comment.typ
 ---
 Our study design is as follows:
 /* Somebody write this up:
-   - 1000 participants.
-   - 2x2 data design. */
+- 1000 participants.
+- 2x2 data design. */
 
 #if draw-edge == auto {
   draw-edge = (

--- a/tests/snapshots/assets__check_file@unit-comment-comment-convergence.typ-0.snap
+++ b/tests/snapshots/assets__check_file@unit-comment-comment-convergence.typ-0.snap
@@ -1,0 +1,27 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/comment/comment-convergence.typ
+---
+#[
+  /* bar
+  */
+]
+
+-   /* bar
+   */ 123
+
+- /* bar
+   */
+
+#[
+  /* Somebody write this up:
+  - 1000 participants.
+  - 2x2 data design. */
+]
+
+#[
+  // Somebody write this up:
+  //  - 1000 participants.
+  //  - 2x2 data design.
+]

--- a/tests/snapshots/assets__check_file@unit-comment-comment-convergence.typ-120.snap
+++ b/tests/snapshots/assets__check_file@unit-comment-comment-convergence.typ-120.snap
@@ -1,0 +1,27 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/comment/comment-convergence.typ
+---
+#[
+  /* bar
+  */
+]
+
+-   /* bar
+   */ 123
+
+- /* bar
+   */
+
+#[
+  /* Somebody write this up:
+  - 1000 participants.
+  - 2x2 data design. */
+]
+
+#[
+  // Somebody write this up:
+  //  - 1000 participants.
+  //  - 2x2 data design.
+]

--- a/tests/snapshots/assets__check_file@unit-comment-comment-convergence.typ-40.snap
+++ b/tests/snapshots/assets__check_file@unit-comment-comment-convergence.typ-40.snap
@@ -1,0 +1,27 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/comment/comment-convergence.typ
+---
+#[
+  /* bar
+  */
+]
+
+-   /* bar
+   */ 123
+
+- /* bar
+   */
+
+#[
+  /* Somebody write this up:
+  - 1000 participants.
+  - 2x2 data design. */
+]
+
+#[
+  // Somebody write this up:
+  //  - 1000 participants.
+  //  - 2x2 data design.
+]

--- a/tests/snapshots/assets__check_file@unit-comment-comment-convergence.typ-80.snap
+++ b/tests/snapshots/assets__check_file@unit-comment-comment-convergence.typ-80.snap
@@ -1,0 +1,27 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/comment/comment-convergence.typ
+---
+#[
+  /* bar
+  */
+]
+
+-   /* bar
+   */ 123
+
+- /* bar
+   */
+
+#[
+  /* Somebody write this up:
+  - 1000 participants.
+  - 2x2 data design. */
+]
+
+#[
+  // Somebody write this up:
+  //  - 1000 participants.
+  //  - 2x2 data design.
+]


### PR DESCRIPTION
fix #136

This a rough fix. Ideally we should get the indent level of the start of the block comment, and strip that specific amount of whitesapce for each line. But this is unfortunately a little bit hard to implement in `typst-syntax`.

This pr unconditionally strips all prefix whitespace for the block comments.