### PR TITLE
feat: strip excessive empty lines in code blocks

### DIFF
--- a/src/pretty/config.rs
+++ b/src/pretty/config.rs
@@ -1,0 +1,14 @@
+/// Configuration Options for Typstyle Printer.
+#[derive(Debug)]
+pub struct PrinterConfig {
+    /// Maximum number of blank lines which can be put between items.
+    pub blank_lines_upper_bound: usize,
+}
+
+impl Default for PrinterConfig {
+    fn default() -> Self {
+        Self {
+            blank_lines_upper_bound: 2,
+        }
+    }
+}

--- a/tests/snapshots/assets__check_file@packages-fletcher-diagram.typ-0.snap
+++ b/tests/snapshots/assets__check_file@packages-fletcher-diagram.typ-0.snap
@@ -516,7 +516,6 @@ snapshot_kind: text
         .class == "node" {
         let node = obj.value
         nodes.push(node)
-
       } else if obj
         .value
         .class == "edge" {
@@ -524,12 +523,10 @@ snapshot_kind: text
         edge.node-index = nodes.len()
         edges.push(edge)
       }
-
     } else if obj.func() == math.equation {
       let result = extract-nodes-and-edges-from-equation(obj)
       nodes += result.nodes
       edges += result.edges
-
     } else {
       panic(
         "Unrecognised value passed to diagram:",
@@ -542,7 +539,6 @@ snapshot_kind: text
     nodes: nodes,
     edges: edges,
   )
-
 }
 
 
@@ -735,7 +731,6 @@ snapshot_kind: text
     )
   },
 ) = {
-
   let spacing = as-pair(spacing).map(as-length)
   let cell-size = as-pair(cell-size).map(as-length)
 

--- a/tests/snapshots/assets__check_file@packages-fletcher-diagram.typ-120.snap
+++ b/tests/snapshots/assets__check_file@packages-fletcher-diagram.typ-120.snap
@@ -263,18 +263,15 @@ snapshot_kind: text
       if obj.value.class == "node" {
         let node = obj.value
         nodes.push(node)
-
       } else if obj.value.class == "edge" {
         let edge = obj.value
         edge.node-index = nodes.len()
         edges.push(edge)
       }
-
     } else if obj.func() == math.equation {
       let result = extract-nodes-and-edges-from-equation(obj)
       nodes += result.nodes
       edges += result.edges
-
     } else {
       panic("Unrecognised value passed to diagram:", obj)
     }
@@ -284,7 +281,6 @@ snapshot_kind: text
     nodes: nodes,
     edges: edges,
   )
-
 }
 
 
@@ -462,7 +458,6 @@ snapshot_kind: text
     cetz.canvas(draw-diagram(grid, nodes, edges, debug: options.debug))
   },
 ) = {
-
   let spacing = as-pair(spacing).map(as-length)
   let cell-size = as-pair(cell-size).map(as-length)
 

--- a/tests/snapshots/assets__check_file@packages-fletcher-diagram.typ-40.snap
+++ b/tests/snapshots/assets__check_file@packages-fletcher-diagram.typ-40.snap
@@ -366,7 +366,6 @@ snapshot_kind: text
       if obj.value.class == "node" {
         let node = obj.value
         nodes.push(node)
-
       } else if obj
         .value
         .class == "edge" {
@@ -374,12 +373,10 @@ snapshot_kind: text
         edge.node-index = nodes.len()
         edges.push(edge)
       }
-
     } else if obj.func() == math.equation {
       let result = extract-nodes-and-edges-from-equation(obj)
       nodes += result.nodes
       edges += result.edges
-
     } else {
       panic(
         "Unrecognised value passed to diagram:",
@@ -392,7 +389,6 @@ snapshot_kind: text
     nodes: nodes,
     edges: edges,
   )
-
 }
 
 
@@ -582,7 +578,6 @@ snapshot_kind: text
     )
   },
 ) = {
-
   let spacing = as-pair(spacing).map(as-length)
   let cell-size = as-pair(cell-size).map(as-length)
 

--- a/tests/snapshots/assets__check_file@packages-fletcher-diagram.typ-80.snap
+++ b/tests/snapshots/assets__check_file@packages-fletcher-diagram.typ-80.snap
@@ -279,18 +279,15 @@ snapshot_kind: text
       if obj.value.class == "node" {
         let node = obj.value
         nodes.push(node)
-
       } else if obj.value.class == "edge" {
         let edge = obj.value
         edge.node-index = nodes.len()
         edges.push(edge)
       }
-
     } else if obj.func() == math.equation {
       let result = extract-nodes-and-edges-from-equation(obj)
       nodes += result.nodes
       edges += result.edges
-
     } else {
       panic("Unrecognised value passed to diagram:", obj)
     }
@@ -300,7 +297,6 @@ snapshot_kind: text
     nodes: nodes,
     edges: edges,
   )
-
 }
 
 
@@ -478,7 +474,6 @@ snapshot_kind: text
     cetz.canvas(draw-diagram(grid, nodes, edges, debug: options.debug))
   },
 ) = {
-
   let spacing = as-pair(spacing).map(as-length)
   let cell-size = as-pair(cell-size).map(as-length)
 

--- a/tests/snapshots/assets__check_file@packages-fletcher-draw.typ-0.snap
+++ b/tests/snapshots/assets__check_file@packages-fletcher-draw.typ-0.snap
@@ -27,10 +27,8 @@ snapshot_kind: text
   node,
   debug: 0,
 ) = {
-
   let result = {
     if node.stroke != none or node.fill != none {
-
       cetz
         .draw
         .group({
@@ -64,7 +62,6 @@ snapshot_kind: text
     }
 
     if node.label != none {
-
       cetz
         .draw
         .content(
@@ -171,7 +168,6 @@ snapshot_kind: text
   curve,
   debug: 0,
 ) = {
-
   let curve-point = curve(edge.label-pos)
   let curve-point-ε = curve(edge.label-pos + 1e-3)
 
@@ -196,7 +192,6 @@ snapshot_kind: text
     ).at(
       repr(edge.label-angle),
     )
-
   } else if edge.label-angle == auto {
     edge.label-angle = θ
     if calc.abs(edge.label-angle) > 90deg {
@@ -370,7 +365,6 @@ snapshot_kind: text
   for shift in (
     edge.extrude
   ) {
-
     let offsets = cap-offsets(
       edge,
       shift,
@@ -439,7 +433,6 @@ snapshot_kind: text
 
   // Draw label
   if edge.label != none {
-
     // Choose label anchor based on edge direction,
     // preferring to place labels above the edge
     if edge.label-side == auto {
@@ -456,7 +449,6 @@ snapshot_kind: text
       debug: debug,
     )
   }
-
 }
 
 
@@ -503,7 +495,6 @@ snapshot_kind: text
   for shift in (
     edge.extrude
   ) {
-
     // Adjust arc angles to accommodate for cap offsets
     let (
       δ-start,
@@ -556,7 +547,6 @@ snapshot_kind: text
 
   // Draw label
   if edge.label != none {
-
     if edge.label-side == auto {
       // Choose label side to be on outside of arc
       edge.label-side = if edge.bend > 0deg {
@@ -571,7 +561,6 @@ snapshot_kind: text
       curve,
       debug: debug,
     )
-
   }
 }
 
@@ -593,7 +582,6 @@ snapshot_kind: text
   edge,
   debug: 0,
 ) = {
-
   let verts = edge.final-vertices
   let n-segments = verts.len() - 1
 
@@ -655,7 +643,6 @@ snapshot_kind: text
 				line-shift: 0*radius, // distance from vertex to beginning of arc
 			)
     } else {
-
       // distance from vertex to center of curvature
       let dist = radius / calc.cos(Δθ / 2)
 
@@ -667,7 +654,6 @@ snapshot_kind: text
 				line-shift: radius*calc.tan(Δθ/2), // distance from vertex to beginning of arc
 			)
     }
-
   }
 
   let rounded-corners
@@ -724,7 +710,6 @@ snapshot_kind: text
     let Δphase = 0pt
 
     if edge.corner-radius == none {
-
       // add phantom marks to ensure segment joins are clean
       if i > 0 {
         let Δθ = θs.at(i) - θs.at(i - 1)
@@ -751,7 +736,6 @@ snapshot_kind: text
           to,
         ),
       )
-
     } else {
       // rounded corners
 
@@ -768,7 +752,6 @@ snapshot_kind: text
       }
 
       if i < θs.len() - 1 {
-
         let (
           arc-center,
           arc-radius,
@@ -820,7 +803,6 @@ snapshot_kind: text
                 stroke: debug-stroke,
               ),
             )
-
           }
         }
 
@@ -874,7 +856,6 @@ snapshot_kind: text
     )
 
     phase += Δphase
-
   }
 
 
@@ -904,7 +885,6 @@ snapshot_kind: text
   target,
   callback,
 ) = {
-
   if objects == none {
     return callback(target)
   }
@@ -924,7 +904,6 @@ snapshot_kind: text
   cetz
     .draw
     .get-ctx(ctx => {
-
     let calculate-anchors = ctx
       .nodes
       .at(node-name)
@@ -955,9 +934,7 @@ snapshot_kind: text
     )
 
     callback(anchor)
-
   })
-
 }
 
 #let find-anchor-pair(
@@ -987,7 +964,6 @@ snapshot_kind: text
       )
     },
   )
-
 }
 
 /// Get the anchor point around a node outline at a certain angle.
@@ -1073,7 +1049,6 @@ snapshot_kind: text
       ),
     ) * calc.sin(θ),
   )
-
 }
 
 
@@ -1117,7 +1092,6 @@ snapshot_kind: text
         θ + 90deg,
       ),
     )
-
   }
 
 
@@ -1171,7 +1145,6 @@ snapshot_kind: text
       )(obj) // post-process (e.g., hide)
     },
   )
-
 }
 
 
@@ -1349,7 +1322,6 @@ snapshot_kind: text
       )(obj) // post-process (e.g., hide)
     },
   )
-
 }
 
 
@@ -1409,7 +1381,6 @@ snapshot_kind: text
   grid,
   debug: false,
 ) = {
-
   let (
     x-lims,
     y-lims,
@@ -1671,7 +1642,6 @@ snapshot_kind: text
         anchor: "north-east",
       )
     }
-
   })
 }
 
@@ -1694,7 +1664,6 @@ snapshot_kind: text
   }
 
   if type(key) == array and key.len() == 2 {
-
     let xy-pos = key
     let candidates = nodes.filter(node => {
       if node.snap == false {
@@ -1727,7 +1696,6 @@ snapshot_kind: text
     }
 
     return candidates
-
   }
 
   error(
@@ -1804,7 +1772,6 @@ snapshot_kind: text
       debug: debug >= 2,
     )
   }
-
 }
 
 /// Make diagram contents invisible, with or without affecting layout. Works by

--- a/tests/snapshots/assets__check_file@packages-fletcher-draw.typ-120.snap
+++ b/tests/snapshots/assets__check_file@packages-fletcher-draw.typ-120.snap
@@ -22,10 +22,8 @@ snapshot_kind: text
 
 
 #let draw-node(node, debug: 0) = {
-
   let result = {
     if node.stroke != none or node.fill != none {
-
       cetz.draw.group({
         cetz.draw.translate(node.pos.xyz)
         for (i, extrude) in node.extrude.enumerate() {
@@ -39,7 +37,6 @@ snapshot_kind: text
     }
 
     if node.label != none {
-
       cetz.draw.content(
         node.pos.xyz,
         box(
@@ -105,7 +102,6 @@ snapshot_kind: text
 /// - curve (function): Parametric curve $RR -> RR^2$ describing the shape of
 ///   the edge in $x y$ coordinates.
 #let place-edge-label-on-curve(edge, curve, debug: 0) = {
-
   let curve-point = curve(edge.label-pos)
   let curve-point-ε = curve(edge.label-pos + 1e-3)
 
@@ -119,7 +115,6 @@ snapshot_kind: text
       left: 180deg,
       bottom: 270deg,
     ).at(repr(edge.label-angle))
-
   } else if edge.label-angle == auto {
     edge.label-angle = θ
     if calc.abs(edge.label-angle) > 90deg {
@@ -215,7 +210,6 @@ snapshot_kind: text
 
   // Draw line(s), one for each extrusion shift
   for shift in edge.extrude {
-
     let offsets = cap-offsets(edge, shift)
     let points = (from, to).zip(offsets).map(((point, offset)) => {
       // Shift line sideways (for multi-stroke effect)
@@ -241,7 +235,6 @@ snapshot_kind: text
 
   // Draw label
   if edge.label != none {
-
     // Choose label anchor based on edge direction,
     // preferring to place labels above the edge
     if edge.label-side == auto {
@@ -250,7 +243,6 @@ snapshot_kind: text
 
     place-edge-label-on-curve(edge, curve, debug: debug)
   }
-
 }
 
 
@@ -276,7 +268,6 @@ snapshot_kind: text
 
   // Draw arc(s), one for each extrusion shift
   for shift in edge.extrude {
-
     // Adjust arc angles to accommodate for cap offsets
     let (δ-start, δ-stop) = cap-offsets(edge, shift).map(arclen => -bend-dir * arclen / radius * 1rad)
 
@@ -300,14 +291,12 @@ snapshot_kind: text
 
   // Draw label
   if edge.label != none {
-
     if edge.label-side == auto {
       // Choose label side to be on outside of arc
       edge.label-side = if edge.bend > 0deg { left } else { right }
     }
 
     place-edge-label-on-curve(edge, curve, debug: debug)
-
   }
 }
 
@@ -326,7 +315,6 @@ snapshot_kind: text
 ///   - `label-side`, `label-pos`, `label-sep`, and `label-anchor`.
 /// - debug (int): Level of debug details to draw.
 #let draw-edge-polyline(edge, debug: 0) = {
-
   let verts = edge.final-vertices
   let n-segments = verts.len() - 1
 
@@ -366,7 +354,6 @@ snapshot_kind: text
 				line-shift: 0*radius, // distance from vertex to beginning of arc
 			)
     } else {
-
       // distance from vertex to center of curvature
       let dist = radius / calc.cos(Δθ / 2)
 
@@ -378,7 +365,6 @@ snapshot_kind: text
 				line-shift: radius*calc.tan(Δθ/2), // distance from vertex to beginning of arc
 			)
     }
-
   }
 
   let rounded-corners
@@ -412,7 +398,6 @@ snapshot_kind: text
     let Δphase = 0pt
 
     if edge.corner-radius == none {
-
       // add phantom marks to ensure segment joins are clean
       if i > 0 {
         let Δθ = θs.at(i) - θs.at(i - 1)
@@ -434,7 +419,6 @@ snapshot_kind: text
       }
 
       Δphase += vector-len(vector.sub(from, to))
-
     } else {
       // rounded corners
 
@@ -445,7 +429,6 @@ snapshot_kind: text
       }
 
       if i < θs.len() - 1 {
-
         let (arc-center, arc-radius, start, delta, line-shift) = rounded-corners.at(i)
         to = vector.add(to, vector-polar(-line-shift, θs.at(i)))
 
@@ -472,7 +455,6 @@ snapshot_kind: text
                 stroke: debug-stroke,
               ),
             )
-
           }
         }
 
@@ -506,7 +488,6 @@ snapshot_kind: text
     )
 
     phase += Δphase
-
   }
 
 
@@ -530,14 +511,12 @@ snapshot_kind: text
 /// - target (point): Target point to sort intersections by proximity with, and
 ///  to use as a fallback if no intersections are found.
 #let find-farthest-intersection(objects, target, callback) = {
-
   if objects == none { return callback(target) }
 
   let node-name = "intersection-finder"
   cetz.draw.hide(cetz.draw.intersections(node-name, objects))
 
   cetz.draw.get-ctx(ctx => {
-
     let calculate-anchors = ctx.nodes.at(node-name).anchors
     let anchor-names = calculate-anchors(())
     let anchor-points = anchor-names
@@ -552,9 +531,7 @@ snapshot_kind: text
     let anchor = anchor-points.at(-1, default: target)
 
     callback(anchor)
-
   })
-
 }
 
 #let find-anchor-pair((from-group, to-group), (from-point, to-point), callback) = {
@@ -571,7 +548,6 @@ snapshot_kind: text
       )
     },
   )
-
 }
 
 /// Get the anchor point around a node outline at a certain angle.
@@ -602,7 +578,6 @@ snapshot_kind: text
     calc.max(0pt, node.size.at(0) / 2 * (1 - 1 / μ)) * calc.cos(θ),
     calc.max(0pt, node.size.at(1) / 2 * (1 - μ / 1)) * calc.sin(θ),
   )
-
 }
 
 
@@ -616,7 +591,6 @@ snapshot_kind: text
   }
   if nodes.at(1).len() == 1 {
     to = vector.add(to, defocus-adjustment(nodes.at(1).at(0), θ + 90deg))
-
   }
 
 
@@ -650,7 +624,6 @@ snapshot_kind: text
       (edge.post)(obj) // post-process (e.g., hide)
     },
   )
-
 }
 
 
@@ -722,7 +695,6 @@ snapshot_kind: text
       (edge.post)(obj) // post-process (e.g., hide)
     },
   )
-
 }
 
 
@@ -751,7 +723,6 @@ snapshot_kind: text
 ///   - `cell-sizes: (x-sizes, y-sizes)`, the physical sizes of each row and
 ///     each column.
 #let draw-debug-axes(grid, debug: false) = {
-
   let (x-lims, y-lims) = range(2).map(axis => (
     grid.centers.at(axis).at(0) - grid.cell-sizes.at(axis).at(0) / 2,
     grid.centers.at(axis).at(-1) + grid.cell-sizes.at(axis).at(-1) / 2,
@@ -822,7 +793,6 @@ snapshot_kind: text
         anchor: "north-east",
       )
     }
-
   })
 }
 
@@ -837,7 +807,6 @@ snapshot_kind: text
   }
 
   if type(key) == array and key.len() == 2 {
-
     let xy-pos = key
     let candidates = nodes.filter(node => {
       if node.snap == false { return false }
@@ -860,7 +829,6 @@ snapshot_kind: text
     }
 
     return candidates
-
   }
 
   error("Couldn't find node corresponding to #0 in diagram.", key)
@@ -894,7 +862,6 @@ snapshot_kind: text
   if debug >= 1 {
     draw-debug-axes(grid, debug: debug >= 2)
   }
-
 }
 
 /// Make diagram contents invisible, with or without affecting layout. Works by

--- a/tests/snapshots/assets__check_file@packages-fletcher-draw.typ-40.snap
+++ b/tests/snapshots/assets__check_file@packages-fletcher-draw.typ-40.snap
@@ -22,10 +22,8 @@ snapshot_kind: text
 
 
 #let draw-node(node, debug: 0) = {
-
   let result = {
     if node.stroke != none or node.fill != none {
-
       cetz.draw.group({
         cetz.draw.translate(node
           .pos
@@ -45,7 +43,6 @@ snapshot_kind: text
     }
 
     if node.label != none {
-
       cetz.draw.content(
         node.pos.xyz,
         box(
@@ -125,7 +122,6 @@ snapshot_kind: text
   curve,
   debug: 0,
 ) = {
-
   let curve-point = curve(edge.label-pos)
   let curve-point-ε = curve(edge.label-pos + 1e-3)
 
@@ -146,7 +142,6 @@ snapshot_kind: text
       left: 180deg,
       bottom: 270deg,
     ).at(repr(edge.label-angle))
-
   } else if edge.label-angle == auto {
     edge.label-angle = θ
     if calc.abs(edge.label-angle) > 90deg {
@@ -267,7 +262,6 @@ snapshot_kind: text
 
   // Draw line(s), one for each extrusion shift
   for shift in edge.extrude {
-
     let offsets = cap-offsets(
       edge,
       shift,
@@ -313,7 +307,6 @@ snapshot_kind: text
 
   // Draw label
   if edge.label != none {
-
     // Choose label anchor based on edge direction,
     // preferring to place labels above the edge
     if edge.label-side == auto {
@@ -328,7 +321,6 @@ snapshot_kind: text
       debug: debug,
     )
   }
-
 }
 
 
@@ -365,7 +357,6 @@ snapshot_kind: text
 
   // Draw arc(s), one for each extrusion shift
   for shift in edge.extrude {
-
     // Adjust arc angles to accommodate for cap offsets
     let (
       δ-start,
@@ -405,7 +396,6 @@ snapshot_kind: text
 
   // Draw label
   if edge.label != none {
-
     if edge.label-side == auto {
       // Choose label side to be on outside of arc
       edge.label-side = if edge.bend > 0deg {
@@ -418,7 +408,6 @@ snapshot_kind: text
       curve,
       debug: debug,
     )
-
   }
 }
 
@@ -440,7 +429,6 @@ snapshot_kind: text
   edge,
   debug: 0,
 ) = {
-
   let verts = edge.final-vertices
   let n-segments = verts.len() - 1
 
@@ -492,7 +480,6 @@ snapshot_kind: text
 				line-shift: 0*radius, // distance from vertex to beginning of arc
 			)
     } else {
-
       // distance from vertex to center of curvature
       let dist = radius / calc.cos(Δθ / 2)
 
@@ -504,7 +491,6 @@ snapshot_kind: text
 				line-shift: radius*calc.tan(Δθ/2), // distance from vertex to beginning of arc
 			)
     }
-
   }
 
   let rounded-corners
@@ -550,7 +536,6 @@ snapshot_kind: text
     let Δphase = 0pt
 
     if edge.corner-radius == none {
-
       // add phantom marks to ensure segment joins are clean
       if i > 0 {
         let Δθ = θs.at(i) - θs.at(i - 1)
@@ -574,7 +559,6 @@ snapshot_kind: text
       Δphase += vector-len(
         vector.sub(from, to),
       )
-
     } else {
       // rounded corners
 
@@ -591,7 +575,6 @@ snapshot_kind: text
       }
 
       if i < θs.len() - 1 {
-
         let (
           arc-center,
           arc-radius,
@@ -632,7 +615,6 @@ snapshot_kind: text
                 stroke: debug-stroke,
               ),
             )
-
           }
         }
 
@@ -679,7 +661,6 @@ snapshot_kind: text
     )
 
     phase += Δphase
-
   }
 
 
@@ -707,7 +688,6 @@ snapshot_kind: text
   target,
   callback,
 ) = {
-
   if objects == none {
     return callback(target)
   }
@@ -721,7 +701,6 @@ snapshot_kind: text
   )
 
   cetz.draw.get-ctx(ctx => {
-
     let calculate-anchors = ctx
       .nodes
       .at(node-name)
@@ -746,9 +725,7 @@ snapshot_kind: text
     )
 
     callback(anchor)
-
   })
-
 }
 
 #let find-anchor-pair(
@@ -772,7 +749,6 @@ snapshot_kind: text
       )
     },
   )
-
 }
 
 /// Get the anchor point around a node outline at a certain angle.
@@ -820,7 +796,6 @@ snapshot_kind: text
       node.size.at(1) / 2 * (1 - μ / 1),
     ) * calc.sin(θ),
   )
-
 }
 
 
@@ -853,7 +828,6 @@ snapshot_kind: text
         θ + 90deg,
       ),
     )
-
   }
 
 
@@ -891,7 +865,6 @@ snapshot_kind: text
       )(obj) // post-process (e.g., hide)
     },
   )
-
 }
 
 
@@ -1008,7 +981,6 @@ snapshot_kind: text
       )(obj) // post-process (e.g., hide)
     },
   )
-
 }
 
 
@@ -1062,7 +1034,6 @@ snapshot_kind: text
   grid,
   debug: false,
 ) = {
-
   let (
     x-lims,
     y-lims,
@@ -1242,7 +1213,6 @@ snapshot_kind: text
         anchor: "north-east",
       )
     }
-
   })
 }
 
@@ -1263,7 +1233,6 @@ snapshot_kind: text
   }
 
   if type(key) == array and key.len() == 2 {
-
     let xy-pos = key
     let candidates = nodes.filter(node => {
       if node.snap == false {
@@ -1294,7 +1263,6 @@ snapshot_kind: text
     }
 
     return candidates
-
   }
 
   error(
@@ -1351,7 +1319,6 @@ snapshot_kind: text
       debug: debug >= 2,
     )
   }
-
 }
 
 /// Make diagram contents invisible, with or without affecting layout. Works by

--- a/tests/snapshots/assets__check_file@packages-fletcher-draw.typ-80.snap
+++ b/tests/snapshots/assets__check_file@packages-fletcher-draw.typ-80.snap
@@ -22,10 +22,8 @@ snapshot_kind: text
 
 
 #let draw-node(node, debug: 0) = {
-
   let result = {
     if node.stroke != none or node.fill != none {
-
       cetz.draw.group({
         cetz.draw.translate(node.pos.xyz)
         for (i, extrude) in node.extrude.enumerate() {
@@ -39,7 +37,6 @@ snapshot_kind: text
     }
 
     if node.label != none {
-
       cetz.draw.content(
         node.pos.xyz,
         box(
@@ -105,7 +102,6 @@ snapshot_kind: text
 /// - curve (function): Parametric curve $RR -> RR^2$ describing the shape of
 ///   the edge in $x y$ coordinates.
 #let place-edge-label-on-curve(edge, curve, debug: 0) = {
-
   let curve-point = curve(edge.label-pos)
   let curve-point-ε = curve(edge.label-pos + 1e-3)
 
@@ -119,7 +115,6 @@ snapshot_kind: text
       left: 180deg,
       bottom: 270deg,
     ).at(repr(edge.label-angle))
-
   } else if edge.label-angle == auto {
     edge.label-angle = θ
     if calc.abs(edge.label-angle) > 90deg {
@@ -217,7 +212,6 @@ snapshot_kind: text
 
   // Draw line(s), one for each extrusion shift
   for shift in edge.extrude {
-
     let offsets = cap-offsets(edge, shift)
     let points = (from, to).zip(offsets).map(((point, offset)) => {
       // Shift line sideways (for multi-stroke effect)
@@ -243,7 +237,6 @@ snapshot_kind: text
 
   // Draw label
   if edge.label != none {
-
     // Choose label anchor based on edge direction,
     // preferring to place labels above the edge
     if edge.label-side == auto {
@@ -252,7 +245,6 @@ snapshot_kind: text
 
     place-edge-label-on-curve(edge, curve, debug: debug)
   }
-
 }
 
 
@@ -282,7 +274,6 @@ snapshot_kind: text
 
   // Draw arc(s), one for each extrusion shift
   for shift in edge.extrude {
-
     // Adjust arc angles to accommodate for cap offsets
     let (δ-start, δ-stop) = cap-offsets(edge, shift).map(arclen => (
       -bend-dir * arclen / radius * 1rad
@@ -308,14 +299,12 @@ snapshot_kind: text
 
   // Draw label
   if edge.label != none {
-
     if edge.label-side == auto {
       // Choose label side to be on outside of arc
       edge.label-side = if edge.bend > 0deg { left } else { right }
     }
 
     place-edge-label-on-curve(edge, curve, debug: debug)
-
   }
 }
 
@@ -334,7 +323,6 @@ snapshot_kind: text
 ///   - `label-side`, `label-pos`, `label-sep`, and `label-anchor`.
 /// - debug (int): Level of debug details to draw.
 #let draw-edge-polyline(edge, debug: 0) = {
-
   let verts = edge.final-vertices
   let n-segments = verts.len() - 1
 
@@ -376,7 +364,6 @@ snapshot_kind: text
 				line-shift: 0*radius, // distance from vertex to beginning of arc
 			)
     } else {
-
       // distance from vertex to center of curvature
       let dist = radius / calc.cos(Δθ / 2)
 
@@ -388,7 +375,6 @@ snapshot_kind: text
 				line-shift: radius*calc.tan(Δθ/2), // distance from vertex to beginning of arc
 			)
     }
-
   }
 
   let rounded-corners
@@ -424,7 +410,6 @@ snapshot_kind: text
     let Δphase = 0pt
 
     if edge.corner-radius == none {
-
       // add phantom marks to ensure segment joins are clean
       if i > 0 {
         let Δθ = θs.at(i) - θs.at(i - 1)
@@ -446,7 +431,6 @@ snapshot_kind: text
       }
 
       Δphase += vector-len(vector.sub(from, to))
-
     } else {
       // rounded corners
 
@@ -457,7 +441,6 @@ snapshot_kind: text
       }
 
       if i < θs.len() - 1 {
-
         let (
           arc-center,
           arc-radius,
@@ -490,7 +473,6 @@ snapshot_kind: text
                 stroke: debug-stroke,
               ),
             )
-
           }
         }
 
@@ -526,7 +508,6 @@ snapshot_kind: text
     )
 
     phase += Δphase
-
   }
 
 
@@ -550,14 +531,12 @@ snapshot_kind: text
 /// - target (point): Target point to sort intersections by proximity with, and
 ///  to use as a fallback if no intersections are found.
 #let find-farthest-intersection(objects, target, callback) = {
-
   if objects == none { return callback(target) }
 
   let node-name = "intersection-finder"
   cetz.draw.hide(cetz.draw.intersections(node-name, objects))
 
   cetz.draw.get-ctx(ctx => {
-
     let calculate-anchors = ctx.nodes.at(node-name).anchors
     let anchor-names = calculate-anchors(())
     let anchor-points = anchor-names
@@ -572,9 +551,7 @@ snapshot_kind: text
     let anchor = anchor-points.at(-1, default: target)
 
     callback(anchor)
-
   })
-
 }
 
 #let find-anchor-pair(
@@ -595,7 +572,6 @@ snapshot_kind: text
       )
     },
   )
-
 }
 
 /// Get the anchor point around a node outline at a certain angle.
@@ -626,7 +602,6 @@ snapshot_kind: text
     calc.max(0pt, node.size.at(0) / 2 * (1 - 1 / μ)) * calc.cos(θ),
     calc.max(0pt, node.size.at(1) / 2 * (1 - μ / 1)) * calc.sin(θ),
   )
-
 }
 
 
@@ -640,7 +615,6 @@ snapshot_kind: text
   }
   if nodes.at(1).len() == 1 {
     to = vector.add(to, defocus-adjustment(nodes.at(1).at(0), θ + 90deg))
-
   }
 
 
@@ -674,7 +648,6 @@ snapshot_kind: text
       (edge.post)(obj) // post-process (e.g., hide)
     },
   )
-
 }
 
 
@@ -753,7 +726,6 @@ snapshot_kind: text
       (edge.post)(obj) // post-process (e.g., hide)
     },
   )
-
 }
 
 
@@ -782,7 +754,6 @@ snapshot_kind: text
 ///   - `cell-sizes: (x-sizes, y-sizes)`, the physical sizes of each row and
 ///     each column.
 #let draw-debug-axes(grid, debug: false) = {
-
   let (x-lims, y-lims) = range(2).map(axis => (
     grid.centers.at(axis).at(0) - grid.cell-sizes.at(axis).at(0) / 2,
     grid.centers.at(axis).at(-1) + grid.cell-sizes.at(axis).at(-1) / 2,
@@ -861,7 +832,6 @@ snapshot_kind: text
         anchor: "north-east",
       )
     }
-
   })
 }
 
@@ -876,7 +846,6 @@ snapshot_kind: text
   }
 
   if type(key) == array and key.len() == 2 {
-
     let xy-pos = key
     let candidates = nodes.filter(node => {
       if node.snap == false { return false }
@@ -899,7 +868,6 @@ snapshot_kind: text
     }
 
     return candidates
-
   }
 
   error("Couldn't find node corresponding to #0 in diagram.", key)
@@ -935,7 +903,6 @@ snapshot_kind: text
   if debug >= 1 {
     draw-debug-axes(grid, debug: debug >= 2)
   }
-
 }
 
 /// Make diagram contents invisible, with or without affecting layout. Works by

--- a/tests/snapshots/assets__check_file@packages-tidy-new-parser.typ-0.snap
+++ b/tests/snapshots/assets__check_file@packages-tidy-new-parser.typ-0.snap
@@ -214,7 +214,6 @@ snapshot_kind: text
   label-prefix: "",
   first-line-number: 0,
 ) = {
-
   let description = lines
     .enumerate(start: first-line-number)
     .map(eval-doc-comment-test.with(label-prefix: label-prefix))
@@ -589,7 +588,6 @@ snapshot_kind: text
         at: start,
       )
       if line.starts-with("let ") and name == none {
-
         found-code = true
         let match = line.match(definition-name-regex)
         if match != none {
@@ -611,7 +609,6 @@ snapshot_kind: text
             finished-definition = true
           }
         }
-
       } else {
         // neither /// nor (#)let
         if not found-code {
@@ -621,7 +618,6 @@ snapshot_kind: text
         if name == none {
           desc-lines = ()
         }
-
       }
     }
   }
@@ -638,8 +634,6 @@ snapshot_kind: text
   )
 }
 #{
-
-
   let src = ```
   ///Description
   let func(

--- a/tests/snapshots/assets__check_file@packages-tidy-new-parser.typ-120.snap
+++ b/tests/snapshots/assets__check_file@packages-tidy-new-parser.typ-120.snap
@@ -113,7 +113,6 @@ snapshot_kind: text
 
 
 #let parse-description-and-types(lines, label-prefix: "", first-line-number: 0) = {
-
   let description = lines
     .enumerate(start: first-line-number)
     .map(eval-doc-comment-test.with(label-prefix: label-prefix))
@@ -336,7 +335,6 @@ snapshot_kind: text
 
       line = line.trim("#", at: start)
       if line.starts-with("let ") and name == none {
-
         found-code = true
         let match = line.match(definition-name-regex)
         if match != none {
@@ -351,7 +349,6 @@ snapshot_kind: text
             finished-definition = true
           }
         }
-
       } else {
         // neither /// nor (#)let
         if not found-code {
@@ -361,7 +358,6 @@ snapshot_kind: text
         if name == none {
           desc-lines = ()
         }
-
       }
     }
   }
@@ -374,8 +370,6 @@ snapshot_kind: text
   )
 }
 #{
-
-
   let src = ```
   ///Description
   let func(

--- a/tests/snapshots/assets__check_file@packages-tidy-new-parser.typ-40.snap
+++ b/tests/snapshots/assets__check_file@packages-tidy-new-parser.typ-40.snap
@@ -156,7 +156,6 @@ snapshot_kind: text
   label-prefix: "",
   first-line-number: 0,
 ) = {
-
   let description = lines
     .enumerate(start: first-line-number)
     .map(eval-doc-comment-test.with(label-prefix: label-prefix))
@@ -480,7 +479,6 @@ snapshot_kind: text
 
       line = line.trim("#", at: start)
       if line.starts-with("let ") and name == none {
-
         found-code = true
         let match = line.match(definition-name-regex)
         if match != none {
@@ -500,7 +498,6 @@ snapshot_kind: text
             finished-definition = true
           }
         }
-
       } else {
         // neither /// nor (#)let
         if not found-code {
@@ -510,7 +507,6 @@ snapshot_kind: text
         if name == none {
           desc-lines = ()
         }
-
       }
     }
   }
@@ -527,8 +523,6 @@ snapshot_kind: text
   )
 }
 #{
-
-
   let src = ```
   ///Description
   let func(

--- a/tests/snapshots/assets__check_file@packages-tidy-new-parser.typ-80.snap
+++ b/tests/snapshots/assets__check_file@packages-tidy-new-parser.typ-80.snap
@@ -121,7 +121,6 @@ snapshot_kind: text
   label-prefix: "",
   first-line-number: 0,
 ) = {
-
   let description = lines
     .enumerate(start: first-line-number)
     .map(eval-doc-comment-test.with(label-prefix: label-prefix))
@@ -372,7 +371,6 @@ snapshot_kind: text
 
       line = line.trim("#", at: start)
       if line.starts-with("let ") and name == none {
-
         found-code = true
         let match = line.match(definition-name-regex)
         if match != none {
@@ -387,7 +385,6 @@ snapshot_kind: text
             finished-definition = true
           }
         }
-
       } else {
         // neither /// nor (#)let
         if not found-code {
@@ -397,7 +394,6 @@ snapshot_kind: text
         if name == none {
           desc-lines = ()
         }
-
       }
     }
   }
@@ -410,8 +406,6 @@ snapshot_kind: text
   )
 }
 #{
-
-
   let src = ```
   ///Description
   let func(

--- a/tests/snapshots/assets__check_file@tablex.typ-0.snap
+++ b/tests/snapshots/assets__check_file@tablex.typ-0.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/tablex.typ
+snapshot_kind: text
 ---
 // Welcome to tablex!
 // Feel free to contribute with any features you think are missing.
@@ -1725,7 +1726,6 @@ input_file: tests/assets/tablex.typ
   align_default: left,
   fill_default: none,
 ) = {
-
   let align_default = if type(align_default) == _function-type {
     align_default(
       cell.x,

--- a/tests/snapshots/assets__check_file@tablex.typ-120.snap
+++ b/tests/snapshots/assets__check_file@tablex.typ-120.snap
@@ -1119,7 +1119,6 @@ snapshot_kind: text
   align_default: left,
   fill_default: none,
 ) = {
-
   let align_default = if type(align_default) == _function-type {
     align_default(cell.x, cell.y) // column, row
   } else {

--- a/tests/snapshots/assets__check_file@tablex.typ-40.snap
+++ b/tests/snapshots/assets__check_file@tablex.typ-40.snap
@@ -1502,7 +1502,6 @@ snapshot_kind: text
   align_default: left,
   fill_default: none,
 ) = {
-
   let align_default = if type(align_default) == _function-type {
     align_default(
       cell.x,

--- a/tests/snapshots/assets__check_file@tablex.typ-80.snap
+++ b/tests/snapshots/assets__check_file@tablex.typ-80.snap
@@ -1183,7 +1183,6 @@ snapshot_kind: text
   align_default: left,
   fill_default: none,
 ) = {
-
   let align_default = if type(align_default) == _function-type {
     align_default(cell.x, cell.y) // column, row
   } else {

--- a/tests/snapshots/assets__check_file@unit-code-if-chain.typ-0.snap
+++ b/tests/snapshots/assets__check_file@unit-code-if-chain.typ-0.snap
@@ -74,7 +74,6 @@ snapshot_kind: text
     *strong*] else {
     none
   }
-
 }
 
 #if a < b {

--- a/tests/snapshots/assets__check_file@unit-code-if-chain.typ-120.snap
+++ b/tests/snapshots/assets__check_file@unit-code-if-chain.typ-120.snap
@@ -32,7 +32,6 @@ snapshot_kind: text
     true
   } else if c < d [ false ] else if 1 + 2 == 3 [
     *strong*] else { none }
-
 }
 
 #if a < b {

--- a/tests/snapshots/assets__check_file@unit-code-if-chain.typ-40.snap
+++ b/tests/snapshots/assets__check_file@unit-code-if-chain.typ-40.snap
@@ -48,7 +48,6 @@ snapshot_kind: text
     true
   } else if c < d [ false ] else if 1 + 2 == 3 [
     *strong*] else { none }
-
 }
 
 #if a < b {

--- a/tests/snapshots/assets__check_file@unit-code-if-chain.typ-80.snap
+++ b/tests/snapshots/assets__check_file@unit-code-if-chain.typ-80.snap
@@ -40,7 +40,6 @@ snapshot_kind: text
     true
   } else if c < d [ false ] else if 1 + 2 == 3 [
     *strong*] else { none }
-
 }
 
 #if a < b {

--- a/tests/snapshots/assets__check_file@unit-code-short-block-with-comment.typ-0.snap
+++ b/tests/snapshots/assets__check_file@unit-code-short-block-with-comment.typ-0.snap
@@ -10,14 +10,11 @@ snapshot_kind: text
 
 #let o = {
   // comments
-
 }
 
 
 #let o = {
-
   // comments
-
 }
 
 #let o = {
@@ -87,25 +84,21 @@ comments */
 
 #let o = {
   666 // comments
-
 }
 
 
 #let o = {
   666
   // comments
-
 }
 
 #let o = {
   666
 
   // comments
-
 }
 
 #let o = {
-
   // comments
   666
 }

--- a/tests/snapshots/assets__check_file@unit-code-short-block-with-comment.typ-120.snap
+++ b/tests/snapshots/assets__check_file@unit-code-short-block-with-comment.typ-120.snap
@@ -10,14 +10,11 @@ snapshot_kind: text
 
 #let o = {
   // comments
-
 }
 
 
 #let o = {
-
   // comments
-
 }
 
 #let o = {
@@ -85,25 +82,21 @@ comments */
 
 #let o = {
   666 // comments
-
 }
 
 
 #let o = {
   666
   // comments
-
 }
 
 #let o = {
   666
 
   // comments
-
 }
 
 #let o = {
-
   // comments
   666
 }

--- a/tests/snapshots/assets__check_file@unit-code-short-block-with-comment.typ-40.snap
+++ b/tests/snapshots/assets__check_file@unit-code-short-block-with-comment.typ-40.snap
@@ -10,14 +10,11 @@ snapshot_kind: text
 
 #let o = {
   // comments
-
 }
 
 
 #let o = {
-
   // comments
-
 }
 
 #let o = {
@@ -85,25 +82,21 @@ comments */
 
 #let o = {
   666 // comments
-
 }
 
 
 #let o = {
   666
   // comments
-
 }
 
 #let o = {
   666
 
   // comments
-
 }
 
 #let o = {
-
   // comments
   666
 }

--- a/tests/snapshots/assets__check_file@unit-code-short-block-with-comment.typ-80.snap
+++ b/tests/snapshots/assets__check_file@unit-code-short-block-with-comment.typ-80.snap
@@ -10,14 +10,11 @@ snapshot_kind: text
 
 #let o = {
   // comments
-
 }
 
 
 #let o = {
-
   // comments
-
 }
 
 #let o = {
@@ -85,25 +82,21 @@ comments */
 
 #let o = {
   666 // comments
-
 }
 
 
 #let o = {
   666
   // comments
-
 }
 
 #let o = {
   666
 
   // comments
-
 }
 
 #let o = {
-
   // comments
   666
 }

--- a/tests/snapshots/assets__check_file@unit-code-short-block.typ-0.snap
+++ b/tests/snapshots/assets__check_file@unit-code-short-block.typ-0.snap
@@ -8,22 +8,12 @@ snapshot_kind: text
 
 #let o = { }
 
-#let o = {
+#let o = { }
 
-}
-
-#let o = {
-
-
-
-
-}
+#let o = { }
 
 #let o = {
-
-
   true
-
 }
 
 #let b = {

--- a/tests/snapshots/assets__check_file@unit-code-short-block.typ-120.snap
+++ b/tests/snapshots/assets__check_file@unit-code-short-block.typ-120.snap
@@ -8,22 +8,12 @@ snapshot_kind: text
 
 #let o = { }
 
-#let o = {
+#let o = { }
 
-}
-
-#let o = {
-
-
-
-
-}
+#let o = { }
 
 #let o = {
-
-
   true
-
 }
 
 #let b = {

--- a/tests/snapshots/assets__check_file@unit-code-short-block.typ-40.snap
+++ b/tests/snapshots/assets__check_file@unit-code-short-block.typ-40.snap
@@ -8,22 +8,12 @@ snapshot_kind: text
 
 #let o = { }
 
-#let o = {
+#let o = { }
 
-}
-
-#let o = {
-
-
-
-
-}
+#let o = { }
 
 #let o = {
-
-
   true
-
 }
 
 #let b = {

--- a/tests/snapshots/assets__check_file@unit-code-short-block.typ-80.snap
+++ b/tests/snapshots/assets__check_file@unit-code-short-block.typ-80.snap
@@ -8,22 +8,12 @@ snapshot_kind: text
 
 #let o = { }
 
-#let o = {
+#let o = { }
 
-}
-
-#let o = {
-
-
-
-
-}
+#let o = { }
 
 #let o = {
-
-
   true
-
 }
 
 #let b = {

--- a/tests/snapshots/assets__check_file@unit-func-spread.typ-0.snap
+++ b/tests/snapshots/assets__check_file@unit-func-spread.typ-0.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/unit/func/spread.typ
+snapshot_kind: text
 ---
 #let tree(
   root,
@@ -13,9 +14,7 @@ input_file: tests/assets/unit/func/spread.typ
   spread: 1,
   name: none,
   ..style,
-) = {
-
-}
+) = { }
 
 #let f = (
   ..,

--- a/tests/snapshots/assets__check_file@unit-func-spread.typ-120.snap
+++ b/tests/snapshots/assets__check_file@unit-func-spread.typ-120.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/unit/func/spread.typ
+snapshot_kind: text
 ---
 #let tree(
   root,
@@ -13,8 +14,6 @@ input_file: tests/assets/unit/func/spread.typ
   spread: 1,
   name: none,
   ..style,
-) = {
-
-}
+) = { }
 
 #let f = (..) => 1

--- a/tests/snapshots/assets__check_file@unit-func-spread.typ-40.snap
+++ b/tests/snapshots/assets__check_file@unit-func-spread.typ-40.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/unit/func/spread.typ
+snapshot_kind: text
 ---
 #let tree(
   root,
@@ -13,8 +14,6 @@ input_file: tests/assets/unit/func/spread.typ
   spread: 1,
   name: none,
   ..style,
-) = {
-
-}
+) = { }
 
 #let f = (..) => 1

--- a/tests/snapshots/assets__check_file@unit-func-spread.typ-80.snap
+++ b/tests/snapshots/assets__check_file@unit-func-spread.typ-80.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/unit/func/spread.typ
+snapshot_kind: text
 ---
 #let tree(
   root,
@@ -13,8 +14,6 @@ input_file: tests/assets/unit/func/spread.typ
   spread: 1,
   name: none,
   ..style,
-) = {
-
-}
+) = { }
 
 #let f = (..) => 1


### PR DESCRIPTION
Now code like
```typst
#{

 "123"


  "456"

}
```
will be formatted to
```typst
#{
 "123"

  "456"
}
```

An option for max consecutive empty lines is provided, although it is not open to CLI.

Note that since we could not handle block comments correctly yet, code blocks with them are still left unformatted.

Besides, there is a special case for comment attachment. A semicolon can be unconsciously added to the end of a statement.