### PR TITLE
feat: support inline code block with simple flavor-based method

### DIFF
--- a/tests/assets/unit/code/if-chain.typ
+++ b/tests/assets/unit/code/if-chain.typ
@@ -1,0 +1,35 @@
+#if a < b { true   } else if c < d {  (false,) }   else if 1 + 2 == 3  {  (true, false) }   else  { none }
+
+#if a < b { true   } else if c < d [  false ]   else if 1 + 2 == 3 [*strong*]   else  { none }
+
+#if a < b { true   } else if c < d [
+   false ]    else if 1 + 2 == 3 [*strong*]    else  {
+    none }
+
+#if a < b {
+  true   } else if c < d [  false ]    else if 1 + 2 == 3 [
+    *strong*]    else  { none
+}
+
+#{ if a < b { true   } else if c < d {  (false,) }   else if 1 + 2 == 3  {  (true, false) }   else  { none }
+
+  if a < b { true   } else if c < d [  false ]   else if 1 + 2 == 3 [*strong*]   else  { none }
+
+         if a < b { true   } else if c < d [
+   false ]    else if 1 + 2 == 3 [*strong*]    else  {
+    none }
+
+if a < b {
+  true   } else if c < d [  false ]    else if 1 + 2 == 3 [
+    *strong*]    else  { none
+}
+
+}
+
+#if a < b { true; false   } else if c < d [  false ]   else if 1 + 2 == 3 [*strong*]   else  { a = 3; none }
+
+#if a < b { true
+ false   } else if c < d [
+   false ]   else if 1 + 2 == 3 [*strong*]  else if false { if 0 < 1 { true } }  else  { a = 3
+   if 3 > 2 { for i in range(10) { i}   }
+   none }

--- a/tests/assets/unit/code/short-block-with-comment.typ
+++ b/tests/assets/unit/code/short-block-with-comment.typ
@@ -1,0 +1,175 @@
+#let   o   =    {
+  // comments
+}
+
+#let   o   =    {    // comments
+
+}
+
+
+#let   o   =    {
+
+ // comments
+
+}
+
+#let   o   =    {
+   /* comments */
+}
+
+#let   o   =    {
+
+   /* comments */
+
+}
+
+#let   o   =    {   /* comments */
+
+}
+
+#let   o   =    {
+
+ /* comments */ }
+
+#let   o   =    {  /*
+   comments
+    */  }
+
+#let   o   =    {
+   /* comments
+ 123
+    */
+}
+
+#let   o   =    {   /*
+comments */
+}
+
+#let   o   =    {   /* comments */  }
+
+#let   o   =    {
+   /* comments */  }
+
+#let   o   =    {   /* comments */
+}
+
+#let a = { 543 }
+
+#let a = { 543 /* something */ }
+
+#let a = { 543 // something
+}
+
+#let   o   =    { 666
+// comments
+}
+
+#let   o   =    {
+  // comments
+666 }
+
+#let   o   =    {    // comments
+666
+}
+
+#let   o   =    {  666  // comments
+
+}
+
+
+#let   o   =    {
+666
+ // comments
+
+}
+
+#let   o   =    { 666
+
+ // comments
+
+}
+
+#let   o   =    {
+
+ // comments
+666
+}
+
+#let   o   =    { 666
+   /* comments */
+}
+
+#let   o   =    {
+666   /* comments */
+}
+
+#let   o   =    {
+   /* comments */  666
+}
+
+#let   o   =    {  666
+
+   /* comments */
+
+}
+
+#let   o   =    {
+
+666   /* comments */
+
+}
+
+#let   o   =    {
+
+   /* comments */ 666
+
+}
+
+#let   o   =    {  6666    /* comments */
+
+}
+
+#let   o   =    {   /* comments */
+    66666
+}
+
+#let   o   =    { 6666
+
+ /* comments    */ }
+
+#let   o   =    {
+666
+ /*    comments */   }
+
+#let   o   =    {
+
+ /* comments */  666 }
+
+#let   o   =    {  666 /*
+   comments
+    */  }
+
+#let   o   =    {  /*
+   comments
+    */ 666 }
+
+#let   o   =    { 666
+   /* comments
+
+  123  */
+}
+
+#let   o   =    {
+   /*       comments
+
+    */ 666
+}
+
+#let   o   =    {   /*
+comments     */
+666 }
+
+#let   o   =    {  666 /*
+
+comments */
+}

--- a/tests/assets/unit/code/short-block.typ
+++ b/tests/assets/unit/code/short-block.typ
@@ -1,0 +1,68 @@
+#let o   = {       }
+
+#let   o = {}
+
+#let o =    {
+
+}
+
+#let o =    {
+
+
+
+
+}
+
+#let o =    {
+
+
+true
+
+}
+
+#let   o   =    {
+  // comments
+}
+
+#let   o   =    {    // comments
+
+}
+
+#let   o   =    {
+   /* comments */
+}
+
+#let   o   =    {  /*
+   comments
+    */  }
+
+#let   o   =    {
+   /* comments
+
+    */
+}
+
+#let   o   =    {   /*
+comments */
+}
+
+#let   o   =    {   /* comments */  }
+
+#let a = { 543 }
+
+#let a = { 543 /* something */ }
+
+#let a = { 543 // something
+}
+
+#let b = { "114"; "514" }
+
+#let c = {  let x = 3 }
+
+#let d = {  let y = true;
+ }
+
+#let d = {  let y = true;
+ false }
+
+#let e = {  let (x, y) = (foo.bar)(baz()) }

--- a/tests/assets/unit/code/short-block.typ
+++ b/tests/assets/unit/code/short-block.typ
@@ -20,41 +20,6 @@ true
 
 }
 
-#let   o   =    {
-  // comments
-}
-
-#let   o   =    {    // comments
-
-}
-
-#let   o   =    {
-   /* comments */
-}
-
-#let   o   =    {  /*
-   comments
-    */  }
-
-#let   o   =    {
-   /* comments
-
-    */
-}
-
-#let   o   =    {   /*
-comments */
-}
-
-#let   o   =    {   /* comments */  }
-
-#let a = { 543 }
-
-#let a = { 543 /* something */ }
-
-#let a = { 543 // something
-}
-
 #let b = { "114"; "514" }
 
 #let c = {  let x = 3 }

--- a/tests/assets/unit/code/short-if.typ
+++ b/tests/assets/unit/code/short-if.typ
@@ -1,0 +1,22 @@
+#table(
+  fill: (x, y) => if y == 0 { white.darken(15%) } else { none },
+  align: (x, y) => if y == 0 { center } else { horizon },
+  [Hi],
+  [there],
+)
+
+#if true {
+  [a]
+} else [
+  bbb
+]
+
+#let a = if true { 0 } else { 1 }
+
+#{
+  if true {
+    [a]
+  } else [
+    bbb
+  ]
+}

--- a/tests/snapshots/assets__check_file@cetz-manual.typ-120.snap
+++ b/tests/snapshots/assets__check_file@cetz-manual.typ-120.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/cetz-manual.typ
+snapshot_kind: text
 ---
 #import "doc/util.typ": *
 #import "doc/example.typ": example
@@ -236,11 +237,7 @@ Marks are arrow tips that can be added to the end of path based elements that su
         let name-to-mnemonic = (:)
         for (name, item) in cetz.mark-shapes.mnemonics {
           let list = name-to-mnemonic.at(item.at(0), default: ())
-          list += (
-            raw(name) + if item.at(1) {
-              " (reversed)"
-            },
-          )
+          list += (raw(name) + if item.at(1) { " (reversed)" },)
           name-to-mnemonic.insert(item.at(0), list)
         }
         (
@@ -1073,9 +1070,7 @@ The palette library provides some predefined palettes.
     {
       import cetz.draw: *
       for i in range(0, p("len")) {
-        if calc.rem(i, 10) == 0 {
-          move-to((rel: (0, -.5)))
-        }
+        if calc.rem(i, 10) == 0 { move-to((rel: (0, -.5))) }
         rect((), (rel: (1, .5)), name: "r", ..p(i))
         move-to("r.south-east")
       }

--- a/tests/snapshots/assets__check_file@cetz-manual.typ-80.snap
+++ b/tests/snapshots/assets__check_file@cetz-manual.typ-80.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/cetz-manual.typ
+snapshot_kind: text
 ---
 #import "doc/util.typ": *
 #import "doc/example.typ": example
@@ -241,11 +242,7 @@ Marks are arrow tips that can be added to the end of path based elements that su
         let name-to-mnemonic = (:)
         for (name, item) in cetz.mark-shapes.mnemonics {
           let list = name-to-mnemonic.at(item.at(0), default: ())
-          list += (
-            raw(name) + if item.at(1) {
-              " (reversed)"
-            },
-          )
+          list += (raw(name) + if item.at(1) { " (reversed)" },)
           name-to-mnemonic.insert(item.at(0), list)
         }
         (
@@ -1118,9 +1115,7 @@ The palette library provides some predefined palettes.
     {
       import cetz.draw: *
       for i in range(0, p("len")) {
-        if calc.rem(i, 10) == 0 {
-          move-to((rel: (0, -.5)))
-        }
+        if calc.rem(i, 10) == 0 { move-to((rel: (0, -.5))) }
         rect((), (rel: (1, .5)), name: "r", ..p(i))
         move-to("r.south-east")
       }

--- a/tests/snapshots/assets__check_file@cetz-tree.typ-120.snap
+++ b/tests/snapshots/assets__check_file@cetz-tree.typ-120.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/cetz-tree.typ
+snapshot_kind: text
 ---
 // CeTZ Library for Layouting Tree-Nodes
 #import "../util.typ"
@@ -41,12 +42,8 @@ input_file: tests/assets/cetz-tree.typ
   assert(grow > 0)
   assert(spread > 0)
 
-  if direction == "down" {
-    direction = "bottom"
-  }
-  if direction == "up" {
-    direction = "top"
-  }
+  if direction == "down" { direction = "bottom" }
+  if direction == "up" { direction = "top" }
 
   let opposite-dir = (left: "right", right: "left", bottom: "top", top: "bottom")
 

--- a/tests/snapshots/assets__check_file@cetz-tree.typ-80.snap
+++ b/tests/snapshots/assets__check_file@cetz-tree.typ-80.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/cetz-tree.typ
+snapshot_kind: text
 ---
 // CeTZ Library for Layouting Tree-Nodes
 #import "../util.typ"
@@ -41,12 +42,8 @@ input_file: tests/assets/cetz-tree.typ
   assert(grow > 0)
   assert(spread > 0)
 
-  if direction == "down" {
-    direction = "bottom"
-  }
-  if direction == "up" {
-    direction = "top"
-  }
+  if direction == "down" { direction = "bottom" }
+  if direction == "up" { direction = "top" }
 
   let opposite-dir = (
     left: "right",

--- a/tests/snapshots/assets__check_file@simple-paper.typ-120.snap
+++ b/tests/snapshots/assets__check_file@simple-paper.typ-120.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/simple-paper.typ
+snapshot_kind: text
 ---
 #let project(
   title: "",
@@ -42,9 +43,7 @@ input_file: tests/assets/simple-paper.typ
   show heading: it => box(width: 100%)[
     #v(0.50em)
     #set text(font: heading-font)
-    #if it.numbering != none {
-      counter(heading).display()
-    }
+    #if it.numbering != none { counter(heading).display() }
     #h(0.75em)
     #it.body
   ]

--- a/tests/snapshots/assets__check_file@simple-paper.typ-80.snap
+++ b/tests/snapshots/assets__check_file@simple-paper.typ-80.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/simple-paper.typ
+snapshot_kind: text
 ---
 #let project(
   title: "",
@@ -42,9 +43,7 @@ input_file: tests/assets/simple-paper.typ
   show heading: it => box(width: 100%)[
     #v(0.50em)
     #set text(font: heading-font)
-    #if it.numbering != none {
-      counter(heading).display()
-    }
+    #if it.numbering != none { counter(heading).display() }
     #h(0.75em)
     #it.body
   ]

--- a/tests/snapshots/assets__check_file@tablex.typ-120.snap
+++ b/tests/snapshots/assets__check_file@tablex.typ-120.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/tablex.typ
+snapshot_kind: text
 ---
 // Welcome to tablex!
 // Feel free to contribute with any features you think are missing.
@@ -359,16 +360,8 @@ input_file: tests/assets/tablex.typ
 // is greater than 1)
 #let positions-spanned-by(cell, x: 0, y: 0, x_limit: 0, y_limit: none) = {
   let result = ()
-  let rowspan = if "rowspan" in cell {
-    cell.rowspan
-  } else {
-    1
-  }
-  let colspan = if "colspan" in cell {
-    cell.colspan
-  } else {
-    1
-  }
+  let rowspan = if "rowspan" in cell { cell.rowspan } else { 1 }
+  let colspan = if "colspan" in cell { cell.colspan } else { 1 }
 
   if rowspan < 1 {
     panic("Cell rowspan must be 1 or greater (bad cell: " + repr((x, y)) + ")")
@@ -2041,9 +2034,7 @@ input_file: tests/assets/tablex.typ
   let stroke = default-if-auto(hline.stroke, stroke)
   let stroke = parse-stroke(stroke)
 
-  if default-if-auto-or-none(start, 0) == default-if-auto-or-none(end, columns.len()) {
-    return
-  }
+  if default-if-auto-or-none(start, 0) == default-if-auto-or-none(end, columns.len()) { return  }
 
   if gutter != none and gutter.row != none and (
     (pre-gutter and hline.gutter-restrict == bottom) or (not pre-gutter and hline.gutter-restrict == top)
@@ -2130,9 +2121,7 @@ input_file: tests/assets/tablex.typ
   let stroke = default-if-auto(vline.stroke, stroke)
   let stroke = parse-stroke(stroke)
 
-  if default-if-auto-or-none(start, 0) == default-if-auto-or-none(end, rows.len()) {
-    return
-  }
+  if default-if-auto-or-none(start, 0) == default-if-auto-or-none(end, rows.len()) { return  }
 
   if gutter != none and gutter.col != none and (
     (pre-gutter and vline.gutter-restrict == right) or (not pre-gutter and vline.gutter-restrict == left)
@@ -2802,11 +2791,7 @@ input_file: tests/assets/tablex.typ
       let cells = map-rows(
         row,
         original-cells.map(c => {
-          if is-tablex-occupied(c) {
-            none
-          } else {
-            c
-          }
+          if is-tablex-occupied(c) { none } else { c }
         }),
       )
 
@@ -2860,11 +2845,7 @@ input_file: tests/assets/tablex.typ
       let cells = map-cols(
         column,
         original-cells.map(c => {
-          if is-tablex-occupied(c) {
-            none
-          } else {
-            c
-          }
+          if is-tablex-occupied(c) { none } else { c }
         }),
       )
 
@@ -3154,11 +3135,7 @@ input_file: tests/assets/tablex.typ
 
     // When there are more rows than the user specified, we ensure they have
     // the same size as the last specified row.
-    let last-row-size = if rows.len() == 0 {
-      auto
-    } else {
-      rows.last()
-    }
+    let last-row-size = if rows.len() == 0 { auto } else { rows.last() }
     for _ in range(grid_info.new_row_count - row_len) {
       rows.push(last-row-size) // add new rows (due to extra cells)
     }

--- a/tests/snapshots/assets__check_file@tablex.typ-40.snap
+++ b/tests/snapshots/assets__check_file@tablex.typ-40.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/tablex.typ
+snapshot_kind: text
 ---
 // Welcome to tablex!
 // Feel free to contribute with any features you think are missing.
@@ -468,14 +469,10 @@ input_file: tests/assets/tablex.typ
   let result = ()
   let rowspan = if "rowspan" in cell {
     cell.rowspan
-  } else {
-    1
-  }
+  } else { 1 }
   let colspan = if "colspan" in cell {
     cell.colspan
-  } else {
-    1
-  }
+  } else { 1 }
 
   if rowspan < 1 {
     panic("Cell rowspan must be 1 or greater (bad cell: " + repr((
@@ -2751,9 +2748,7 @@ input_file: tests/assets/tablex.typ
   ) == default-if-auto-or-none(
     end,
     columns.len(),
-  ) {
-    return
-  }
+  ) { return  }
 
   if gutter != none and gutter.row != none and (
     (
@@ -2882,9 +2877,7 @@ input_file: tests/assets/tablex.typ
   ) == default-if-auto-or-none(
     end,
     rows.len(),
-  ) {
-    return
-  }
+  ) { return  }
 
   if gutter != none and gutter.col != none and (
     (
@@ -3878,9 +3871,7 @@ input_file: tests/assets/tablex.typ
         original-cells.map(c => {
           if is-tablex-occupied(c) {
             none
-          } else {
-            c
-          }
+          } else { c }
         }),
       )
 
@@ -3950,9 +3941,7 @@ input_file: tests/assets/tablex.typ
         original-cells.map(c => {
           if is-tablex-occupied(c) {
             none
-          } else {
-            c
-          }
+          } else { c }
         }),
       )
 
@@ -4302,9 +4291,7 @@ input_file: tests/assets/tablex.typ
     // the same size as the last specified row.
     let last-row-size = if rows.len() == 0 {
       auto
-    } else {
-      rows.last()
-    }
+    } else { rows.last() }
     for _ in range(grid_info.new_row_count - row_len) {
       rows.push(last-row-size) // add new rows (due to extra cells)
     }

--- a/tests/snapshots/assets__check_file@tablex.typ-80.snap
+++ b/tests/snapshots/assets__check_file@tablex.typ-80.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/tablex.typ
+snapshot_kind: text
 ---
 // Welcome to tablex!
 // Feel free to contribute with any features you think are missing.
@@ -378,16 +379,8 @@ input_file: tests/assets/tablex.typ
 // is greater than 1)
 #let positions-spanned-by(cell, x: 0, y: 0, x_limit: 0, y_limit: none) = {
   let result = ()
-  let rowspan = if "rowspan" in cell {
-    cell.rowspan
-  } else {
-    1
-  }
-  let colspan = if "colspan" in cell {
-    cell.colspan
-  } else {
-    1
-  }
+  let rowspan = if "rowspan" in cell { cell.rowspan } else { 1 }
+  let colspan = if "colspan" in cell { cell.colspan } else { 1 }
 
   if rowspan < 1 {
     panic("Cell rowspan must be 1 or greater (bad cell: " + repr((x, y)) + ")")
@@ -2210,9 +2203,7 @@ input_file: tests/assets/tablex.typ
   if default-if-auto-or-none(start, 0) == default-if-auto-or-none(
     end,
     columns.len(),
-  ) {
-    return
-  }
+  ) { return  }
 
   if gutter != none and gutter.row != none and (
     (pre-gutter and hline.gutter-restrict == bottom) or (
@@ -2314,9 +2305,7 @@ input_file: tests/assets/tablex.typ
   if default-if-auto-or-none(start, 0) == default-if-auto-or-none(
     end,
     rows.len(),
-  ) {
-    return
-  }
+  ) { return  }
 
   if gutter != none and gutter.col != none and (
     (pre-gutter and vline.gutter-restrict == right) or (
@@ -3079,11 +3068,7 @@ input_file: tests/assets/tablex.typ
       let cells = map-rows(
         row,
         original-cells.map(c => {
-          if is-tablex-occupied(c) {
-            none
-          } else {
-            c
-          }
+          if is-tablex-occupied(c) { none } else { c }
         }),
       )
 
@@ -3139,11 +3124,7 @@ input_file: tests/assets/tablex.typ
       let cells = map-cols(
         column,
         original-cells.map(c => {
-          if is-tablex-occupied(c) {
-            none
-          } else {
-            c
-          }
+          if is-tablex-occupied(c) { none } else { c }
         }),
       )
 
@@ -3446,11 +3427,7 @@ input_file: tests/assets/tablex.typ
 
     // When there are more rows than the user specified, we ensure they have
     // the same size as the last specified row.
-    let last-row-size = if rows.len() == 0 {
-      auto
-    } else {
-      rows.last()
-    }
+    let last-row-size = if rows.len() == 0 { auto } else { rows.last() }
     for _ in range(grid_info.new_row_count - row_len) {
       rows.push(last-row-size) // add new rows (due to extra cells)
     }

--- a/tests/snapshots/assets__check_file@undergraduate-math.typ-120.snap
+++ b/tests/snapshots/assets__check_file@undergraduate-math.typ-120.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/undergraduate-math.typ
+snapshot_kind: text
 ---
 // Meta data
 #set document(title: "Typst Math for Undergrads", author: "johanvx")
@@ -87,9 +88,7 @@ input_file: tests/assets/undergraduate-math.typ
 )
 
 // Black raw code
-#show raw.where(block: false): it => {
-  it.text
-}
+#show raw.where(block: false): it => { it.text }
 
 // Two-column layout
 #show: rest => columns(2, rest)

--- a/tests/snapshots/assets__check_file@undergraduate-math.typ-80.snap
+++ b/tests/snapshots/assets__check_file@undergraduate-math.typ-80.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/undergraduate-math.typ
+snapshot_kind: text
 ---
 // Meta data
 #set document(title: "Typst Math for Undergrads", author: "johanvx")
@@ -87,9 +88,7 @@ input_file: tests/assets/undergraduate-math.typ
 )
 
 // Black raw code
-#show raw.where(block: false): it => {
-  it.text
-}
+#show raw.where(block: false): it => { it.text }
 
 // Two-column layout
 #show: rest => columns(2, rest)

--- a/tests/snapshots/assets__check_file@unit-code-for-loop-line-break.typ-120.snap
+++ b/tests/snapshots/assets__check_file@unit-code-for-loop-line-break.typ-120.snap
@@ -2,17 +2,14 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/unit/code/for-loop-line-break.typ
+snapshot_kind: text
 ---
 #import "@preview/cetz:0.2.2"
 
 #let 六面体 = {
   import cetz.draw: *
   import cetz: *
-  let neg(u) = if u == 0 {
-    1
-  } else {
-    -1
-  }
+  let neg(u) = if u == 0 { 1 } else { -1 }
   for (p, c) in (
     ((0, 0, 0), black),
     ((1, 1, 0), red),

--- a/tests/snapshots/assets__check_file@unit-code-for-loop-line-break.typ-40.snap
+++ b/tests/snapshots/assets__check_file@unit-code-for-loop-line-break.typ-40.snap
@@ -2,15 +2,14 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/unit/code/for-loop-line-break.typ
+snapshot_kind: text
 ---
 #import "@preview/cetz:0.2.2"
 
 #let 六面体 = {
   import cetz.draw: *
   import cetz: *
-  let neg(u) = if u == 0 {
-    1
-  } else {
+  let neg(u) = if u == 0 { 1 } else {
     -1
   }
   for (p, c) in (

--- a/tests/snapshots/assets__check_file@unit-code-for-loop-line-break.typ-80.snap
+++ b/tests/snapshots/assets__check_file@unit-code-for-loop-line-break.typ-80.snap
@@ -2,17 +2,14 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/unit/code/for-loop-line-break.typ
+snapshot_kind: text
 ---
 #import "@preview/cetz:0.2.2"
 
 #let 六面体 = {
   import cetz.draw: *
   import cetz: *
-  let neg(u) = if u == 0 {
-    1
-  } else {
-    -1
-  }
+  let neg(u) = if u == 0 { 1 } else { -1 }
   for (p, c) in (
     ((0, 0, 0), black),
     ((1, 1, 0), red),

--- a/tests/snapshots/assets__check_file@unit-code-if-chain.typ-0.snap
+++ b/tests/snapshots/assets__check_file@unit-code-if-chain.typ-0.snap
@@ -1,0 +1,104 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/code/if-chain.typ
+snapshot_kind: text
+---
+#if a < b {
+  true
+} else if c < d {
+  (
+    false,
+  )
+} else if 1 + 2 == 3 {
+  (
+    true,
+    false,
+  )
+} else {
+  none
+}
+
+#if a < b {
+  true
+} else if c < d [ false ] else if 1 + 2 == 3 [*strong*] else {
+  none
+}
+
+#if a < b {
+  true
+} else if c < d [
+  false ] else if 1 + 2 == 3 [*strong*] else {
+  none
+}
+
+#if a < b {
+  true
+} else if c < d [ false ] else if 1 + 2 == 3 [
+  *strong*] else {
+  none
+}
+
+#{
+  if a < b {
+    true
+  } else if c < d {
+    (
+      false,
+    )
+  } else if 1 + 2 == 3 {
+    (
+      true,
+      false,
+    )
+  } else {
+    none
+  }
+
+  if a < b {
+    true
+  } else if c < d [ false ] else if 1 + 2 == 3 [*strong*] else {
+    none
+  }
+
+  if a < b {
+    true
+  } else if c < d [
+    false ] else if 1 + 2 == 3 [*strong*] else {
+    none
+  }
+
+  if a < b {
+    true
+  } else if c < d [ false ] else if 1 + 2 == 3 [
+    *strong*] else {
+    none
+  }
+
+}
+
+#if a < b {
+  true
+  false
+} else if c < d [ false ] else if 1 + 2 == 3 [*strong*] else {
+  a = 3
+  none
+}
+
+#if a < b {
+  true
+  false
+} else if c < d [
+  false ] else if 1 + 2 == 3 [*strong*] else if false {
+  if 0 < 1 {
+    true
+  }
+} else {
+  a = 3
+  if 3 > 2 {
+    for i in range(10) {
+      i
+    }
+  }
+  none
+}

--- a/tests/snapshots/assets__check_file@unit-code-if-chain.typ-120.snap
+++ b/tests/snapshots/assets__check_file@unit-code-if-chain.typ-120.snap
@@ -1,0 +1,54 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/code/if-chain.typ
+snapshot_kind: text
+---
+#if a < b { true } else if c < d { (false,) } else if 1 + 2 == 3 { (true, false) } else { none }
+
+#if a < b { true } else if c < d [ false ] else if 1 + 2 == 3 [*strong*] else { none }
+
+#if a < b { true } else if c < d [
+  false ] else if 1 + 2 == 3 [*strong*] else {
+  none
+}
+
+#if a < b {
+  true
+} else if c < d [ false ] else if 1 + 2 == 3 [
+  *strong*] else { none }
+
+#{
+  if a < b { true } else if c < d { (false,) } else if 1 + 2 == 3 { (true, false) } else { none }
+
+  if a < b { true } else if c < d [ false ] else if 1 + 2 == 3 [*strong*] else { none }
+
+  if a < b { true } else if c < d [
+    false ] else if 1 + 2 == 3 [*strong*] else {
+    none
+  }
+
+  if a < b {
+    true
+  } else if c < d [ false ] else if 1 + 2 == 3 [
+    *strong*] else { none }
+
+}
+
+#if a < b {
+  true
+  false
+} else if c < d [ false ] else if 1 + 2 == 3 [*strong*] else {
+  a = 3
+  none
+}
+
+#if a < b {
+  true
+  false
+} else if c < d [
+  false ] else if 1 + 2 == 3 [*strong*] else if false { if 0 < 1 { true } } else {
+  a = 3
+  if 3 > 2 { for i in range(10) { i } }
+  none
+}

--- a/tests/snapshots/assets__check_file@unit-code-if-chain.typ-40.snap
+++ b/tests/snapshots/assets__check_file@unit-code-if-chain.typ-40.snap
@@ -1,0 +1,72 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/code/if-chain.typ
+snapshot_kind: text
+---
+#if a < b { true } else if c < d {
+  (false,)
+} else if 1 + 2 == 3 {
+  (true, false)
+} else { none }
+
+#if a < b {
+  true
+} else if c < d [ false ] else if 1 + 2 == 3 [*strong*] else {
+  none
+}
+
+#if a < b { true } else if c < d [
+  false ] else if 1 + 2 == 3 [*strong*] else {
+  none
+}
+
+#if a < b {
+  true
+} else if c < d [ false ] else if 1 + 2 == 3 [
+  *strong*] else { none }
+
+#{
+  if a < b { true } else if c < d {
+    (false,)
+  } else if 1 + 2 == 3 {
+    (true, false)
+  } else { none }
+
+  if a < b {
+    true
+  } else if c < d [ false ] else if 1 + 2 == 3 [*strong*] else {
+    none
+  }
+
+  if a < b { true } else if c < d [
+    false ] else if 1 + 2 == 3 [*strong*] else {
+    none
+  }
+
+  if a < b {
+    true
+  } else if c < d [ false ] else if 1 + 2 == 3 [
+    *strong*] else { none }
+
+}
+
+#if a < b {
+  true
+  false
+} else if c < d [ false ] else if 1 + 2 == 3 [*strong*] else {
+  a = 3
+  none
+}
+
+#if a < b {
+  true
+  false
+} else if c < d [
+  false ] else if 1 + 2 == 3 [*strong*] else if false {
+  if 0 < 1 { true }
+} else {
+  a = 3
+  if 3 > 2 { for i in range(10) { i } }
+  none
+}

--- a/tests/snapshots/assets__check_file@unit-code-if-chain.typ-80.snap
+++ b/tests/snapshots/assets__check_file@unit-code-if-chain.typ-80.snap
@@ -1,0 +1,64 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/code/if-chain.typ
+snapshot_kind: text
+---
+#if a < b { true } else if c < d { (false,) } else if 1 + 2 == 3 {
+  (true, false)
+} else { none }
+
+#if a < b { true } else if c < d [ false ] else if 1 + 2 == 3 [*strong*] else {
+  none
+}
+
+#if a < b { true } else if c < d [
+  false ] else if 1 + 2 == 3 [*strong*] else {
+  none
+}
+
+#if a < b {
+  true
+} else if c < d [ false ] else if 1 + 2 == 3 [
+  *strong*] else { none }
+
+#{
+  if a < b { true } else if c < d { (false,) } else if 1 + 2 == 3 {
+    (true, false)
+  } else { none }
+
+  if a < b { true } else if c < d [ false ] else if 1 + 2 == 3 [*strong*] else {
+    none
+  }
+
+  if a < b { true } else if c < d [
+    false ] else if 1 + 2 == 3 [*strong*] else {
+    none
+  }
+
+  if a < b {
+    true
+  } else if c < d [ false ] else if 1 + 2 == 3 [
+    *strong*] else { none }
+
+}
+
+#if a < b {
+  true
+  false
+} else if c < d [ false ] else if 1 + 2 == 3 [*strong*] else {
+  a = 3
+  none
+}
+
+#if a < b {
+  true
+  false
+} else if c < d [
+  false ] else if 1 + 2 == 3 [*strong*] else if false {
+  if 0 < 1 { true }
+} else {
+  a = 3
+  if 3 > 2 { for i in range(10) { i } }
+  none
+}

--- a/tests/snapshots/assets__check_file@unit-code-short-block-with-comment.typ-0.snap
+++ b/tests/snapshots/assets__check_file@unit-code-short-block-with-comment.typ-0.snap
@@ -1,0 +1,190 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/code/short-block-with-comment.typ
+snapshot_kind: text
+---
+#let o = {
+  // comments
+}
+
+#let o = {
+  // comments
+
+}
+
+
+#let o = {
+
+  // comments
+
+}
+
+#let o = {
+   /* comments */
+}
+
+#let o = {
+
+   /* comments */
+
+}
+
+#let o = {   /* comments */
+
+}
+
+#let o = {
+
+ /* comments */ }
+
+#let o = {  /*
+   comments
+    */  }
+
+#let o = {
+   /* comments
+ 123
+    */
+}
+
+#let o = {   /*
+comments */
+}
+
+#let o = {   /* comments */  }
+
+#let o = {
+   /* comments */  }
+
+#let o = {   /* comments */
+}
+
+#let a = {
+  543
+}
+
+#let a = { 543 /* something */ }
+
+#let a = {
+  543 // something
+}
+
+#let o = {
+  666
+  // comments
+}
+
+#let o = {
+  // comments
+  666
+}
+
+#let o = {
+  // comments
+  666
+}
+
+#let o = {
+  666 // comments
+
+}
+
+
+#let o = {
+  666
+  // comments
+
+}
+
+#let o = {
+  666
+
+  // comments
+
+}
+
+#let o = {
+
+  // comments
+  666
+}
+
+#let o = { 666
+   /* comments */
+}
+
+#let o = {
+666   /* comments */
+}
+
+#let o = {
+   /* comments */  666
+}
+
+#let o = {  666
+
+   /* comments */
+
+}
+
+#let o = {
+
+666   /* comments */
+
+}
+
+#let o = {
+
+   /* comments */ 666
+
+}
+
+#let o = {  6666    /* comments */
+
+}
+
+#let o = {   /* comments */
+    66666
+}
+
+#let o = { 6666
+
+ /* comments    */ }
+
+#let o = {
+666
+ /*    comments */   }
+
+#let o = {
+
+ /* comments */  666 }
+
+#let o = {  666 /*
+   comments
+    */  }
+
+#let o = {  /*
+   comments
+    */ 666 }
+
+#let o = { 666
+   /* comments
+
+  123  */
+}
+
+#let o = {
+   /*       comments
+
+    */ 666
+}
+
+#let o = {   /*
+comments     */
+666 }
+
+#let o = {  666 /*
+
+comments */
+}

--- a/tests/snapshots/assets__check_file@unit-code-short-block-with-comment.typ-120.snap
+++ b/tests/snapshots/assets__check_file@unit-code-short-block-with-comment.typ-120.snap
@@ -1,0 +1,188 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/code/short-block-with-comment.typ
+snapshot_kind: text
+---
+#let o = {
+  // comments
+}
+
+#let o = {
+  // comments
+
+}
+
+
+#let o = {
+
+  // comments
+
+}
+
+#let o = {
+   /* comments */
+}
+
+#let o = {
+
+   /* comments */
+
+}
+
+#let o = {   /* comments */
+
+}
+
+#let o = {
+
+ /* comments */ }
+
+#let o = {  /*
+   comments
+    */  }
+
+#let o = {
+   /* comments
+ 123
+    */
+}
+
+#let o = {   /*
+comments */
+}
+
+#let o = {   /* comments */  }
+
+#let o = {
+   /* comments */  }
+
+#let o = {   /* comments */
+}
+
+#let a = { 543 }
+
+#let a = { 543 /* something */ }
+
+#let a = {
+  543 // something
+}
+
+#let o = {
+  666
+  // comments
+}
+
+#let o = {
+  // comments
+  666
+}
+
+#let o = {
+  // comments
+  666
+}
+
+#let o = {
+  666 // comments
+
+}
+
+
+#let o = {
+  666
+  // comments
+
+}
+
+#let o = {
+  666
+
+  // comments
+
+}
+
+#let o = {
+
+  // comments
+  666
+}
+
+#let o = { 666
+   /* comments */
+}
+
+#let o = {
+666   /* comments */
+}
+
+#let o = {
+   /* comments */  666
+}
+
+#let o = {  666
+
+   /* comments */
+
+}
+
+#let o = {
+
+666   /* comments */
+
+}
+
+#let o = {
+
+   /* comments */ 666
+
+}
+
+#let o = {  6666    /* comments */
+
+}
+
+#let o = {   /* comments */
+    66666
+}
+
+#let o = { 6666
+
+ /* comments    */ }
+
+#let o = {
+666
+ /*    comments */   }
+
+#let o = {
+
+ /* comments */  666 }
+
+#let o = {  666 /*
+   comments
+    */  }
+
+#let o = {  /*
+   comments
+    */ 666 }
+
+#let o = { 666
+   /* comments
+
+  123  */
+}
+
+#let o = {
+   /*       comments
+
+    */ 666
+}
+
+#let o = {   /*
+comments     */
+666 }
+
+#let o = {  666 /*
+
+comments */
+}

--- a/tests/snapshots/assets__check_file@unit-code-short-block-with-comment.typ-40.snap
+++ b/tests/snapshots/assets__check_file@unit-code-short-block-with-comment.typ-40.snap
@@ -1,0 +1,188 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/code/short-block-with-comment.typ
+snapshot_kind: text
+---
+#let o = {
+  // comments
+}
+
+#let o = {
+  // comments
+
+}
+
+
+#let o = {
+
+  // comments
+
+}
+
+#let o = {
+   /* comments */
+}
+
+#let o = {
+
+   /* comments */
+
+}
+
+#let o = {   /* comments */
+
+}
+
+#let o = {
+
+ /* comments */ }
+
+#let o = {  /*
+   comments
+    */  }
+
+#let o = {
+   /* comments
+ 123
+    */
+}
+
+#let o = {   /*
+comments */
+}
+
+#let o = {   /* comments */  }
+
+#let o = {
+   /* comments */  }
+
+#let o = {   /* comments */
+}
+
+#let a = { 543 }
+
+#let a = { 543 /* something */ }
+
+#let a = {
+  543 // something
+}
+
+#let o = {
+  666
+  // comments
+}
+
+#let o = {
+  // comments
+  666
+}
+
+#let o = {
+  // comments
+  666
+}
+
+#let o = {
+  666 // comments
+
+}
+
+
+#let o = {
+  666
+  // comments
+
+}
+
+#let o = {
+  666
+
+  // comments
+
+}
+
+#let o = {
+
+  // comments
+  666
+}
+
+#let o = { 666
+   /* comments */
+}
+
+#let o = {
+666   /* comments */
+}
+
+#let o = {
+   /* comments */  666
+}
+
+#let o = {  666
+
+   /* comments */
+
+}
+
+#let o = {
+
+666   /* comments */
+
+}
+
+#let o = {
+
+   /* comments */ 666
+
+}
+
+#let o = {  6666    /* comments */
+
+}
+
+#let o = {   /* comments */
+    66666
+}
+
+#let o = { 6666
+
+ /* comments    */ }
+
+#let o = {
+666
+ /*    comments */   }
+
+#let o = {
+
+ /* comments */  666 }
+
+#let o = {  666 /*
+   comments
+    */  }
+
+#let o = {  /*
+   comments
+    */ 666 }
+
+#let o = { 666
+   /* comments
+
+  123  */
+}
+
+#let o = {
+   /*       comments
+
+    */ 666
+}
+
+#let o = {   /*
+comments     */
+666 }
+
+#let o = {  666 /*
+
+comments */
+}

--- a/tests/snapshots/assets__check_file@unit-code-short-block-with-comment.typ-80.snap
+++ b/tests/snapshots/assets__check_file@unit-code-short-block-with-comment.typ-80.snap
@@ -1,0 +1,188 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/code/short-block-with-comment.typ
+snapshot_kind: text
+---
+#let o = {
+  // comments
+}
+
+#let o = {
+  // comments
+
+}
+
+
+#let o = {
+
+  // comments
+
+}
+
+#let o = {
+   /* comments */
+}
+
+#let o = {
+
+   /* comments */
+
+}
+
+#let o = {   /* comments */
+
+}
+
+#let o = {
+
+ /* comments */ }
+
+#let o = {  /*
+   comments
+    */  }
+
+#let o = {
+   /* comments
+ 123
+    */
+}
+
+#let o = {   /*
+comments */
+}
+
+#let o = {   /* comments */  }
+
+#let o = {
+   /* comments */  }
+
+#let o = {   /* comments */
+}
+
+#let a = { 543 }
+
+#let a = { 543 /* something */ }
+
+#let a = {
+  543 // something
+}
+
+#let o = {
+  666
+  // comments
+}
+
+#let o = {
+  // comments
+  666
+}
+
+#let o = {
+  // comments
+  666
+}
+
+#let o = {
+  666 // comments
+
+}
+
+
+#let o = {
+  666
+  // comments
+
+}
+
+#let o = {
+  666
+
+  // comments
+
+}
+
+#let o = {
+
+  // comments
+  666
+}
+
+#let o = { 666
+   /* comments */
+}
+
+#let o = {
+666   /* comments */
+}
+
+#let o = {
+   /* comments */  666
+}
+
+#let o = {  666
+
+   /* comments */
+
+}
+
+#let o = {
+
+666   /* comments */
+
+}
+
+#let o = {
+
+   /* comments */ 666
+
+}
+
+#let o = {  6666    /* comments */
+
+}
+
+#let o = {   /* comments */
+    66666
+}
+
+#let o = { 6666
+
+ /* comments    */ }
+
+#let o = {
+666
+ /*    comments */   }
+
+#let o = {
+
+ /* comments */  666 }
+
+#let o = {  666 /*
+   comments
+    */  }
+
+#let o = {  /*
+   comments
+    */ 666 }
+
+#let o = { 666
+   /* comments
+
+  123  */
+}
+
+#let o = {
+   /*       comments
+
+    */ 666
+}
+
+#let o = {   /*
+comments     */
+666 }
+
+#let o = {  666 /*
+
+comments */
+}

--- a/tests/snapshots/assets__check_file@unit-code-short-block.typ-0.snap
+++ b/tests/snapshots/assets__check_file@unit-code-short-block.typ-0.snap
@@ -26,45 +26,6 @@ snapshot_kind: text
 
 }
 
-#let o = {
-  // comments
-}
-
-#let o = {
-  // comments
-
-}
-
-#let o = {
-   /* comments */
-}
-
-#let o = {  /*
-   comments
-    */  }
-
-#let o = {
-   /* comments
-
-    */
-}
-
-#let o = {   /*
-comments */
-}
-
-#let o = {   /* comments */  }
-
-#let a = {
-  543
-}
-
-#let a = { 543 /* something */ }
-
-#let a = {
-  543 // something
-}
-
 #let b = {
   "114"
   "514"

--- a/tests/snapshots/assets__check_file@unit-code-short-block.typ-0.snap
+++ b/tests/snapshots/assets__check_file@unit-code-short-block.typ-0.snap
@@ -1,0 +1,95 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/code/short-block.typ
+snapshot_kind: text
+---
+#let o = { }
+
+#let o = { }
+
+#let o = {
+
+}
+
+#let o = {
+
+
+
+
+}
+
+#let o = {
+
+
+  true
+
+}
+
+#let o = {
+  // comments
+}
+
+#let o = {
+  // comments
+
+}
+
+#let o = {
+   /* comments */
+}
+
+#let o = {  /*
+   comments
+    */  }
+
+#let o = {
+   /* comments
+
+    */
+}
+
+#let o = {   /*
+comments */
+}
+
+#let o = {   /* comments */  }
+
+#let a = {
+  543
+}
+
+#let a = { 543 /* something */ }
+
+#let a = {
+  543 // something
+}
+
+#let b = {
+  "114"
+  "514"
+}
+
+#let c = {
+  let x = 3
+}
+
+#let d = {
+  let y = true
+}
+
+#let d = {
+  let y = true
+  false
+}
+
+#let e = {
+  let (
+    x,
+    y,
+  ) = (
+    foo.bar
+  )(
+    baz(),
+  )
+}

--- a/tests/snapshots/assets__check_file@unit-code-short-block.typ-120.snap
+++ b/tests/snapshots/assets__check_file@unit-code-short-block.typ-120.snap
@@ -26,43 +26,6 @@ snapshot_kind: text
 
 }
 
-#let o = {
-  // comments
-}
-
-#let o = {
-  // comments
-
-}
-
-#let o = {
-   /* comments */
-}
-
-#let o = {  /*
-   comments
-    */  }
-
-#let o = {
-   /* comments
-
-    */
-}
-
-#let o = {   /*
-comments */
-}
-
-#let o = {   /* comments */  }
-
-#let a = { 543 }
-
-#let a = { 543 /* something */ }
-
-#let a = {
-  543 // something
-}
-
 #let b = {
   "114"
   "514"

--- a/tests/snapshots/assets__check_file@unit-code-short-block.typ-120.snap
+++ b/tests/snapshots/assets__check_file@unit-code-short-block.typ-120.snap
@@ -59,7 +59,9 @@ comments */
 
 #let a = { 543 /* something */ }
 
-#let a = { 543 // something }
+#let a = {
+  543 // something
+}
 
 #let b = {
   "114"

--- a/tests/snapshots/assets__check_file@unit-code-short-block.typ-120.snap
+++ b/tests/snapshots/assets__check_file@unit-code-short-block.typ-120.snap
@@ -1,0 +1,78 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/code/short-block.typ
+snapshot_kind: text
+---
+#let o = { }
+
+#let o = { }
+
+#let o = {
+
+}
+
+#let o = {
+
+
+
+
+}
+
+#let o = {
+
+
+  true
+
+}
+
+#let o = {
+  // comments
+}
+
+#let o = {
+  // comments
+
+}
+
+#let o = {
+   /* comments */
+}
+
+#let o = {  /*
+   comments
+    */  }
+
+#let o = {
+   /* comments
+
+    */
+}
+
+#let o = {   /*
+comments */
+}
+
+#let o = {   /* comments */  }
+
+#let a = { 543 }
+
+#let a = { 543 /* something */ }
+
+#let a = { 543 // something }
+
+#let b = {
+  "114"
+  "514"
+}
+
+#let c = { let x = 3 }
+
+#let d = { let y = true }
+
+#let d = {
+  let y = true
+  false
+}
+
+#let e = { let (x, y) = (foo.bar)(baz()) }

--- a/tests/snapshots/assets__check_file@unit-code-short-block.typ-40.snap
+++ b/tests/snapshots/assets__check_file@unit-code-short-block.typ-40.snap
@@ -26,43 +26,6 @@ snapshot_kind: text
 
 }
 
-#let o = {
-  // comments
-}
-
-#let o = {
-  // comments
-
-}
-
-#let o = {
-   /* comments */
-}
-
-#let o = {  /*
-   comments
-    */  }
-
-#let o = {
-   /* comments
-
-    */
-}
-
-#let o = {   /*
-comments */
-}
-
-#let o = {   /* comments */  }
-
-#let a = { 543 }
-
-#let a = { 543 /* something */ }
-
-#let a = {
-  543 // something
-}
-
 #let b = {
   "114"
   "514"

--- a/tests/snapshots/assets__check_file@unit-code-short-block.typ-40.snap
+++ b/tests/snapshots/assets__check_file@unit-code-short-block.typ-40.snap
@@ -1,0 +1,80 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/code/short-block.typ
+snapshot_kind: text
+---
+#let o = { }
+
+#let o = { }
+
+#let o = {
+
+}
+
+#let o = {
+
+
+
+
+}
+
+#let o = {
+
+
+  true
+
+}
+
+#let o = {
+  // comments
+}
+
+#let o = {
+  // comments
+
+}
+
+#let o = {
+   /* comments */
+}
+
+#let o = {  /*
+   comments
+    */  }
+
+#let o = {
+   /* comments
+
+    */
+}
+
+#let o = {   /*
+comments */
+}
+
+#let o = {   /* comments */  }
+
+#let a = { 543 }
+
+#let a = { 543 /* something */ }
+
+#let a = { 543 // something }
+
+#let b = {
+  "114"
+  "514"
+}
+
+#let c = { let x = 3 }
+
+#let d = { let y = true }
+
+#let d = {
+  let y = true
+  false
+}
+
+#let e = {
+  let (x, y) = (foo.bar)(baz())
+}

--- a/tests/snapshots/assets__check_file@unit-code-short-block.typ-40.snap
+++ b/tests/snapshots/assets__check_file@unit-code-short-block.typ-40.snap
@@ -59,7 +59,9 @@ comments */
 
 #let a = { 543 /* something */ }
 
-#let a = { 543 // something }
+#let a = {
+  543 // something
+}
 
 #let b = {
   "114"

--- a/tests/snapshots/assets__check_file@unit-code-short-block.typ-80.snap
+++ b/tests/snapshots/assets__check_file@unit-code-short-block.typ-80.snap
@@ -26,43 +26,6 @@ snapshot_kind: text
 
 }
 
-#let o = {
-  // comments
-}
-
-#let o = {
-  // comments
-
-}
-
-#let o = {
-   /* comments */
-}
-
-#let o = {  /*
-   comments
-    */  }
-
-#let o = {
-   /* comments
-
-    */
-}
-
-#let o = {   /*
-comments */
-}
-
-#let o = {   /* comments */  }
-
-#let a = { 543 }
-
-#let a = { 543 /* something */ }
-
-#let a = {
-  543 // something
-}
-
 #let b = {
   "114"
   "514"

--- a/tests/snapshots/assets__check_file@unit-code-short-block.typ-80.snap
+++ b/tests/snapshots/assets__check_file@unit-code-short-block.typ-80.snap
@@ -59,7 +59,9 @@ comments */
 
 #let a = { 543 /* something */ }
 
-#let a = { 543 // something }
+#let a = {
+  543 // something
+}
 
 #let b = {
   "114"

--- a/tests/snapshots/assets__check_file@unit-code-short-block.typ-80.snap
+++ b/tests/snapshots/assets__check_file@unit-code-short-block.typ-80.snap
@@ -1,0 +1,78 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/code/short-block.typ
+snapshot_kind: text
+---
+#let o = { }
+
+#let o = { }
+
+#let o = {
+
+}
+
+#let o = {
+
+
+
+
+}
+
+#let o = {
+
+
+  true
+
+}
+
+#let o = {
+  // comments
+}
+
+#let o = {
+  // comments
+
+}
+
+#let o = {
+   /* comments */
+}
+
+#let o = {  /*
+   comments
+    */  }
+
+#let o = {
+   /* comments
+
+    */
+}
+
+#let o = {   /*
+comments */
+}
+
+#let o = {   /* comments */  }
+
+#let a = { 543 }
+
+#let a = { 543 /* something */ }
+
+#let a = { 543 // something }
+
+#let b = {
+  "114"
+  "514"
+}
+
+#let c = { let x = 3 }
+
+#let d = { let y = true }
+
+#let d = {
+  let y = true
+  false
+}
+
+#let e = { let (x, y) = (foo.bar)(baz()) }

--- a/tests/snapshots/assets__check_file@unit-code-short-if.typ-0.snap
+++ b/tests/snapshots/assets__check_file@unit-code-short-if.typ-0.snap
@@ -1,0 +1,46 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/code/short-if.typ
+snapshot_kind: text
+---
+#table(
+  fill: (
+    x,
+    y,
+  ) => if y == 0 {
+    white.darken(15%)
+  } else {
+    none
+  },
+  align: (
+    x,
+    y,
+  ) => if y == 0 {
+    center
+  } else {
+    horizon
+  },
+  [Hi],
+  [there],
+)
+
+#if true {
+  [a]
+} else [
+  bbb
+]
+
+#let a = if true {
+  0
+} else {
+  1
+}
+
+#{
+  if true {
+    [a]
+  } else [
+    bbb
+  ]
+}

--- a/tests/snapshots/assets__check_file@unit-code-short-if.typ-120.snap
+++ b/tests/snapshots/assets__check_file@unit-code-short-if.typ-120.snap
@@ -1,0 +1,28 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/code/short-if.typ
+snapshot_kind: text
+---
+#table(
+  fill: (x, y) => if y == 0 { white.darken(15%) } else { none },
+  align: (x, y) => if y == 0 { center } else { horizon },
+  [Hi],
+  [there],
+)
+
+#if true {
+  [a]
+} else [
+  bbb
+]
+
+#let a = if true { 0 } else { 1 }
+
+#{
+  if true {
+    [a]
+  } else [
+    bbb
+  ]
+}

--- a/tests/snapshots/assets__check_file@unit-code-short-if.typ-40.snap
+++ b/tests/snapshots/assets__check_file@unit-code-short-if.typ-40.snap
@@ -1,0 +1,32 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/code/short-if.typ
+snapshot_kind: text
+---
+#table(
+  fill: (x, y) => if y == 0 {
+    white.darken(15%)
+  } else { none },
+  align: (x, y) => if y == 0 {
+    center
+  } else { horizon },
+  [Hi],
+  [there],
+)
+
+#if true {
+  [a]
+} else [
+  bbb
+]
+
+#let a = if true { 0 } else { 1 }
+
+#{
+  if true {
+    [a]
+  } else [
+    bbb
+  ]
+}

--- a/tests/snapshots/assets__check_file@unit-code-short-if.typ-80.snap
+++ b/tests/snapshots/assets__check_file@unit-code-short-if.typ-80.snap
@@ -1,0 +1,28 @@
+---
+source: tests/assets.rs
+expression: doc_string
+input_file: tests/assets/unit/code/short-if.typ
+snapshot_kind: text
+---
+#table(
+  fill: (x, y) => if y == 0 { white.darken(15%) } else { none },
+  align: (x, y) => if y == 0 { center } else { horizon },
+  [Hi],
+  [there],
+)
+
+#if true {
+  [a]
+} else [
+  bbb
+]
+
+#let a = if true { 0 } else { 1 }
+
+#{
+  if true {
+    [a]
+  } else [
+    bbb
+  ]
+}

--- a/tests/snapshots/assets__check_file@unit-grid-colspan.typ-120.snap
+++ b/tests/snapshots/assets__check_file@unit-grid-colspan.typ-120.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/unit/grid/colspan.typ
+snapshot_kind: text
 ---
 #let ofi = [Office]
 #let rem = [_Remote_]
@@ -14,11 +15,7 @@ input_file: tests/assets/unit/grid/colspan.typ
 
 #table(
   columns: 6 * (1fr,),
-  align: (x, y) => if x == 0 or y == 0 {
-    left
-  } else {
-    center
-  },
+  align: (x, y) => if x == 0 or y == 0 { left } else { center },
   stroke: (
     x,
     y,
@@ -27,9 +24,7 @@ input_file: tests/assets/unit/grid/colspan.typ
     left: if y == 0 and x > 0 { white } else { black },
     rest: black,
   ),
-  fill: (_, y) => if y == 0 {
-    black
-  },
+  fill: (_, y) => if y == 0 { black },
 
   table.header(
     [Team member],
@@ -56,9 +51,7 @@ input_file: tests/assets/unit/grid/colspan.typ
   columns: 4 * (1fr,),
 
   [a], [b], [c], [d],
-  fill: (_, y) => if y == 0 {
-    black
-  },
+  fill: (_, y) => if y == 0 { black },
   table.cell(rowspan: 2)[aa], table.cell(colspan: 2)[bc], [d],
   [b], table.cell(colspan: 2)[cd],
 )

--- a/tests/snapshots/assets__check_file@unit-grid-colspan.typ-40.snap
+++ b/tests/snapshots/assets__check_file@unit-grid-colspan.typ-40.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/unit/grid/colspan.typ
+snapshot_kind: text
 ---
 #let ofi = [Office]
 #let rem = [_Remote_]
@@ -16,9 +17,7 @@ input_file: tests/assets/unit/grid/colspan.typ
   columns: 6 * (1fr,),
   align: (x, y) => if x == 0 or y == 0 {
     left
-  } else {
-    center
-  },
+  } else { center },
   stroke: (
     x,
     y,
@@ -27,9 +26,7 @@ input_file: tests/assets/unit/grid/colspan.typ
     left: if y == 0 and x > 0 { white } else { black },
     rest: black,
   ),
-  fill: (_, y) => if y == 0 {
-    black
-  },
+  fill: (_, y) => if y == 0 { black },
 
   table.header(
     [Team member],
@@ -56,9 +53,7 @@ input_file: tests/assets/unit/grid/colspan.typ
   columns: 4 * (1fr,),
 
   [a], [b], [c], [d],
-  fill: (_, y) => if y == 0 {
-    black
-  },
+  fill: (_, y) => if y == 0 { black },
   table.cell(rowspan: 2)[aa], table.cell(colspan: 2)[bc], [d],
   [b], table.cell(colspan: 2)[cd],
 )

--- a/tests/snapshots/assets__check_file@unit-grid-colspan.typ-80.snap
+++ b/tests/snapshots/assets__check_file@unit-grid-colspan.typ-80.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/unit/grid/colspan.typ
+snapshot_kind: text
 ---
 #let ofi = [Office]
 #let rem = [_Remote_]
@@ -14,11 +15,7 @@ input_file: tests/assets/unit/grid/colspan.typ
 
 #table(
   columns: 6 * (1fr,),
-  align: (x, y) => if x == 0 or y == 0 {
-    left
-  } else {
-    center
-  },
+  align: (x, y) => if x == 0 or y == 0 { left } else { center },
   stroke: (
     x,
     y,
@@ -27,9 +24,7 @@ input_file: tests/assets/unit/grid/colspan.typ
     left: if y == 0 and x > 0 { white } else { black },
     rest: black,
   ),
-  fill: (_, y) => if y == 0 {
-    black
-  },
+  fill: (_, y) => if y == 0 { black },
 
   table.header(
     [Team member],
@@ -56,9 +51,7 @@ input_file: tests/assets/unit/grid/colspan.typ
   columns: 4 * (1fr,),
 
   [a], [b], [c], [d],
-  fill: (_, y) => if y == 0 {
-    black
-  },
+  fill: (_, y) => if y == 0 { black },
   table.cell(rowspan: 2)[aa], table.cell(colspan: 2)[bc], [d],
   [b], table.cell(colspan: 2)[cd],
 )

--- a/tests/snapshots/assets__check_file@unit-show-code-show-closure.typ-120.snap
+++ b/tests/snapshots/assets__check_file@unit-show-code-show-closure.typ-120.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/unit/show/code-show-closure.typ
+snapshot_kind: text
 ---
 #let project(
   title: "",
@@ -9,9 +10,7 @@ input_file: tests/assets/unit/show/code-show-closure.typ
   show heading: it => box(width: 100%)[
     #v(0.50em)
     #set text(font: heading-font)
-    #if it.numbering != none {
-      counter(heading).display()
-    }
+    #if it.numbering != none { counter(heading).display() }
     #h(0.75em)
     #it.body
   ]

--- a/tests/snapshots/assets__check_file@unit-show-code-show-closure.typ-80.snap
+++ b/tests/snapshots/assets__check_file@unit-show-code-show-closure.typ-80.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/unit/show/code-show-closure.typ
+snapshot_kind: text
 ---
 #let project(
   title: "",
@@ -9,9 +10,7 @@ input_file: tests/assets/unit/show/code-show-closure.typ
   show heading: it => box(width: 100%)[
     #v(0.50em)
     #set text(font: heading-font)
-    #if it.numbering != none {
-      counter(heading).display()
-    }
+    #if it.numbering != none { counter(heading).display() }
     #h(0.75em)
     #it.body
   ]


### PR DESCRIPTION
A similar solution to #77, but simple and more acceptable for now.
The core changes are just in `convert_code_block`, together with some relevant improvements.
**Only when the code block contains only one item (without comments), and it does not follow a linebreak, we will try to put it into a single line.**

This is a context-insensitive method. We just see whether the code block contains a new line to decide whether it can be put in a single line. So, inline or not is controlled by the writer itself, and we have little control over it, except that we are really unable to squeeze them into the same line.

This respects the original structure and has some compatibility. If we enlarge the column width, it will not put any code blocks into a single line.
Unfortunately, when the source is formatted with a shorter column width, it can bring awkward results, such as
```typst
#if a < b {
  something-long-enough
} else { return }
```
But we can still manually check it, and break the block into multiple lines, which will not be formatted back.

To handle such cases, I think we can require that if the whole if-statement cannot be put into a single line (including conditions), all then-else blocks should be put into multiple lines. This requires some work about scopes.

IMO, this solution can serve as a transitional scheme until we reach an ideal one, and may make the current formatting results more acceptable to a large extent.