### PR TITLE
perf: greatly improve hash efficiency in computing attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3940,6 +3940,7 @@ dependencies = [
  "reflexo-typst-shim",
  "reflexo-vfs",
  "reflexo-world",
+ "rustc-hash",
  "typst",
  "typst-assets",
  "typst-pdf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 itertools = "0.13.0"
 pretty = "0.12.3"
+rustc-hash = "2.0"
 typst-syntax = "0.12.0"
 
 anyhow = "1"

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -1,160 +1,151 @@
-use std::collections::{hash_map::Entry, HashMap};
+use rustc_hash::FxHashMap;
 
 use typst_syntax::{
     ast::{Args, AstNode, Math, Raw, Space},
-    SyntaxKind, SyntaxNode,
+    Span, SyntaxKind, SyntaxNode,
 };
 
 struct State {
     is_math: bool,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct Attributes {
     no_format: bool,
     /// If (a) the first space child contains a newline, (b) one of the children is a multiline
-    is_multiline_flavor: bool,
+    multiline: bool,
 }
 
 impl Attributes {
     pub fn no_format(&self) -> bool {
         self.no_format
     }
+
     pub fn is_multiline_flavor(&self) -> bool {
-        self.is_multiline_flavor
-    }
-    pub fn with_no_format(self, no_format: bool) -> Self {
-        Self { no_format, ..self }
-    }
-    pub fn with_is_multiline(self, is_multiline: bool) -> Self {
-        Self {
-            is_multiline_flavor: is_multiline,
-            ..self
-        }
+        self.multiline
     }
 }
 
-pub fn calculate_attributes(node: SyntaxNode) -> HashMap<SyntaxNode, Attributes> {
-    let mut attr_map = HashMap::new();
-    get_no_format_nodes(&node, &mut attr_map);
-    get_multiline_nodes(&node, &mut attr_map);
-    attr_map
+#[derive(Debug, Default)]
+pub struct AttrStore {
+    attr_map: FxHashMap<Span, Attributes>,
 }
 
-fn get_multiline_nodes(root: &SyntaxNode, attr_map: &mut HashMap<SyntaxNode, Attributes>) {
-    get_multiline_nodes_impl(root, attr_map);
-}
-
-fn get_multiline_nodes_impl(node: &SyntaxNode, attr_map: &mut HashMap<SyntaxNode, Attributes>) {
-    if attr_map
-        .get(node)
-        .map_or(false, |attr| attr.is_multiline_flavor)
-    {
-        return;
-    }
-    let set_multiline =
-        |node: SyntaxNode, attr_map: &mut HashMap<SyntaxNode, Attributes>| match attr_map
-            .entry(node)
-        {
-            Entry::Occupied(mut entry) => {
-                entry.get_mut().is_multiline_flavor = true;
-            }
-            Entry::Vacant(entry) => {
-                entry.insert(Attributes::default().with_is_multiline(true));
-            }
+impl AttrStore {
+    pub fn new(node: &SyntaxNode) -> AttrStore {
+        let mut store = AttrStore {
+            attr_map: Default::default(),
         };
-    if node.children().count() == 0 {
-        return;
+        store.compute_no_format(node);
+        store.compute_multiline(node);
+        store
     }
-    if let Some(space) = node.cast_first_match::<Space>() {
-        if space.to_untyped().text().contains('\n') {
-            set_multiline(node.clone(), attr_map);
-        }
-    }
-    for child in node.children() {
-        get_multiline_nodes_impl(child, attr_map);
-        if let Some(attr) = attr_map.get(child) {
-            if attr.is_multiline_flavor {
-                set_multiline(node.clone(), attr_map);
-            }
-        }
-    }
-}
 
-fn get_no_format_nodes(root: &SyntaxNode, attr_map: &mut HashMap<SyntaxNode, Attributes>) {
-    let mut state = State { is_math: false };
-    get_no_format_nodes_impl(root, attr_map, &mut state);
-}
+    pub fn is_node_multiline(&self, node: &SyntaxNode) -> bool {
+        self.attr_map
+            .get(&node.span())
+            .is_some_and(|attr| attr.multiline)
+    }
 
-fn get_no_format_nodes_impl(
-    node: &SyntaxNode,
-    attr_map: &mut HashMap<SyntaxNode, Attributes>,
-    state: &mut State,
-) {
-    if attr_map.get(node).map_or(false, |attr| attr.no_format) {
-        return;
+    pub fn is_node_no_format(&self, node: &SyntaxNode) -> bool {
+        self.attr_map
+            .get(&node.span())
+            .is_some_and(|attr| attr.no_format)
     }
-    let mut no_format = false;
-    let original_is_math = state.is_math;
-    if node.cast::<Math>().is_some() {
-        state.is_math = true;
+
+    fn compute_multiline(&mut self, root: &SyntaxNode) {
+        self.compute_multiline_impl(root);
     }
-    let set_no_format =
-        |node: SyntaxNode, attr_map: &mut HashMap<SyntaxNode, Attributes>| match attr_map
-            .entry(node)
-        {
-            Entry::Occupied(mut entry) => {
-                entry.get_mut().no_format = true;
-            }
-            Entry::Vacant(entry) => {
-                entry.insert(Attributes::default().with_no_format(true));
-            }
-        };
-    for child in node.children() {
-        let child_kind = child.kind();
-        if child_kind == SyntaxKind::LineComment || child_kind == SyntaxKind::BlockComment {
-            // @typstyle off affects the whole next block
-            if child.text().contains("@typstyle off") {
-                no_format = true;
-                set_no_format(child.clone(), attr_map);
-            }
-            // currently we only support comments as children of these nodes
-            if !matches!(
-                node.kind(),
-                SyntaxKind::ContentBlock | SyntaxKind::CodeBlock | SyntaxKind::Code
-            ) {
-                set_no_format(node.clone(), attr_map);
-            }
-            continue;
+
+    fn compute_multiline_impl(&mut self, node: &SyntaxNode) {
+        if self.is_node_multiline(node) {
+            return;
         }
-        // no format multiline single backtick raw block
-        if let Some(raw) = child.cast::<Raw>() {
-            if !raw.block() && raw.lines().count() > 1 {
-                set_no_format(child.clone(), attr_map);
+        if node.children().count() == 0 {
+            return;
+        }
+        if let Some(space) = node.cast_first_match::<Space>() {
+            if space.to_untyped().text().contains('\n') {
+                self.set_multiline(node);
             }
         }
-        // no format hash related nodes in math blocks
-        if child_kind == SyntaxKind::Hash && state.is_math {
-            set_no_format(node.clone(), attr_map);
-            break;
+        for child in node.children() {
+            self.compute_multiline_impl(child);
+            if self.is_node_multiline(child) {
+                self.set_multiline(node);
+            }
         }
-        // no format args in math blocks
-        if child.cast::<Args>().is_some() && state.is_math {
-            set_no_format(child.clone(), attr_map);
-            continue;
-        }
-        if child.children().count() == 0 {
-            continue;
-        }
-        // no format nodes with @typstyle off
-        if no_format {
-            set_no_format(child.clone(), attr_map);
-            no_format = false;
-            continue;
-        }
-        get_no_format_nodes_impl(child, attr_map, state);
     }
-    state.is_math = original_is_math;
+
+    fn set_multiline(&mut self, node: &SyntaxNode) {
+        self.attr_map.entry(node.span()).or_default().multiline = true;
+    }
+
+    fn compute_no_format(&mut self, root: &SyntaxNode) {
+        let mut state = State { is_math: false };
+        self.compute_no_format_impl(root, &mut state);
+    }
+
+    fn compute_no_format_impl(&mut self, node: &SyntaxNode, state: &mut State) {
+        if self.is_node_no_format(node) {
+            return;
+        }
+        let mut no_format = false;
+        let original_is_math = state.is_math;
+        if node.is::<Math>() {
+            state.is_math = true;
+        }
+
+        for child in node.children() {
+            let child_kind = child.kind();
+            if child_kind == SyntaxKind::LineComment || child_kind == SyntaxKind::BlockComment {
+                // @typstyle off affects the whole next block
+                if child.text().contains("@typstyle off") {
+                    no_format = true;
+                    self.set_no_format(child);
+                }
+                // currently we only support comments as children of these nodes
+                if !matches!(
+                    node.kind(),
+                    SyntaxKind::ContentBlock | SyntaxKind::CodeBlock | SyntaxKind::Code
+                ) {
+                    self.set_no_format(node);
+                }
+                continue;
+            }
+            // no format multiline single backtick raw block
+            if let Some(raw) = child.cast::<Raw>() {
+                if !raw.block() && raw.lines().count() > 1 {
+                    self.set_no_format(child);
+                }
+            }
+            // no format hash related nodes in math blocks
+            if child_kind == SyntaxKind::Hash && state.is_math {
+                self.set_no_format(node);
+                break;
+            }
+            // no format args in math blocks
+            if child.cast::<Args>().is_some() && state.is_math {
+                self.set_no_format(child);
+                continue;
+            }
+            if child.children().count() == 0 {
+                continue;
+            }
+            // no format nodes with @typstyle off
+            if no_format {
+                self.set_no_format(child);
+                no_format = false;
+                continue;
+            }
+            self.compute_no_format_impl(child, state);
+        }
+        state.is_math = original_is_math;
+    }
+
+    fn set_no_format(&mut self, node: &SyntaxNode) {
+        self.attr_map.entry(node.span()).or_default().no_format = true;
+    }
 }
 
 #[allow(unused)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,28 +1,11 @@
 use pretty::BoxDoc;
 
-use crate::attr::Attributes;
-
 /// A style for formatting items
 pub enum FoldStyle {
     /// Fold items if them can fit in a single line
     Fit,
     /// Never fold items
     Never,
-}
-
-impl FoldStyle {
-    pub fn from_attr(attr: Option<&Attributes>) -> FoldStyle {
-        match attr {
-            Some(attr) => {
-                if attr.is_multiline_flavor() {
-                    FoldStyle::Never
-                } else {
-                    FoldStyle::Fit
-                }
-            }
-            None => FoldStyle::Fit,
-        }
-    }
 }
 
 pub fn comma_separated_items<'a, I>(


### PR DESCRIPTION
This PR resolves a critical issue that the formatter runs surprisingly slow on some large documents (e.g., the touying package), which was noticed earlier by @Myriad-Dreamin but not publicly disclosed.

After conducting an investigation with timing, I found that it is the HashMap in node attribution computation instead of Doc creating and pretty printing that hurts. In discussions with @Enter-tainer and @Myriad-Dreamin, we discovered that the previously used `SyntaxNode` hash value is computed recursively, which should be avoided in our preprocessing. As an alternative, we can use the span as the unique identifier for nodes. The root node needs to be created from `Source`. Otherwise, it would have no valid span attached.

With the changes in this PR, the time of formatting `tablex.typ` (the largest one in our test assets) dramatically drops from ~500ms to ~20ms. Additionally, unit tests can be completed much faster, although the improvement is not that significant.

Benchmarks will be added later.