### PR TITLE
fix: problems with formatting func-call in chain access

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -5,6 +5,8 @@ use typst_syntax::{
     Span, SyntaxKind, SyntaxNode,
 };
 
+use crate::ext::StrExt;
+
 struct State {
     is_math: bool,
 }
@@ -90,7 +92,7 @@ impl AttrStore {
         }
         if node
             .cast_first_match::<Space>()
-            .is_some_and(|space| space.to_untyped().text().contains('\n'))
+            .is_some_and(|space| space.to_untyped().text().has_linebreak())
         {
             self.set_multiline(node);
             self.set_multiline_flavor(node);

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -1,0 +1,27 @@
+pub trait BoolExt {
+    fn replace(&mut self, value: Self) -> Self;
+}
+
+impl BoolExt for bool {
+    fn replace(&mut self, value: Self) -> Self {
+        let old = *self;
+        *self = value;
+        old
+    }
+}
+
+pub trait StrExt {
+    fn has_linebreak(&self) -> bool;
+
+    fn count_linebreaks(&self) -> usize;
+}
+
+impl StrExt for str {
+    fn has_linebreak(&self) -> bool {
+        self.contains('\n')
+    }
+
+    fn count_linebreaks(&self) -> usize {
+        self.chars().filter(|c| *c == '\n').count()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 #[doc(hidden)]
 pub mod attr;
 #[doc(hidden)]
+pub mod ext;
+#[doc(hidden)]
 pub mod pretty;
 
 #[doc(hidden)]

--- a/src/pretty/code_flow.rs
+++ b/src/pretty/code_flow.rs
@@ -1,7 +1,9 @@
 use pretty::DocAllocator;
 use typst_syntax::{ast::*, SyntaxKind};
 
-use super::{flow::FlowItem, util::BoolExt, ArenaDoc, PrettyPrinter};
+use crate::ext::BoolExt;
+
+use super::{flow::FlowItem, ArenaDoc, PrettyPrinter};
 
 impl<'a> PrettyPrinter<'a> {
     pub(super) fn convert_named(&'a self, named: Named<'a>) -> ArenaDoc<'a> {

--- a/src/pretty/dot_chain.rs
+++ b/src/pretty/dot_chain.rs
@@ -1,11 +1,47 @@
-use typst_syntax::ast::*;
+use pretty::DocAllocator;
+use typst_syntax::{ast::*, SyntaxNode};
 
 use crate::PrettyPrinter;
 
 use super::ArenaDoc;
 
 impl<'a> PrettyPrinter<'a> {
-    pub fn resolve_dot_chain(&'a self, field_access: FieldAccess<'a>) -> Option<Vec<ArenaDoc<'a>>> {
+    pub(super) fn convert_field_access(&'a self, field_access: FieldAccess<'a>) -> ArenaDoc<'a> {
+        if let Some(res) = self.check_unformattable(field_access.to_untyped()) {
+            return res;
+        }
+        if !self.current_mode().is_code() {
+            let left = self.convert_expr(field_access.target());
+            let singleline_right = self.arena.text(".") + self.convert_ident(field_access.field());
+            return left + singleline_right;
+        }
+        self.convert_dot_chain(field_access.to_untyped())
+    }
+
+    pub(super) fn convert_dot_chain(&'a self, node: &'a SyntaxNode) -> ArenaDoc<'a> {
+        let mut chain = self.resolve_dot_chain(node);
+        if chain.len() == 2 {
+            let last = chain.pop().unwrap();
+            let first = chain.pop().unwrap();
+            return first + self.arena.text(".") + last;
+        }
+        let first_doc = chain.remove(0);
+        let other_doc = self
+            .arena
+            .intersperse(chain, self.arena.line_() + self.arena.text("."));
+        let chain = first_doc
+            + (self.arena.line_() + self.arena.text(".") + other_doc)
+                .nest(2)
+                .group();
+        // if matches!(self.current_mode(), Mode::Markup | Mode::Math) {
+        //     optional_paren(chain)
+        // } else {
+        //     chain
+        // }
+        chain
+    }
+
+    fn resolve_dot_chain(&'a self, node: &'a SyntaxNode) -> Vec<ArenaDoc<'a>> {
         let mut nodes = vec![];
         let mut push_node = |node: ArenaDoc<'a>, last_is_field_access: bool| {
             if last_is_field_access {
@@ -15,7 +51,7 @@ impl<'a> PrettyPrinter<'a> {
                 nodes.push(node + last);
             }
         };
-        let mut current = field_access.to_untyped();
+        let mut current = node;
         let mut last_is_field_access = true;
         loop {
             if let Some(field_access) = current.cast::<FieldAccess>() {
@@ -37,6 +73,6 @@ impl<'a> PrettyPrinter<'a> {
             break;
         }
         nodes.reverse();
-        Some(nodes)
+        nodes
     }
 }

--- a/src/pretty/func_call.rs
+++ b/src/pretty/func_call.rs
@@ -40,7 +40,7 @@ impl<'a> PrettyPrinter<'a> {
     pub(super) fn convert_args(&'a self, args: Args<'a>) -> ArenaDoc<'a> {
         let has_parenthesized_args = has_parenthesized_args(args);
         let parenthesized = if has_parenthesized_args {
-            self.convert_parenthesized_args_as_is(args)
+            self.convert_parenthesized_args(args)
         } else {
             self.arena.nil()
         };

--- a/src/pretty/list.rs
+++ b/src/pretty/list.rs
@@ -1,6 +1,8 @@
 use pretty::DocAllocator;
 use typst_syntax::{ast::*, SyntaxKind, SyntaxNode};
 
+use crate::ext::StrExt;
+
 use super::{doc_ext::DocExt, style::FoldStyle, util::is_comment_node, ArenaDoc, PrettyPrinter};
 
 enum Item<'a> {
@@ -186,7 +188,7 @@ impl<'a> ListStylist<'a> {
         } else if node.kind() == SyntaxKind::Comma {
             self.try_attach_comments();
         } else if node.kind() == SyntaxKind::Space {
-            let newline_cnt = node.text().chars().filter(|c| *c == '\n').count();
+            let newline_cnt = node.text().count_linebreaks();
             if newline_cnt > 0 {
                 self.attach_or_detach_comments();
                 self.can_attach = false;

--- a/src/pretty/mod.rs
+++ b/src/pretty/mod.rs
@@ -411,38 +411,6 @@ impl<'a> PrettyPrinter<'a> {
         }
     }
 
-    fn convert_field_access(&'a self, field_access: FieldAccess<'a>) -> ArenaDoc<'a> {
-        if let Some(res) = self.check_unformattable(field_access.to_untyped()) {
-            return res;
-        }
-        let chain = self.resolve_dot_chain(field_access);
-        if chain.is_none() || matches!(self.current_mode(), Mode::Markup | Mode::Math) {
-            let left = self.convert_expr(field_access.target());
-            let singleline_right = self.arena.text(".") + self.convert_ident(field_access.field());
-            return left + singleline_right;
-        }
-        let mut chain = chain.unwrap();
-        if chain.len() == 2 {
-            let last = chain.pop().unwrap();
-            let first = chain.pop().unwrap();
-            return first + self.arena.text(".") + last;
-        }
-        let first_doc = chain.remove(0);
-        let other_doc = self
-            .arena
-            .intersperse(chain, self.arena.line_() + self.arena.text("."));
-        let chain = first_doc
-            + (self.arena.line_() + self.arena.text(".") + other_doc)
-                .nest(2)
-                .group();
-        // if matches!(self.current_mode(), Mode::Markup | Mode::Math) {
-        //     optional_paren(chain)
-        // } else {
-        //     chain
-        // }
-        chain
-    }
-
     fn convert_param(&'a self, param: Param<'a>) -> ArenaDoc<'a> {
         match param {
             Param::Pos(p) => self.convert_pattern(p),

--- a/src/pretty/mode.rs
+++ b/src/pretty/mode.rs
@@ -8,6 +8,21 @@ pub enum Mode {
     Math,
 }
 
+#[allow(unused)]
+impl Mode {
+    pub fn is_markup(&self) -> bool {
+        *self == Self::Markup
+    }
+
+    pub fn is_code(&self) -> bool {
+        *self == Self::Code
+    }
+
+    pub fn is_math(&self) -> bool {
+        *self == Self::Math
+    }
+}
+
 impl PrettyPrinter<'_> {
     pub(super) fn push_mode(&self, mode: Mode) {
         self.mode.borrow_mut().push(mode);

--- a/src/pretty/plain.rs
+++ b/src/pretty/plain.rs
@@ -1,6 +1,8 @@
 use pretty::DocAllocator;
 use typst_syntax::{ast::AstNode, SyntaxKind, SyntaxNode};
 
+use crate::ext::StrExt;
+
 use super::{doc_ext::DocExt, flow::FlowStylist, ArenaDoc, PrettyPrinter};
 
 #[derive(Debug)]
@@ -47,7 +49,7 @@ impl<'a> PlainStylist<'a> {
             self.items.push(match child.kind() {
                 SyntaxKind::Comma => PlainItem::Comma,
                 SyntaxKind::Space => {
-                    let newline_count = child.text().chars().filter(|&c| c == '\n').count();
+                    let newline_count = child.text().count_linebreaks();
                     if newline_count > 0 {
                         self.is_multiline = true;
                         if !self.items.is_empty() {

--- a/src/pretty/util.rs
+++ b/src/pretty/util.rs
@@ -68,15 +68,3 @@ pub(super) fn has_additional_args(node: Args<'_>) -> bool {
         .filter_map(|node| node.cast::<'_, Arg>());
     args.count() > 1
 }
-
-pub trait BoolExt {
-    fn replace(&mut self, value: Self) -> Self;
-}
-
-impl BoolExt for bool {
-    fn replace(&mut self, value: Self) -> Self {
-        let old = *self;
-        *self = value;
-        old
-    }
-}

--- a/tests/assets/unit/code/chained-call.typ
+++ b/tests/assets/unit/code/chained-call.typ
@@ -39,3 +39,32 @@
     .filter((h, _) => (h.y == header_last_y + 1))
 
 }
+
+#{
+  aaaaaaaa(bbbbbbb, ccccccc).ddddddddd()().eeeeeeeee[].ffffffffff
+
+
+let points = (
+      from,
+      to,
+    )
+      .zip(offsets)
+      .map((
+      (
+        point,
+        offset,
+      ),
+    ) => none)
+
+          (
+         (
+        1,
+           2,
+      ),
+        2,
+      3,
+    )
+    .rev()
+
+    import cetz.draw: *
+}

--- a/tests/snapshots/assets__check_file@cetz-manual.typ-0.snap
+++ b/tests/snapshots/assets__check_file@cetz-manual.typ-0.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/cetz-manual.typ
+snapshot_kind: text
 ---
 #import "doc/util.typ": *
 #import "doc/example.typ": (
@@ -302,9 +303,12 @@ Marks are arrow tips that can be added to the end of path based elements that su
         (
           raw(name),
           name-to-mnemonic
-            .at(name, default: (
+            .at(
+              name,
+              default: (
                 [],
-              ))
+              ),
+            )
             .join([, ]),
           cetz.canvas(
             cetz

--- a/tests/snapshots/assets__check_file@cetz-manual.typ-0.snap
+++ b/tests/snapshots/assets__check_file@cetz-manual.typ-0.snap
@@ -82,9 +82,9 @@ Note that draw functions are imported inside the scope of the `canvas` block. Th
     it
       .text
       .slice(
-      1,
-      -1,
-    ),
+        1,
+        -1,
+      ),
   )
 } else {
   it
@@ -314,15 +314,15 @@ Marks are arrow tips that can be added to the end of path based elements that su
             cetz
               .draw
               .line(
-              (),
-              (
-                1,
-                0,
+                (),
+                (
+                  1,
+                  0,
+                ),
+                mark: (
+                  end: name,
+                ),
               ),
-              mark: (
-                end: name,
-              ),
-            ),
           ),
         )
       }

--- a/tests/snapshots/assets__check_file@cetz-manual.typ-40.snap
+++ b/tests/snapshots/assets__check_file@cetz-manual.typ-40.snap
@@ -282,11 +282,13 @@ Marks are arrow tips that can be added to the end of path based elements that su
             .at(name, default: ([],))
             .join([, ]),
           cetz.canvas(
-            cetz.draw.line(
-              (),
-              (1, 0),
-              mark: (end: name),
-            ),
+            cetz
+              .draw
+              .line(
+                (),
+                (1, 0),
+                mark: (end: name),
+              ),
           ),
         )
       }

--- a/tests/snapshots/assets__check_file@cetz-tree.typ-0.snap
+++ b/tests/snapshots/assets__check_file@cetz-tree.typ-0.snap
@@ -166,15 +166,15 @@ snapshot_kind: text
         .slice(1)
         .enumerate()
         .map((
-        (
-          n,
+          (
+            n,
+            c,
+          ),
+        ) => build-node(
           c,
-        ),
-      ) => build-node(
-        c,
-        depth: depth + 1,
-        sibling: n,
-      ))
+          depth: depth + 1,
+          sibling: n,
+        ))
       cnt = tree.at(0)
     } else {
       cnt = tree
@@ -423,13 +423,13 @@ snapshot_kind: text
         ctx
           .groups
           .push((
-          ctx: ctx,
-          anchors: (:),
-          tree-root: layout(
-            root,
-            ctx,
-          ),
-        ))
+            ctx: ctx,
+            anchors: (:),
+            tree-root: layout(
+              root,
+              ctx,
+            ),
+          ))
         return ctx
       },
       after: ctx => {
@@ -442,9 +442,9 @@ snapshot_kind: text
           ctx
             .nodes
             .insert(
-            name,
-            nodes.at(name),
-          )
+              name,
+              nodes.at(name),
+            )
         }
         return ctx
       },

--- a/tests/snapshots/assets__check_file@cetz-tree.typ-120.snap
+++ b/tests/snapshots/assets__check_file@cetz-tree.typ-120.snap
@@ -228,11 +228,13 @@ snapshot_kind: text
       name: name,
       style: style.named(),
       before: ctx => {
-        ctx.groups.push((
-          ctx: ctx,
-          anchors: (:),
-          tree-root: layout(root, ctx),
-        ))
+        ctx
+          .groups
+          .push((
+            ctx: ctx,
+            anchors: (:),
+            tree-root: layout(root, ctx),
+          ))
         return ctx
       },
       after: ctx => {

--- a/tests/snapshots/assets__check_file@cetz-tree.typ-40.snap
+++ b/tests/snapshots/assets__check_file@cetz-tree.typ-40.snap
@@ -149,10 +149,10 @@ snapshot_kind: text
         .slice(1)
         .enumerate()
         .map(((n, c)) => build-node(
-        c,
-        depth: depth + 1,
-        sibling: n,
-      ))
+          c,
+          depth: depth + 1,
+          sibling: n,
+        ))
       cnt = tree.at(0)
     } else {
       cnt = tree
@@ -321,11 +321,16 @@ snapshot_kind: text
       name: name,
       style: style.named(),
       before: ctx => {
-        ctx.groups.push((
-          ctx: ctx,
-          anchors: (:),
-          tree-root: layout(root, ctx),
-        ))
+        ctx
+          .groups
+          .push((
+            ctx: ctx,
+            anchors: (:),
+            tree-root: layout(
+              root,
+              ctx,
+            ),
+          ))
         return ctx
       },
       after: ctx => {
@@ -333,10 +338,12 @@ snapshot_kind: text
         let nodes = ctx.nodes
         ctx = self.ctx
         if name != none {
-          ctx.nodes.insert(
-            name,
-            nodes.at(name),
-          )
+          ctx
+            .nodes
+            .insert(
+              name,
+              nodes.at(name),
+            )
         }
         return ctx
       },

--- a/tests/snapshots/assets__check_file@cetz-tree.typ-80.snap
+++ b/tests/snapshots/assets__check_file@cetz-tree.typ-80.snap
@@ -108,11 +108,10 @@ snapshot_kind: text
     let children = ()
     let cnt = none
     if type(tree) == array {
-      children = tree.slice(1).enumerate().map(((n, c)) => build-node(
-        c,
-        depth: depth + 1,
-        sibling: n,
-      ))
+      children = tree
+        .slice(1)
+        .enumerate()
+        .map(((n, c)) => build-node(c, depth: depth + 1, sibling: n))
       cnt = tree.at(0)
     } else {
       cnt = tree
@@ -244,11 +243,13 @@ snapshot_kind: text
       name: name,
       style: style.named(),
       before: ctx => {
-        ctx.groups.push((
-          ctx: ctx,
-          anchors: (:),
-          tree-root: layout(root, ctx),
-        ))
+        ctx
+          .groups
+          .push((
+            ctx: ctx,
+            anchors: (:),
+            tree-root: layout(root, ctx),
+          ))
         return ctx
       },
       after: ctx => {

--- a/tests/snapshots/assets__check_file@packages-codly.typ-0.snap
+++ b/tests/snapshots/assets__check_file@packages-codly.typ-0.snap
@@ -229,7 +229,10 @@ snapshot_kind: text
   position,
   length,
 ) = {
-  state("codly-skips", ()).update(skips => {
+  state(
+    "codly-skips",
+    (),
+  ).update(skips => {
     if skips == none {
       skips = ()
     }
@@ -359,9 +362,12 @@ snapshot_kind: text
   )(if "highlight-stroke" in extra {
     extra.highlight-stroke
   } else {
-    state("codly-highlight-stroke", __codly-args
+    state(
+      "codly-highlight-stroke",
+      __codly-args
         .highlight-stroke
-        .default).get()
+        .default,
+    ).get()
   })
 
   let highlight-fill = (
@@ -371,9 +377,12 @@ snapshot_kind: text
   )(if "highlight-fill" in extra {
     extra.highlight-fill
   } else {
-    state("codly-highlight-fill", __codly-args
+    state(
+      "codly-highlight-fill",
+      __codly-args
         .highlight-fill
-        .default).get()
+        .default,
+    ).get()
   })
 
   let highlight-radius = (
@@ -383,9 +392,12 @@ snapshot_kind: text
   )(if "highlight-radius" in extra {
     extra.highlight-radius
   } else {
-    state("codly-highlight-radius", __codly-args
+    state(
+      "codly-highlight-radius",
+      __codly-args
         .highlight-radius
-        .default).get()
+        .default,
+    ).get()
   })
 
   let highlight-inset = (
@@ -395,9 +407,12 @@ snapshot_kind: text
   )(if "highlight-inset" in extra {
     extra.highlight-inset
   } else {
-    state("codly-highlight-inset", __codly-args
+    state(
+      "codly-highlight-inset",
+      __codly-args
         .highlight-inset
-        .default).get()
+        .default,
+    ).get()
   })
 
   let default-color = (
@@ -407,9 +422,12 @@ snapshot_kind: text
   )(if "default-color" in extra {
     extra.default-color
   } else {
-    state("codly-default-color", __codly-args
+    state(
+      "codly-default-color",
+      __codly-args
         .default-color
-        .default).get()
+        .default,
+    ).get()
   })
 
   let highlights = {
@@ -420,17 +438,20 @@ snapshot_kind: text
     )(if "highlights" in extra {
       extra.highlights
     } else {
-      state("codly-highlights", __codly-args
+      state(
+        "codly-highlights",
+        __codly-args
           .highlights
-          .default).get()
+          .default,
+      ).get()
     })
     if highlights == none {
       ()
     } else {
       highlights
         .sorted(key: x => (
-            x.line
-          ))
+          x.line
+        ))
         .map(x => {
         if not "start" in x or x.start == none {
           x.insert(
@@ -473,9 +494,12 @@ snapshot_kind: text
   )(if "smart-indent" in extra {
     extra.smart-indent
   } else {
-    state("codly-smart-indent", __codly-args
+    state(
+      "codly-smart-indent",
+      __codly-args
         .smart-indent
-        .default).get()
+        .default,
+    ).get()
   })
   let body = if it
     .body
@@ -634,11 +658,11 @@ snapshot_kind: text
       } else if elem.has("child") and elem.has("styles") {
         get-flattened-body(elem.child)
           .map(x => (
-              elem.func()
-            )(
-              x,
-              elem.styles,
-            ))
+            elem.func()
+          )(
+            x,
+            elem.styles,
+          ))
           .flatten()
       } else if elem.has("text") {
         // Separate the whitespaces at the start of text
@@ -714,9 +738,12 @@ snapshot_kind: text
         )(if "reference-by" in extra {
           extra.reference-by
         } else {
-          state("codly-reference-by", __codly-args
+          state(
+            "codly-reference-by",
+            __codly-args
               .reference-by
-              .default).get()
+              .default,
+          ).get()
         })
         let reference-sep = (
           __codly-args
@@ -725,9 +752,12 @@ snapshot_kind: text
         )(if "reference-sep" in extra {
           extra.reference-sep
         } else {
-          state("codly-reference-sep", __codly-args
+          state(
+            "codly-reference-sep",
+            __codly-args
               .reference-sep
-              .default).get()
+              .default,
+          ).get()
         })
 
         let referenced = if reference-by == "line" {
@@ -738,9 +768,12 @@ snapshot_kind: text
           )(if "reference-number-format" in extra {
             extra.reference-number-format
           } else {
-            state("codly-reference-number-format", __codly-args
+            state(
+              "codly-reference-number-format",
+              __codly-args
                 .reference-number-format
-                .default).get()
+                .default,
+            ).get()
           })
 
           reference-number-format(it.number)
@@ -878,9 +911,12 @@ snapshot_kind: text
   )(if "enabled" in extra {
     extra.enabled
   } else {
-    state("codly-enabled", __codly-args
+    state(
+      "codly-enabled",
+      __codly-args
         .enabled
-        .default).get()
+        .default,
+    ).get()
   })
 
   if not enabled {
@@ -895,9 +931,12 @@ snapshot_kind: text
   )(if "range" in extra {
     extra.range
   } else {
-    state("codly-range", __codly-args
+    state(
+      "codly-range",
+      __codly-args
         .range
-        .default).get()
+        .default,
+    ).get()
   })
 
   let ranges = (
@@ -907,9 +946,12 @@ snapshot_kind: text
   )(if "ranges" in extra {
     extra.ranges
   } else {
-    state("codly-ranges", __codly-args
+    state(
+      "codly-ranges",
+      __codly-args
         .ranges
-        .default).get()
+        .default,
+    ).get()
   })
 
   if ranges == none and range != none {
@@ -963,9 +1005,12 @@ snapshot_kind: text
   )(if "display-name" in extra {
     extra.display-name
   } else {
-    state("codly-display-name", __codly-args
+    state(
+      "codly-display-name",
+      __codly-args
         .display-name
-        .default).get()
+        .default,
+    ).get()
   })
 
   let display-icons = (
@@ -975,9 +1020,12 @@ snapshot_kind: text
   )(if "display-icon" in extra {
     extra.display-icon
   } else {
-    state("codly-display-icon", __codly-args
+    state(
+      "codly-display-icon",
+      __codly-args
         .display-icon
-        .default).get()
+        .default,
+    ).get()
   })
 
   let lang-outset = (
@@ -987,9 +1035,12 @@ snapshot_kind: text
   )(if "lang-outset" in extra {
     extra.lang-outset
   } else {
-    state("codly-lang-outset", __codly-args
+    state(
+      "codly-lang-outset",
+      __codly-args
         .lang-outset
-        .default).get()
+        .default,
+    ).get()
   })
 
   let language-block = {
@@ -1000,9 +1051,12 @@ snapshot_kind: text
     )(if "lang-format" in extra {
       extra.lang-format
     } else {
-      state("codly-lang-format", __codly-args
+      state(
+        "codly-lang-format",
+        __codly-args
           .lang-format
-          .default).get()
+          .default,
+      ).get()
     })
 
     if fn == none {
@@ -1024,9 +1078,12 @@ snapshot_kind: text
   )(if "default-color" in extra {
     extra.default-color
   } else {
-    state("codly-default-color", __codly-args
+    state(
+      "codly-default-color",
+      __codly-args
         .default-color
-        .default).get()
+        .default,
+    ).get()
   })
 
   let radius = (
@@ -1036,9 +1093,12 @@ snapshot_kind: text
   )(if "radius" in extra {
     extra.radius
   } else {
-    state("codly-radius", __codly-args
+    state(
+      "codly-radius",
+      __codly-args
         .radius
-        .default).get()
+        .default,
+    ).get()
   })
 
   let offset = (
@@ -1048,9 +1108,12 @@ snapshot_kind: text
   )(if "offset" in extra {
     extra.offset
   } else {
-    state("codly-offset", __codly-args
+    state(
+      "codly-offset",
+      __codly-args
         .offset
-        .default).get()
+        .default,
+    ).get()
   })
 
   let stroke = (
@@ -1060,9 +1123,12 @@ snapshot_kind: text
   )(if "stroke" in extra {
     extra.stroke
   } else {
-    state("codly-stroke", __codly-args
+    state(
+      "codly-stroke",
+      __codly-args
         .stroke
-        .default).get()
+        .default,
+    ).get()
   })
 
   let zebra-color = (
@@ -1072,9 +1138,12 @@ snapshot_kind: text
   )(if "zebra-fill" in extra {
     extra.zebra-fill
   } else {
-    state("codly-zebra-fill", __codly-args
+    state(
+      "codly-zebra-fill",
+      __codly-args
         .zebra-fill
-        .default).get()
+        .default,
+    ).get()
   })
 
   let numbers-format = (
@@ -1084,9 +1153,12 @@ snapshot_kind: text
   )(if "number-format" in extra {
     extra.number-format
   } else {
-    state("codly-number-format", __codly-args
+    state(
+      "codly-number-format",
+      __codly-args
         .number-format
-        .default).get()
+        .default,
+    ).get()
   })
 
   let numbers-alignment = (
@@ -1096,9 +1168,12 @@ snapshot_kind: text
   )(if "number-align" in extra {
     extra.number-align
   } else {
-    state("codly-number-align", __codly-args
+    state(
+      "codly-number-align",
+      __codly-args
         .number-align
-        .default).get()
+        .default,
+    ).get()
   })
 
   let padding = __codly-inset(
@@ -1109,9 +1184,12 @@ snapshot_kind: text
     )(if "inset" in extra {
       extrainset
     } else {
-      state("codly-inset", __codly-args
+      state(
+        "codly-inset",
+        __codly-args
           .inset
-          .default).get()
+          .default,
+      ).get()
     }),
   )
 
@@ -1122,9 +1200,12 @@ snapshot_kind: text
   )(if "breakable" in extra {
     extra.breakable
   } else {
-    state("codly-breakable", __codly-args
+    state(
+      "codly-breakable",
+      __codly-args
         .breakable
-        .default).get()
+        .default,
+    ).get()
   })
 
   let fill = (
@@ -1134,9 +1215,12 @@ snapshot_kind: text
   )(if "fill" in extra {
     extra.fill
   } else {
-    state("codly-fill", __codly-args
+    state(
+      "codly-fill",
+      __codly-args
         .fill
-        .default).get()
+        .default,
+    ).get()
   })
 
   let skips = {
@@ -1147,9 +1231,12 @@ snapshot_kind: text
     )(if "skips" in extra {
       extra.skips
     } else {
-      state("codly-skips", __codly-args
+      state(
+        "codly-skips",
+        __codly-args
           .skips
-          .default).get()
+          .default,
+      ).get()
     })
     if skips == none {
       ()
@@ -1167,9 +1254,12 @@ snapshot_kind: text
   )(if "skip-line" in extra {
     extra.skip-line
   } else {
-    state("codly-skip-line", __codly-args
+    state(
+      "codly-skip-line",
+      __codly-args
         .skip-line
-        .default).get()
+        .default,
+    ).get()
   })
 
   let skip-number = (
@@ -1179,9 +1269,12 @@ snapshot_kind: text
   )(if "skip-number" in extra {
     extra.skip-number
   } else {
-    state("codly-skip-number", __codly-args
+    state(
+      "codly-skip-number",
+      __codly-args
         .skip-number
-        .default).get()
+        .default,
+    ).get()
   })
 
   let reference-by = (
@@ -1191,9 +1284,12 @@ snapshot_kind: text
   )(if "reference-by" in extra {
     extra.reference-by
   } else {
-    state("codly-reference-by", __codly-args
+    state(
+      "codly-reference-by",
+      __codly-args
         .reference-by
-        .default).get()
+        .default,
+    ).get()
   })
 
   if not reference-by in (
@@ -1210,9 +1306,12 @@ snapshot_kind: text
   )(if "reference-sep" in extra {
     extra.reference-sep
   } else {
-    state("codly-reference-sep", __codly-args
+    state(
+      "codly-reference-sep",
+      __codly-args
         .reference-sep
-        .default).get()
+        .default,
+    ).get()
   })
 
   let reference-number-format = (
@@ -1222,9 +1321,12 @@ snapshot_kind: text
   )(if "reference-number-format" in extra {
     extra.reference-number-format
   } else {
-    state("codly-reference-number-format", __codly-args
+    state(
+      "codly-reference-number-format",
+      __codly-args
         .reference-number-format
-        .default).get()
+        .default,
+    ).get()
   })
 
   let annotation-format = {
@@ -1235,9 +1337,12 @@ snapshot_kind: text
     )(if "annotation-format" in extra {
       extra.annotation-format
     } else {
-      state("codly-annotation-format", __codly-args
+      state(
+        "codly-annotation-format",
+        __codly-args
           .annotation-format
-          .default).get()
+          .default,
+      ).get()
     })
     if fn == none {
       _ => (
@@ -1256,17 +1361,20 @@ snapshot_kind: text
     )(if "annotations" in extra {
       extra.annotations
     } else {
-      state("codly-annotations", __codly-args
+      state(
+        "codly-annotations",
+        __codly-args
           .annotations
-          .default).get()
+          .default,
+      ).get()
     })
     annotations = if annotations == none {
       ()
     } else {
       annotations
         .sorted(key: x => (
-            x.start
-          ))
+          x.start
+        ))
         .map(x => {
         if (
           not "end" in x
@@ -1320,8 +1428,8 @@ snapshot_kind: text
   // Get the widest annotation.
   let annot-bodies-width = annotations
     .map(x => (
-        x.content
-      ))
+      x.content
+    ))
     .map(measure)
     .map(x => (
     x.width
@@ -1331,9 +1439,9 @@ snapshot_kind: text
   )
   let lr-width = if annotations.len() > 0 {
     measure(math.lr(
-        "}",
-        size: 5em,
-      ) + num).width
+      "}",
+      size: 5em,
+    ) + num).width
   } else {
     0pt
   }
@@ -1356,7 +1464,7 @@ snapshot_kind: text
       1,
       "Hello, World!",
       [Hello, World!],
-    )
+    ),
   ).height + padding.top + padding.bottom
 
   let items = ()
@@ -1373,9 +1481,12 @@ snapshot_kind: text
   )(if "header" in extra {
     extra.header
   } else {
-    state("codly-header", __codly-args
+    state(
+      "codly-header",
+      __codly-args
         .header
-        .default).get()
+        .default,
+    ).get()
   })
   let header-repeat = (
     __codly-args
@@ -1384,9 +1495,12 @@ snapshot_kind: text
   )(if "header-repeat" in extra {
     extra.header-repeat
   } else {
-    state("codly-header-repeat", __codly-args
+    state(
+      "codly-header-repeat",
+      __codly-args
         .header-repeat
-        .default).get()
+        .default,
+    ).get()
   })
 
   // The language block (icon + name)
@@ -1397,9 +1511,12 @@ snapshot_kind: text
   )(if "languages" in extra {
     extra.languages
   } else {
-    state("codly-languages", __codly-args
+    state(
+      "codly-languages",
+      __codly-args
         .languages
-        .default).get()
+        .default,
+    ).get()
   })
   let language-block = if it.lang == none {
     none
@@ -1431,9 +1548,12 @@ snapshot_kind: text
       )(if "lang-radius" in extra {
         extra.lang-radius
       } else {
-        state("codly-lang-radius", __codly-args
+        state(
+          "codly-lang-radius",
+          __codly-args
             .lang-radius
-            .default).get()
+            .default,
+        ).get()
       })
       let padding = __codly-inset(
         (
@@ -1443,9 +1563,12 @@ snapshot_kind: text
         )(if "lang-inset" in extra {
           extra.lang-inset
         } else {
-          state("codly-lang-inset", __codly-args
+          state(
+            "codly-lang-inset",
+            __codly-args
               .lang-inset
-              .default).get()
+              .default,
+          ).get()
         }),
       )
 
@@ -1456,9 +1579,12 @@ snapshot_kind: text
       )(if "lang-stroke" in extra {
         extra.lang-stroke
       } else {
-        state("codly-lang-stroke", __codly-args
+        state(
+          "codly-lang-stroke",
+          __codly-args
             .lang-stroke
-            .default).get()
+            .default,
+        ).get()
       })
       let lang-fill = (
         __codly-args
@@ -1467,9 +1593,12 @@ snapshot_kind: text
       )(if "lang-fill" in extra {
         extra.lang-fill
       } else {
-        state("codly-lang-fill", __codly-args
+        state(
+          "codly-lang-fill",
+          __codly-args
             .lang-fill
-            .default).get()
+            .default,
+        ).get()
       })
 
       let fill = if type(lang-fill) == function {
@@ -1526,9 +1655,12 @@ snapshot_kind: text
       )(if "lang-radius" in extra {
         extra.lang-radius
       } else {
-        state("codly-lang-radius", __codly-args
+        state(
+          "codly-lang-radius",
+          __codly-args
             .lang-radius
-            .default).get()
+            .default,
+        ).get()
       })
 
       let padding = __codly-inset(
@@ -1539,9 +1671,12 @@ snapshot_kind: text
         )(if "lang-inset" in extra {
           extra.lang-inset
         } else {
-          state("codly-lang-inset", __codly-args
+          state(
+            "codly-lang-inset",
+            __codly-args
               .lang-inset
-              .default).get()
+              .default,
+          ).get()
         }),
       )
 
@@ -1552,9 +1687,12 @@ snapshot_kind: text
       )(if "lang-stroke" in extra {
         extra.lang-stroke
       } else {
-        state("codly-lang-stroke", __codly-args
+        state(
+          "codly-lang-stroke",
+          __codly-args
             .lang-stroke
-            .default).get()
+            .default,
+        ).get()
       })
 
       let lang-fill = (
@@ -1564,9 +1702,12 @@ snapshot_kind: text
       )(if "lang-fill" in extra {
         extra.lang-fill
       } else {
-        state("codly-lang-fill", __codly-args
+        state(
+          "codly-lang-fill",
+          __codly-args
             .lang-fill
-            .default).get()
+            .default,
+        ).get()
       })
 
       let fill = if type(lang-fill) == function {
@@ -1633,9 +1774,12 @@ snapshot_kind: text
     )(if "header-cell-args" in extra {
       extra.header-cell-args
     } else {
-      state("codly-header-cell-args", __codly-args
+      state(
+        "codly-header-cell-args",
+        __codly-args
           .header-cell-args
-          .default).get()
+          .default,
+      ).get()
     })
     let transform = (
       __codly-args
@@ -1644,9 +1788,12 @@ snapshot_kind: text
     )(if "header-transform" in extra {
       extra.header-transform
     } else {
-      state("codly-header-transform", __codly-args
+      state(
+        "codly-header-transform",
+        __codly-args
           .header-transform
-          .default).get()
+          .default,
+      ).get()
     })
     (
       grid.header(
@@ -1833,9 +1980,12 @@ snapshot_kind: text
   )(if "footer" in extra {
     extra.footer
   } else {
-    state("codly-footer", __codly-args
+    state(
+      "codly-footer",
+      __codly-args
         .footer
-        .default).get()
+        .default,
+    ).get()
   })
   let footer-repeat = (
     __codly-args
@@ -1844,9 +1994,12 @@ snapshot_kind: text
   )(if "footer-repeat" in extra {
     extra.footer-repeat
   } else {
-    state("codly-footer-repeat", __codly-args
+    state(
+      "codly-footer-repeat",
+      __codly-args
         .footer-repeat
-        .default).get()
+        .default,
+    ).get()
   })
   let footer = if footer != none {
     let footer-args = (
@@ -1856,9 +2009,12 @@ snapshot_kind: text
     )(if "footer-cell-args" in extra {
       extra.footer-cell-args
     } else {
-      state("codly-footer-cell-args", __codly-args
+      state(
+        "codly-footer-cell-args",
+        __codly-args
           .footer-cell-args
-          .default).get()
+          .default,
+      ).get()
     })
     let transform = (
       __codly-args
@@ -1867,9 +2023,12 @@ snapshot_kind: text
     )(if "footer-transform" in extra {
       extra.footer-transform
     } else {
-      state("codly-footer-transform", __codly-args
+      state(
+        "codly-footer-transform",
+        __codly-args
           .footer-transform
-          .default).get()
+          .default,
+      ).get()
     })
     (
       grid.footer(
@@ -1919,14 +2078,14 @@ snapshot_kind: text
             inset: padding
               .pairs()
               .map((
-                  (
-                    k,
-                    x,
-                  ),
-                ) => (
+                (
                   k,
-                  x * 1.5,
-                ))
+                  x,
+                ),
+              ) => (
+                k,
+                x * 1.5,
+              ))
               .to-dict(),
             fill: (
               x,
@@ -1964,14 +2123,14 @@ snapshot_kind: text
           inset: padding
             .pairs()
             .map((
-                (
-                  k,
-                  x,
-                ),
-              ) => (
+              (
                 k,
-                x * 1.5,
-              ))
+                x,
+              ),
+            ) => (
+              k,
+              x * 1.5,
+            ))
             .to-dict(),
           stroke: none,
           align: (
@@ -2012,14 +2171,14 @@ snapshot_kind: text
           inset: padding
             .pairs()
             .map((
-                (
-                  k,
-                  x,
-                ),
-              ) => (
+              (
                 k,
-                x * 1.5,
-              ))
+                x,
+              ),
+            ) => (
+              k,
+              x * 1.5,
+            ))
             .to-dict(),
           stroke: none,
           align: (
@@ -2114,9 +2273,12 @@ snapshot_kind: text
     )(if "reference-sep" in extra {
       extra.reference-sep
     } else {
-      state("codly-reference-sep", __codly-args
+      state(
+        "codly-reference-sep",
+        __codly-args
           .reference-sep
-          .default).get()
+          .default,
+      ).get()
     })
     let (
       tag,
@@ -2142,9 +2304,12 @@ snapshot_kind: text
     )(if "reference-sep" in extra {
       extra.reference-sep
     } else {
-      state("codly-reference-sep", __codly-args
+      state(
+        "codly-reference-sep",
+        __codly-args
           .reference-sep
-          .default).get()
+          .default,
+      ).get()
     })
     let (
       num,
@@ -2168,7 +2333,10 @@ snapshot_kind: text
     )
     let lab = label(
       segments
-        .slice(0, -1)
+        .slice(
+          0,
+          -1,
+        )
         .join(":"),
     )
 
@@ -2179,9 +2347,12 @@ snapshot_kind: text
     )(if "reference-sep" in extra {
       extra.reference-sep
     } else {
-      state("codly-reference-sep", __codly-args
+      state(
+        "codly-reference-sep",
+        __codly-args
           .reference-sep
-          .default).get()
+          .default,
+      ).get()
     })
 
     let reference-number-format = (
@@ -2191,9 +2362,12 @@ snapshot_kind: text
     )(if "reference-number-format" in extra {
       extra.reference-number-format
     } else {
-      state("codly-reference-number-format", __codly-args
+      state(
+        "codly-reference-number-format",
+        __codly-args
           .reference-number-format
-          .default).get()
+          .default,
+      ).get()
     })
 
     link(
@@ -2270,8 +2444,14 @@ snapshot_kind: text
   if nested {
     let extra = args.named()
     context {
-      let current = state("codly-extra-args", (:)).get()
-      state("codly-extra-args", (:)).update(old => {
+      let current = state(
+        "codly-extra-args",
+        (:),
+      ).get()
+      state(
+        "codly-extra-args",
+        (:),
+      ).update(old => {
         old + extra
       })
 

--- a/tests/snapshots/assets__check_file@packages-codly.typ-0.snap
+++ b/tests/snapshots/assets__check_file@packages-codly.typ-0.snap
@@ -453,28 +453,28 @@ snapshot_kind: text
           x.line
         ))
         .map(x => {
-        if not "start" in x or x.start == none {
-          x.insert(
-            "start",
-            0,
-          )
-        }
+          if not "start" in x or x.start == none {
+            x.insert(
+              "start",
+              0,
+            )
+          }
 
-        if not "end" in x or x.end == none {
-          x.insert(
-            "end",
-            999999999,
-          )
-        }
+          if not "end" in x or x.end == none {
+            x.insert(
+              "end",
+              999999999,
+            )
+          }
 
-        if not "fill" in x {
-          x.insert(
-            "fill",
-            default-color,
-          )
-        }
-        x
-      })
+          if not "fill" in x {
+            x.insert(
+              "fill",
+              default-color,
+            )
+          }
+          x
+        })
     }
   }
 
@@ -564,9 +564,9 @@ snapshot_kind: text
         let indent = first
           .text
           .slice(
-          match.start,
-          match.end,
-        )
+            match.start,
+            match.end,
+          )
         width = measure([#indent]).width
       }
     }
@@ -1376,32 +1376,32 @@ snapshot_kind: text
           x.start
         ))
         .map(x => {
-        if (
-          not "end" in x
-        ) or x.end == none {
-          x.insert(
-            "end",
-            x.start,
-          )
-        }
-
-        if (
-          not "content" in x
-        ) {
-          x.insert(
-            "content",
-            none,
-          )
-        }
-
-        if "label" in x {
-          if block-label == none {
-            panic("codly: label " + str(x.label) + " is only allowed in a figure block")
+          if (
+            not "end" in x
+          ) or x.end == none {
+            x.insert(
+              "end",
+              x.start,
+            )
           }
-        }
 
-        x
-      })
+          if (
+            not "content" in x
+          ) {
+            x.insert(
+              "content",
+              none,
+            )
+          }
+
+          if "label" in x {
+            if block-label == none {
+              panic("codly: label " + str(x.label) + " is only allowed in a figure block")
+            }
+          }
+
+          x
+        })
     }
 
     // Check for overlapping annotations.
@@ -1432,8 +1432,8 @@ snapshot_kind: text
     ))
     .map(measure)
     .map(x => (
-    x.width
-  ))
+      x.width
+    ))
   let num = annotation-format(
     annotations.len(),
   )

--- a/tests/snapshots/assets__check_file@packages-codly.typ-120.snap
+++ b/tests/snapshots/assets__check_file@packages-codly.typ-120.snap
@@ -928,7 +928,7 @@ snapshot_kind: text
 
   // Get the height of an individual line.
   let line-height = measure(
-    raw.line(1, 1, "Hello, World!", [Hello, World!])
+    raw.line(1, 1, "Hello, World!", [Hello, World!]),
   ).height + padding.top + padding.bottom
 
   let items = ()

--- a/tests/snapshots/assets__check_file@packages-codly.typ-120.snap
+++ b/tests/snapshots/assets__check_file@packages-codly.typ-120.snap
@@ -299,20 +299,22 @@ snapshot_kind: text
     if highlights == none {
       ()
     } else {
-      highlights.sorted(key: x => x.line).map(x => {
-        if not "start" in x or x.start == none {
-          x.insert("start", 0)
-        }
+      highlights
+        .sorted(key: x => x.line)
+        .map(x => {
+          if not "start" in x or x.start == none {
+            x.insert("start", 0)
+          }
 
-        if not "end" in x or x.end == none {
-          x.insert("end", 999999999)
-        }
+          if not "end" in x or x.end == none {
+            x.insert("end", 999999999)
+          }
 
-        if not "fill" in x {
-          x.insert("fill", default-color)
-        }
-        x
-      })
+          if not "fill" in x {
+            x.insert("fill", default-color)
+          }
+          x
+        })
     }
   }
 
@@ -874,23 +876,25 @@ snapshot_kind: text
     annotations = if annotations == none {
       ()
     } else {
-      annotations.sorted(key: x => x.start).map(x => {
-        if (not "end" in x) or x.end == none {
-          x.insert("end", x.start)
-        }
-
-        if (not "content" in x) {
-          x.insert("content", none)
-        }
-
-        if "label" in x {
-          if block-label == none {
-            panic("codly: label " + str(x.label) + " is only allowed in a figure block")
+      annotations
+        .sorted(key: x => x.start)
+        .map(x => {
+          if (not "end" in x) or x.end == none {
+            x.insert("end", x.start)
           }
-        }
 
-        x
-      })
+          if (not "content" in x) {
+            x.insert("content", none)
+          }
+
+          if "label" in x {
+            if block-label == none {
+              panic("codly: label " + str(x.label) + " is only allowed in a figure block")
+            }
+          }
+
+          x
+        })
     }
 
     // Check for overlapping annotations.

--- a/tests/snapshots/assets__check_file@packages-codly.typ-40.snap
+++ b/tests/snapshots/assets__check_file@packages-codly.typ-40.snap
@@ -192,7 +192,10 @@ snapshot_kind: text
   position,
   length,
 ) = {
-  state("codly-skips", ()).update(skips => {
+  state(
+    "codly-skips",
+    (),
+  ).update(skips => {
     if skips == none {
       skips = ()
     }
@@ -303,9 +306,12 @@ snapshot_kind: text
   )(if "highlight-stroke" in extra {
     extra.highlight-stroke
   } else {
-    state("codly-highlight-stroke", __codly-args
+    state(
+      "codly-highlight-stroke",
+      __codly-args
         .highlight-stroke
-        .default).get()
+        .default,
+    ).get()
   })
 
   let highlight-fill = (
@@ -315,9 +321,12 @@ snapshot_kind: text
   )(if "highlight-fill" in extra {
     extra.highlight-fill
   } else {
-    state("codly-highlight-fill", __codly-args
+    state(
+      "codly-highlight-fill",
+      __codly-args
         .highlight-fill
-        .default).get()
+        .default,
+    ).get()
   })
 
   let highlight-radius = (
@@ -327,9 +336,12 @@ snapshot_kind: text
   )(if "highlight-radius" in extra {
     extra.highlight-radius
   } else {
-    state("codly-highlight-radius", __codly-args
+    state(
+      "codly-highlight-radius",
+      __codly-args
         .highlight-radius
-        .default).get()
+        .default,
+    ).get()
   })
 
   let highlight-inset = (
@@ -339,9 +351,12 @@ snapshot_kind: text
   )(if "highlight-inset" in extra {
     extra.highlight-inset
   } else {
-    state("codly-highlight-inset", __codly-args
+    state(
+      "codly-highlight-inset",
+      __codly-args
         .highlight-inset
-        .default).get()
+        .default,
+    ).get()
   })
 
   let default-color = (
@@ -351,9 +366,12 @@ snapshot_kind: text
   )(if "default-color" in extra {
     extra.default-color
   } else {
-    state("codly-default-color", __codly-args
+    state(
+      "codly-default-color",
+      __codly-args
         .default-color
-        .default).get()
+        .default,
+    ).get()
   })
 
   let highlights = {
@@ -362,9 +380,10 @@ snapshot_kind: text
     )(if "highlights" in extra {
       extra.highlights
     } else {
-      state("codly-highlights", __codly-args
-          .highlights
-          .default).get()
+      state(
+        "codly-highlights",
+        __codly-args.highlights.default,
+      ).get()
     })
     if highlights == none {
       ()
@@ -403,9 +422,10 @@ snapshot_kind: text
   )(if "smart-indent" in extra {
     extra.smart-indent
   } else {
-    state("codly-smart-indent", __codly-args
-        .smart-indent
-        .default).get()
+    state(
+      "codly-smart-indent",
+      __codly-args.smart-indent.default,
+    ).get()
   })
   let body = if it
     .body
@@ -544,9 +564,9 @@ snapshot_kind: text
       } else if elem.has("child") and elem.has("styles") {
         get-flattened-body(elem.child)
           .map(x => (elem.func())(
-              x,
-              elem.styles,
-            ))
+            x,
+            elem.styles,
+          ))
           .flatten()
       } else if elem.has("text") {
         // Separate the whitespaces at the start of text
@@ -608,9 +628,12 @@ snapshot_kind: text
         )(if "reference-by" in extra {
           extra.reference-by
         } else {
-          state("codly-reference-by", __codly-args
+          state(
+            "codly-reference-by",
+            __codly-args
               .reference-by
-              .default).get()
+              .default,
+          ).get()
         })
         let reference-sep = (
           __codly-args
@@ -619,9 +642,12 @@ snapshot_kind: text
         )(if "reference-sep" in extra {
           extra.reference-sep
         } else {
-          state("codly-reference-sep", __codly-args
+          state(
+            "codly-reference-sep",
+            __codly-args
               .reference-sep
-              .default).get()
+              .default,
+          ).get()
         })
 
         let referenced = if reference-by == "line" {
@@ -632,9 +658,12 @@ snapshot_kind: text
           )(if "reference-number-format" in extra {
             extra.reference-number-format
           } else {
-            state("codly-reference-number-format", __codly-args
+            state(
+              "codly-reference-number-format",
+              __codly-args
                 .reference-number-format
-                .default).get()
+                .default,
+            ).get()
           })
 
           reference-number-format(it.number)
@@ -770,9 +799,10 @@ snapshot_kind: text
   )(if "enabled" in extra {
     extra.enabled
   } else {
-    state("codly-enabled", __codly-args
-        .enabled
-        .default).get()
+    state(
+      "codly-enabled",
+      __codly-args.enabled.default,
+    ).get()
   })
 
   if not enabled {
@@ -785,9 +815,10 @@ snapshot_kind: text
   )(if "range" in extra {
     extra.range
   } else {
-    state("codly-range", __codly-args
-        .range
-        .default).get()
+    state(
+      "codly-range",
+      __codly-args.range.default,
+    ).get()
   })
 
   let ranges = (
@@ -795,9 +826,10 @@ snapshot_kind: text
   )(if "ranges" in extra {
     extra.ranges
   } else {
-    state("codly-ranges", __codly-args
-        .ranges
-        .default).get()
+    state(
+      "codly-ranges",
+      __codly-args.ranges.default,
+    ).get()
   })
 
   if ranges == none and range != none {
@@ -843,9 +875,10 @@ snapshot_kind: text
   )(if "display-name" in extra {
     extra.display-name
   } else {
-    state("codly-display-name", __codly-args
-        .display-name
-        .default).get()
+    state(
+      "codly-display-name",
+      __codly-args.display-name.default,
+    ).get()
   })
 
   let display-icons = (
@@ -853,9 +886,10 @@ snapshot_kind: text
   )(if "display-icon" in extra {
     extra.display-icon
   } else {
-    state("codly-display-icon", __codly-args
-        .display-icon
-        .default).get()
+    state(
+      "codly-display-icon",
+      __codly-args.display-icon.default,
+    ).get()
   })
 
   let lang-outset = (
@@ -863,9 +897,10 @@ snapshot_kind: text
   )(if "lang-outset" in extra {
     extra.lang-outset
   } else {
-    state("codly-lang-outset", __codly-args
-        .lang-outset
-        .default).get()
+    state(
+      "codly-lang-outset",
+      __codly-args.lang-outset.default,
+    ).get()
   })
 
   let language-block = {
@@ -876,9 +911,12 @@ snapshot_kind: text
     )(if "lang-format" in extra {
       extra.lang-format
     } else {
-      state("codly-lang-format", __codly-args
+      state(
+        "codly-lang-format",
+        __codly-args
           .lang-format
-          .default).get()
+          .default,
+      ).get()
     })
 
     if fn == none {
@@ -896,9 +934,12 @@ snapshot_kind: text
   )(if "default-color" in extra {
     extra.default-color
   } else {
-    state("codly-default-color", __codly-args
+    state(
+      "codly-default-color",
+      __codly-args
         .default-color
-        .default).get()
+        .default,
+    ).get()
   })
 
   let radius = (
@@ -906,9 +947,10 @@ snapshot_kind: text
   )(if "radius" in extra {
     extra.radius
   } else {
-    state("codly-radius", __codly-args
-        .radius
-        .default).get()
+    state(
+      "codly-radius",
+      __codly-args.radius.default,
+    ).get()
   })
 
   let offset = (
@@ -916,9 +958,10 @@ snapshot_kind: text
   )(if "offset" in extra {
     extra.offset
   } else {
-    state("codly-offset", __codly-args
-        .offset
-        .default).get()
+    state(
+      "codly-offset",
+      __codly-args.offset.default,
+    ).get()
   })
 
   let stroke = (
@@ -926,9 +969,10 @@ snapshot_kind: text
   )(if "stroke" in extra {
     extra.stroke
   } else {
-    state("codly-stroke", __codly-args
-        .stroke
-        .default).get()
+    state(
+      "codly-stroke",
+      __codly-args.stroke.default,
+    ).get()
   })
 
   let zebra-color = (
@@ -936,9 +980,10 @@ snapshot_kind: text
   )(if "zebra-fill" in extra {
     extra.zebra-fill
   } else {
-    state("codly-zebra-fill", __codly-args
-        .zebra-fill
-        .default).get()
+    state(
+      "codly-zebra-fill",
+      __codly-args.zebra-fill.default,
+    ).get()
   })
 
   let numbers-format = (
@@ -948,9 +993,12 @@ snapshot_kind: text
   )(if "number-format" in extra {
     extra.number-format
   } else {
-    state("codly-number-format", __codly-args
+    state(
+      "codly-number-format",
+      __codly-args
         .number-format
-        .default).get()
+        .default,
+    ).get()
   })
 
   let numbers-alignment = (
@@ -958,9 +1006,10 @@ snapshot_kind: text
   )(if "number-align" in extra {
     extra.number-align
   } else {
-    state("codly-number-align", __codly-args
-        .number-align
-        .default).get()
+    state(
+      "codly-number-align",
+      __codly-args.number-align.default,
+    ).get()
   })
 
   let padding = __codly-inset(
@@ -969,9 +1018,10 @@ snapshot_kind: text
     )(if "inset" in extra {
       extrainset
     } else {
-      state("codly-inset", __codly-args
-          .inset
-          .default).get()
+      state(
+        "codly-inset",
+        __codly-args.inset.default,
+      ).get()
     }),
   )
 
@@ -980,9 +1030,10 @@ snapshot_kind: text
   )(if "breakable" in extra {
     extra.breakable
   } else {
-    state("codly-breakable", __codly-args
-        .breakable
-        .default).get()
+    state(
+      "codly-breakable",
+      __codly-args.breakable.default,
+    ).get()
   })
 
   let fill = (
@@ -990,9 +1041,10 @@ snapshot_kind: text
   )(if "fill" in extra {
     extra.fill
   } else {
-    state("codly-fill", __codly-args
-        .fill
-        .default).get()
+    state(
+      "codly-fill",
+      __codly-args.fill.default,
+    ).get()
   })
 
   let skips = {
@@ -1001,9 +1053,10 @@ snapshot_kind: text
     )(if "skips" in extra {
       extra.skips
     } else {
-      state("codly-skips", __codly-args
-          .skips
-          .default).get()
+      state(
+        "codly-skips",
+        __codly-args.skips.default,
+      ).get()
     })
     if skips == none {
       ()
@@ -1019,9 +1072,10 @@ snapshot_kind: text
   )(if "skip-line" in extra {
     extra.skip-line
   } else {
-    state("codly-skip-line", __codly-args
-        .skip-line
-        .default).get()
+    state(
+      "codly-skip-line",
+      __codly-args.skip-line.default,
+    ).get()
   })
 
   let skip-number = (
@@ -1029,9 +1083,10 @@ snapshot_kind: text
   )(if "skip-number" in extra {
     extra.skip-number
   } else {
-    state("codly-skip-number", __codly-args
-        .skip-number
-        .default).get()
+    state(
+      "codly-skip-number",
+      __codly-args.skip-number.default,
+    ).get()
   })
 
   let reference-by = (
@@ -1039,9 +1094,10 @@ snapshot_kind: text
   )(if "reference-by" in extra {
     extra.reference-by
   } else {
-    state("codly-reference-by", __codly-args
-        .reference-by
-        .default).get()
+    state(
+      "codly-reference-by",
+      __codly-args.reference-by.default,
+    ).get()
   })
 
   if not reference-by in (
@@ -1058,9 +1114,12 @@ snapshot_kind: text
   )(if "reference-sep" in extra {
     extra.reference-sep
   } else {
-    state("codly-reference-sep", __codly-args
+    state(
+      "codly-reference-sep",
+      __codly-args
         .reference-sep
-        .default).get()
+        .default,
+    ).get()
   })
 
   let reference-number-format = (
@@ -1070,9 +1129,12 @@ snapshot_kind: text
   )(if "reference-number-format" in extra {
     extra.reference-number-format
   } else {
-    state("codly-reference-number-format", __codly-args
+    state(
+      "codly-reference-number-format",
+      __codly-args
         .reference-number-format
-        .default).get()
+        .default,
+    ).get()
   })
 
   let annotation-format = {
@@ -1083,9 +1145,12 @@ snapshot_kind: text
     )(if "annotation-format" in extra {
       extra.annotation-format
     } else {
-      state("codly-annotation-format", __codly-args
+      state(
+        "codly-annotation-format",
+        __codly-args
           .annotation-format
-          .default).get()
+          .default,
+      ).get()
     })
     if fn == none {
       _ => none
@@ -1102,9 +1167,12 @@ snapshot_kind: text
     )(if "annotations" in extra {
       extra.annotations
     } else {
-      state("codly-annotations", __codly-args
+      state(
+        "codly-annotations",
+        __codly-args
           .annotations
-          .default).get()
+          .default,
+      ).get()
     })
     annotations = if annotations == none {
       ()
@@ -1161,9 +1229,9 @@ snapshot_kind: text
   )
   let lr-width = if annotations.len() > 0 {
     measure(math.lr(
-        "}",
-        size: 5em,
-      ) + num).width
+      "}",
+      size: 5em,
+    ) + num).width
   } else {
     0pt
   }
@@ -1180,7 +1248,7 @@ snapshot_kind: text
       1,
       "Hello, World!",
       [Hello, World!],
-    )
+    ),
   ).height + padding.top + padding.bottom
 
   let items = ()
@@ -1195,9 +1263,10 @@ snapshot_kind: text
   )(if "header" in extra {
     extra.header
   } else {
-    state("codly-header", __codly-args
-        .header
-        .default).get()
+    state(
+      "codly-header",
+      __codly-args.header.default,
+    ).get()
   })
   let header-repeat = (
     __codly-args
@@ -1206,9 +1275,12 @@ snapshot_kind: text
   )(if "header-repeat" in extra {
     extra.header-repeat
   } else {
-    state("codly-header-repeat", __codly-args
+    state(
+      "codly-header-repeat",
+      __codly-args
         .header-repeat
-        .default).get()
+        .default,
+    ).get()
   })
 
   // The language block (icon + name)
@@ -1217,9 +1289,10 @@ snapshot_kind: text
   )(if "languages" in extra {
     extra.languages
   } else {
-    state("codly-languages", __codly-args
-        .languages
-        .default).get()
+    state(
+      "codly-languages",
+      __codly-args.languages.default,
+    ).get()
   })
   let language-block = if it.lang == none {
     none
@@ -1251,9 +1324,12 @@ snapshot_kind: text
       )(if "lang-radius" in extra {
         extra.lang-radius
       } else {
-        state("codly-lang-radius", __codly-args
+        state(
+          "codly-lang-radius",
+          __codly-args
             .lang-radius
-            .default).get()
+            .default,
+        ).get()
       })
       let padding = __codly-inset(
         (
@@ -1263,9 +1339,12 @@ snapshot_kind: text
         )(if "lang-inset" in extra {
           extra.lang-inset
         } else {
-          state("codly-lang-inset", __codly-args
+          state(
+            "codly-lang-inset",
+            __codly-args
               .lang-inset
-              .default).get()
+              .default,
+          ).get()
         }),
       )
 
@@ -1276,9 +1355,12 @@ snapshot_kind: text
       )(if "lang-stroke" in extra {
         extra.lang-stroke
       } else {
-        state("codly-lang-stroke", __codly-args
+        state(
+          "codly-lang-stroke",
+          __codly-args
             .lang-stroke
-            .default).get()
+            .default,
+        ).get()
       })
       let lang-fill = (
         __codly-args
@@ -1287,9 +1369,12 @@ snapshot_kind: text
       )(if "lang-fill" in extra {
         extra.lang-fill
       } else {
-        state("codly-lang-fill", __codly-args
+        state(
+          "codly-lang-fill",
+          __codly-args
             .lang-fill
-            .default).get()
+            .default,
+        ).get()
       })
 
       let fill = if type(lang-fill) == function {
@@ -1340,9 +1425,12 @@ snapshot_kind: text
       )(if "lang-radius" in extra {
         extra.lang-radius
       } else {
-        state("codly-lang-radius", __codly-args
+        state(
+          "codly-lang-radius",
+          __codly-args
             .lang-radius
-            .default).get()
+            .default,
+        ).get()
       })
 
       let padding = __codly-inset(
@@ -1353,9 +1441,12 @@ snapshot_kind: text
         )(if "lang-inset" in extra {
           extra.lang-inset
         } else {
-          state("codly-lang-inset", __codly-args
+          state(
+            "codly-lang-inset",
+            __codly-args
               .lang-inset
-              .default).get()
+              .default,
+          ).get()
         }),
       )
 
@@ -1366,9 +1457,12 @@ snapshot_kind: text
       )(if "lang-stroke" in extra {
         extra.lang-stroke
       } else {
-        state("codly-lang-stroke", __codly-args
+        state(
+          "codly-lang-stroke",
+          __codly-args
             .lang-stroke
-            .default).get()
+            .default,
+        ).get()
       })
 
       let lang-fill = (
@@ -1378,9 +1472,12 @@ snapshot_kind: text
       )(if "lang-fill" in extra {
         extra.lang-fill
       } else {
-        state("codly-lang-fill", __codly-args
+        state(
+          "codly-lang-fill",
+          __codly-args
             .lang-fill
-            .default).get()
+            .default,
+        ).get()
       })
 
       let fill = if type(lang-fill) == function {
@@ -1441,9 +1538,12 @@ snapshot_kind: text
     )(if "header-cell-args" in extra {
       extra.header-cell-args
     } else {
-      state("codly-header-cell-args", __codly-args
+      state(
+        "codly-header-cell-args",
+        __codly-args
           .header-cell-args
-          .default).get()
+          .default,
+      ).get()
     })
     let transform = (
       __codly-args
@@ -1452,9 +1552,12 @@ snapshot_kind: text
     )(if "header-transform" in extra {
       extra.header-transform
     } else {
-      state("codly-header-transform", __codly-args
+      state(
+        "codly-header-transform",
+        __codly-args
           .header-transform
-          .default).get()
+          .default,
+      ).get()
     })
     (
       grid.header(
@@ -1621,9 +1724,10 @@ snapshot_kind: text
   )(if "footer" in extra {
     extra.footer
   } else {
-    state("codly-footer", __codly-args
-        .footer
-        .default).get()
+    state(
+      "codly-footer",
+      __codly-args.footer.default,
+    ).get()
   })
   let footer-repeat = (
     __codly-args
@@ -1632,9 +1736,12 @@ snapshot_kind: text
   )(if "footer-repeat" in extra {
     extra.footer-repeat
   } else {
-    state("codly-footer-repeat", __codly-args
+    state(
+      "codly-footer-repeat",
+      __codly-args
         .footer-repeat
-        .default).get()
+        .default,
+    ).get()
   })
   let footer = if footer != none {
     let footer-args = (
@@ -1644,9 +1751,12 @@ snapshot_kind: text
     )(if "footer-cell-args" in extra {
       extra.footer-cell-args
     } else {
-      state("codly-footer-cell-args", __codly-args
+      state(
+        "codly-footer-cell-args",
+        __codly-args
           .footer-cell-args
-          .default).get()
+          .default,
+      ).get()
     })
     let transform = (
       __codly-args
@@ -1655,9 +1765,12 @@ snapshot_kind: text
     )(if "footer-transform" in extra {
       extra.footer-transform
     } else {
-      state("codly-footer-transform", __codly-args
+      state(
+        "codly-footer-transform",
+        __codly-args
           .footer-transform
-          .default).get()
+          .default,
+      ).get()
     })
     (
       grid.footer(
@@ -1702,9 +1815,9 @@ snapshot_kind: text
             inset: padding
               .pairs()
               .map(((k, x)) => (
-                  k,
-                  x * 1.5,
-                ))
+                k,
+                x * 1.5,
+              ))
               .to-dict(),
             fill: (
               x,
@@ -1735,9 +1848,9 @@ snapshot_kind: text
           inset: padding
             .pairs()
             .map(((k, x)) => (
-                k,
-                x * 1.5,
-              ))
+              k,
+              x * 1.5,
+            ))
             .to-dict(),
           stroke: none,
           align: (
@@ -1773,9 +1886,9 @@ snapshot_kind: text
           inset: padding
             .pairs()
             .map(((k, x)) => (
-                k,
-                x * 1.5,
-              ))
+              k,
+              x * 1.5,
+            ))
             .to-dict(),
           stroke: none,
           align: (
@@ -1857,9 +1970,12 @@ snapshot_kind: text
     )(if "reference-sep" in extra {
       extra.reference-sep
     } else {
-      state("codly-reference-sep", __codly-args
+      state(
+        "codly-reference-sep",
+        __codly-args
           .reference-sep
-          .default).get()
+          .default,
+      ).get()
     })
     let (
       tag,
@@ -1885,9 +2001,12 @@ snapshot_kind: text
     )(if "reference-sep" in extra {
       extra.reference-sep
     } else {
-      state("codly-reference-sep", __codly-args
+      state(
+        "codly-reference-sep",
+        __codly-args
           .reference-sep
-          .default).get()
+          .default,
+      ).get()
     })
     let (
       num,
@@ -1920,9 +2039,12 @@ snapshot_kind: text
     )(if "reference-sep" in extra {
       extra.reference-sep
     } else {
-      state("codly-reference-sep", __codly-args
+      state(
+        "codly-reference-sep",
+        __codly-args
           .reference-sep
-          .default).get()
+          .default,
+      ).get()
     })
 
     let reference-number-format = (
@@ -1932,9 +2054,12 @@ snapshot_kind: text
     )(if "reference-number-format" in extra {
       extra.reference-number-format
     } else {
-      state("codly-reference-number-format", __codly-args
+      state(
+        "codly-reference-number-format",
+        __codly-args
           .reference-number-format
-          .default).get()
+          .default,
+      ).get()
     })
 
     link(
@@ -2011,8 +2136,14 @@ snapshot_kind: text
   if nested {
     let extra = args.named()
     context {
-      let current = state("codly-extra-args", (:)).get()
-      state("codly-extra-args", (:)).update(old => {
+      let current = state(
+        "codly-extra-args",
+        (:),
+      ).get()
+      state(
+        "codly-extra-args",
+        (:),
+      ).update(old => {
         old + extra
       })
 

--- a/tests/snapshots/assets__check_file@packages-codly.typ-40.snap
+++ b/tests/snapshots/assets__check_file@packages-codly.typ-40.snap
@@ -391,22 +391,22 @@ snapshot_kind: text
       highlights
         .sorted(key: x => x.line)
         .map(x => {
-        if not "start" in x or x.start == none {
-          x.insert("start", 0)
-        }
+          if not "start" in x or x.start == none {
+            x.insert("start", 0)
+          }
 
-        if not "end" in x or x.end == none {
-          x.insert("end", 999999999)
-        }
+          if not "end" in x or x.end == none {
+            x.insert("end", 999999999)
+          }
 
-        if not "fill" in x {
-          x.insert(
-            "fill",
-            default-color,
-          )
-        }
-        x
-      })
+          if not "fill" in x {
+            x.insert(
+              "fill",
+              default-color,
+            )
+          }
+          x
+        })
     }
   }
 
@@ -479,10 +479,9 @@ snapshot_kind: text
         let indent = match.end - match.start
 
         // Then measure the necessary indent.
-        let indent = first.text.slice(
-          match.start,
-          match.end,
-        )
+        let indent = first
+          .text
+          .slice(match.start, match.end)
         width = measure([#indent]).width
       }
     }
@@ -1180,24 +1179,24 @@ snapshot_kind: text
       annotations
         .sorted(key: x => x.start)
         .map(x => {
-        if (
-          not "end" in x
-        ) or x.end == none {
-          x.insert("end", x.start)
-        }
-
-        if (not "content" in x) {
-          x.insert("content", none)
-        }
-
-        if "label" in x {
-          if block-label == none {
-            panic("codly: label " + str(x.label) + " is only allowed in a figure block")
+          if (
+            not "end" in x
+          ) or x.end == none {
+            x.insert("end", x.start)
           }
-        }
 
-        x
-      })
+          if (not "content" in x) {
+            x.insert("content", none)
+          }
+
+          if "label" in x {
+            if block-label == none {
+              panic("codly: label " + str(x.label) + " is only allowed in a figure block")
+            }
+          }
+
+          x
+        })
     }
 
     // Check for overlapping annotations.

--- a/tests/snapshots/assets__check_file@packages-codly.typ-80.snap
+++ b/tests/snapshots/assets__check_file@packages-codly.typ-80.snap
@@ -299,20 +299,22 @@ snapshot_kind: text
     if highlights == none {
       ()
     } else {
-      highlights.sorted(key: x => x.line).map(x => {
-        if not "start" in x or x.start == none {
-          x.insert("start", 0)
-        }
+      highlights
+        .sorted(key: x => x.line)
+        .map(x => {
+          if not "start" in x or x.start == none {
+            x.insert("start", 0)
+          }
 
-        if not "end" in x or x.end == none {
-          x.insert("end", 999999999)
-        }
+          if not "end" in x or x.end == none {
+            x.insert("end", 999999999)
+          }
 
-        if not "fill" in x {
-          x.insert("fill", default-color)
-        }
-        x
-      })
+          if not "fill" in x {
+            x.insert("fill", default-color)
+          }
+          x
+        })
     }
   }
 
@@ -897,23 +899,25 @@ snapshot_kind: text
     annotations = if annotations == none {
       ()
     } else {
-      annotations.sorted(key: x => x.start).map(x => {
-        if (not "end" in x) or x.end == none {
-          x.insert("end", x.start)
-        }
-
-        if (not "content" in x) {
-          x.insert("content", none)
-        }
-
-        if "label" in x {
-          if block-label == none {
-            panic("codly: label " + str(x.label) + " is only allowed in a figure block")
+      annotations
+        .sorted(key: x => x.start)
+        .map(x => {
+          if (not "end" in x) or x.end == none {
+            x.insert("end", x.start)
           }
-        }
 
-        x
-      })
+          if (not "content" in x) {
+            x.insert("content", none)
+          }
+
+          if "label" in x {
+            if block-label == none {
+              panic("codly: label " + str(x.label) + " is only allowed in a figure block")
+            }
+          }
+
+          x
+        })
     }
 
     // Check for overlapping annotations.

--- a/tests/snapshots/assets__check_file@packages-codly.typ-80.snap
+++ b/tests/snapshots/assets__check_file@packages-codly.typ-80.snap
@@ -513,9 +513,10 @@ snapshot_kind: text
           )(if "reference-number-format" in extra {
             extra.reference-number-format
           } else {
-            state("codly-reference-number-format", __codly-args
-                .reference-number-format
-                .default).get()
+            state(
+              "codly-reference-number-format",
+              __codly-args.reference-number-format.default,
+            ).get()
           })
 
           reference-number-format(it.number)
@@ -861,9 +862,10 @@ snapshot_kind: text
   )(if "reference-number-format" in extra {
     extra.reference-number-format
   } else {
-    state("codly-reference-number-format", __codly-args
-        .reference-number-format
-        .default).get()
+    state(
+      "codly-reference-number-format",
+      __codly-args.reference-number-format.default,
+    ).get()
   })
 
   let annotation-format = {
@@ -872,9 +874,10 @@ snapshot_kind: text
     )(if "annotation-format" in extra {
       extra.annotation-format
     } else {
-      state("codly-annotation-format", __codly-args
-          .annotation-format
-          .default).get()
+      state(
+        "codly-annotation-format",
+        __codly-args.annotation-format.default,
+      ).get()
     })
     if fn == none {
       _ => none
@@ -951,7 +954,7 @@ snapshot_kind: text
 
   // Get the height of an individual line.
   let line-height = measure(
-    raw.line(1, 1, "Hello, World!", [Hello, World!])
+    raw.line(1, 1, "Hello, World!", [Hello, World!]),
   ).height + padding.top + padding.bottom
 
   let items = ()
@@ -1140,18 +1143,20 @@ snapshot_kind: text
     )(if "header-cell-args" in extra {
       extra.header-cell-args
     } else {
-      state("codly-header-cell-args", __codly-args
-          .header-cell-args
-          .default).get()
+      state(
+        "codly-header-cell-args",
+        __codly-args.header-cell-args.default,
+      ).get()
     })
     let transform = (
       __codly-args.header-transform.type_check
     )(if "header-transform" in extra {
       extra.header-transform
     } else {
-      state("codly-header-transform", __codly-args
-          .header-transform
-          .default).get()
+      state(
+        "codly-header-transform",
+        __codly-args.header-transform.default,
+      ).get()
     })
     (
       grid.header(
@@ -1305,18 +1310,20 @@ snapshot_kind: text
     )(if "footer-cell-args" in extra {
       extra.footer-cell-args
     } else {
-      state("codly-footer-cell-args", __codly-args
-          .footer-cell-args
-          .default).get()
+      state(
+        "codly-footer-cell-args",
+        __codly-args.footer-cell-args.default,
+      ).get()
     })
     let transform = (
       __codly-args.footer-transform.type_check
     )(if "footer-transform" in extra {
       extra.footer-transform
     } else {
-      state("codly-footer-transform", __codly-args
-          .footer-transform
-          .default).get()
+      state(
+        "codly-footer-transform",
+        __codly-args.footer-transform.default,
+      ).get()
     })
     (
       grid.footer(
@@ -1509,9 +1516,10 @@ snapshot_kind: text
     )(if "reference-number-format" in extra {
       extra.reference-number-format
     } else {
-      state("codly-reference-number-format", __codly-args
-          .reference-number-format
-          .default).get()
+      state(
+        "codly-reference-number-format",
+        __codly-args.reference-number-format.default,
+      ).get()
     })
 
     link(

--- a/tests/snapshots/assets__check_file@packages-fletcher-diagram.typ-0.snap
+++ b/tests/snapshots/assets__check_file@packages-fletcher-diagram.typ-0.snap
@@ -283,7 +283,10 @@ snapshot_kind: text
 ) = {
   // (x: (c1x, c2x, ...), y: ...)
   let centers = array
-    .zip(grid.cell-sizes, grid.spacing)
+    .zip(
+      grid.cell-sizes,
+      grid.spacing,
+    )
     .map((
     (
       sizes,
@@ -291,9 +294,13 @@ snapshot_kind: text
     ),
   ) => {
     array
-      .zip(cumsum(sizes), sizes, range(
+      .zip(
+        cumsum(sizes),
+        sizes,
+        range(
           sizes.len(),
-        ))
+        ),
+      )
       .map((
       (
         end,
@@ -306,7 +313,10 @@ snapshot_kind: text
   })
 
   let bounding-size = array
-    .zip(centers, grid.cell-sizes)
+    .zip(
+      centers,
+      grid.cell-sizes,
+    )
     .map((
     (
       centers,
@@ -468,10 +478,13 @@ snapshot_kind: text
       item,
     ) in row.enumerate() {
       if not is-space(item) {
-        nodes.push(node((
+        nodes.push(node(
+          (
             x,
             y,
-          ), $item$).value)
+          ),
+          $item$,
+        ).value)
       }
     }
   }
@@ -764,7 +777,9 @@ snapshot_kind: text
   box(context {
     let options = options
 
-    options.em-size = measure(h(1em)).width
+    options.em-size = measure(
+      h(1em),
+    ).width
     let to-pt(
       len,
     ) = to-abs-length(
@@ -812,10 +827,10 @@ snapshot_kind: text
     // nodes and edges whose uv coordinates can be resolved without knowing the grid
     let rects-affecting-grid = nodes
       .filter(node => (
-          not is-nan-vector(node
-            .pos
-            .uv)
-        ))
+        not is-nan-vector(node
+          .pos
+          .uv)
+      ))
       .map(node => (
       center: node
         .pos
@@ -825,14 +840,14 @@ snapshot_kind: text
 
     let vertices-affecting-grid = edges
       .map(edge => {
-          resolve-edge-vertices(
-            edge,
-            ctx: ctx-with-uv-anchors + (
-              target-system: "uv",
-            ),
-            nodes,
-          )
-        })
+        resolve-edge-vertices(
+          edge,
+          ctx: ctx-with-uv-anchors + (
+            target-system: "uv",
+          ),
+          nodes,
+        )
+      })
       .join() + () // coerce none to ()
     vertices-affecting-grid = vertices-affecting-grid.filter(vert => (
       not is-nan-vector(vert)

--- a/tests/snapshots/assets__check_file@packages-fletcher-diagram.typ-0.snap
+++ b/tests/snapshots/assets__check_file@packages-fletcher-diagram.typ-0.snap
@@ -245,13 +245,13 @@ snapshot_kind: text
       cell-sizes
         .at(axis)
         .at(
-        indices.at(axis),
-      ) = calc.max(
+          indices.at(axis),
+        ) = calc.max(
         cell-sizes
           .at(axis)
           .at(
-          indices.at(axis),
-        ),
+            indices.at(axis),
+          ),
         rect
           .size
           .at(axis),
@@ -288,29 +288,29 @@ snapshot_kind: text
       grid.spacing,
     )
     .map((
-    (
-      sizes,
-      spacing,
-    ),
-  ) => {
-    array
-      .zip(
-        cumsum(sizes),
-        sizes,
-        range(
-          sizes.len(),
-        ),
-      )
-      .map((
       (
-        end,
-        size,
-        i,
+        sizes,
+        spacing,
       ),
-    ) => (
-      end - size / 2 + spacing * i
-    ))
-  })
+    ) => {
+      array
+        .zip(
+          cumsum(sizes),
+          sizes,
+          range(
+            sizes.len(),
+          ),
+        )
+        .map((
+          (
+            end,
+            size,
+            i,
+          ),
+        ) => (
+          end - size / 2 + spacing * i
+        ))
+    })
 
   let bounding-size = array
     .zip(
@@ -318,13 +318,13 @@ snapshot_kind: text
       grid.cell-sizes,
     )
     .map((
-    (
-      centers,
-      sizes,
-    ),
-  ) => (
-    centers.at(-1) + sizes.at(-1) / 2
-  ))
+      (
+        centers,
+        sizes,
+      ),
+    ) => (
+      centers.at(-1) + sizes.at(-1) / 2
+    ))
 
   (
     centers: centers,
@@ -359,15 +359,15 @@ snapshot_kind: text
     .cell-sizes
     .zip(options.cell-size)
     .map((
-    (
-      sizes,
-      min-size,
-    ),
-  ) => sizes.map(
-    calc
-      .max
-      .with(min-size),
-  ))
+      (
+        sizes,
+        min-size,
+      ),
+    ) => sizes.map(
+      calc
+        .max
+        .with(min-size),
+    ))
 
   grid += compute-cell-centers(grid)
 
@@ -832,11 +832,11 @@ snapshot_kind: text
           .uv)
       ))
       .map(node => (
-      center: node
-        .pos
-        .uv,
-      size: node.size,
-    ))
+        center: node
+          .pos
+          .uv,
+        size: node.size,
+      ))
 
     let vertices-affecting-grid = edges
       .map(edge => {

--- a/tests/snapshots/assets__check_file@packages-fletcher-diagram.typ-120.snap
+++ b/tests/snapshots/assets__check_file@packages-fletcher-diagram.typ-120.snap
@@ -157,9 +157,11 @@ snapshot_kind: text
 /// -> dictionary
 #let compute-cell-centers(grid) = {
   // (x: (c1x, c2x, ...), y: ...)
-  let centers = array.zip(grid.cell-sizes, grid.spacing).map(((sizes, spacing)) => {
-    array.zip(cumsum(sizes), sizes, range(sizes.len())).map(((end, size, i)) => end - size / 2 + spacing * i)
-  })
+  let centers = array
+    .zip(grid.cell-sizes, grid.spacing)
+    .map(((sizes, spacing)) => {
+      array.zip(cumsum(sizes), sizes, range(sizes.len())).map(((end, size, i)) => end - size / 2 + spacing * i)
+    })
 
   let bounding-size = array.zip(centers, grid.cell-sizes).map(((centers, sizes)) => centers.at(-1) + sizes.at(-1) / 2)
 
@@ -184,9 +186,10 @@ snapshot_kind: text
   grid += compute-cell-sizes(grid, verts, rects)
 
   // enforce minimum cell size
-  grid.cell-sizes = grid.cell-sizes.zip(options.cell-size).map(((sizes, min-size)) => sizes.map(
-    calc.max.with(min-size),
-  ))
+  grid.cell-sizes = grid
+    .cell-sizes
+    .zip(options.cell-size)
+    .map(((sizes, min-size)) => sizes.map(calc.max.with(min-size)))
 
   grid += compute-cell-centers(grid)
 
@@ -510,10 +513,9 @@ snapshot_kind: text
 
 
     // nodes and edges whose uv coordinates can be resolved without knowing the grid
-    let rects-affecting-grid = nodes.filter(node => not is-nan-vector(node.pos.uv)).map(node => (
-      center: node.pos.uv,
-      size: node.size,
-    ))
+    let rects-affecting-grid = nodes
+      .filter(node => not is-nan-vector(node.pos.uv))
+      .map(node => (center: node.pos.uv, size: node.size))
 
     let vertices-affecting-grid = edges
       .map(edge => {

--- a/tests/snapshots/assets__check_file@packages-fletcher-diagram.typ-120.snap
+++ b/tests/snapshots/assets__check_file@packages-fletcher-diagram.typ-120.snap
@@ -517,8 +517,8 @@ snapshot_kind: text
 
     let vertices-affecting-grid = edges
       .map(edge => {
-          resolve-edge-vertices(edge, ctx: ctx-with-uv-anchors + (target-system: "uv"), nodes)
-        })
+        resolve-edge-vertices(edge, ctx: ctx-with-uv-anchors + (target-system: "uv"), nodes)
+      })
       .join() + () // coerce none to ()
     vertices-affecting-grid = vertices-affecting-grid.filter(vert => not is-nan-vector(vert))
 

--- a/tests/snapshots/assets__check_file@packages-fletcher-diagram.typ-40.snap
+++ b/tests/snapshots/assets__check_file@packages-fletcher-diagram.typ-40.snap
@@ -214,9 +214,11 @@ snapshot_kind: text
     .zip(grid.cell-sizes, grid.spacing)
     .map(((sizes, spacing)) => {
     array
-      .zip(cumsum(sizes), sizes, range(
-          sizes.len(),
-        ))
+      .zip(
+        cumsum(sizes),
+        sizes,
+        range(sizes.len()),
+      )
       .map(((end, size, i)) => (
       end - size / 2 + spacing * i
     ))
@@ -328,10 +330,10 @@ snapshot_kind: text
   for (y, row) in matrix.enumerate() {
     for (x, item) in row.enumerate() {
       if not is-space(item) {
-        nodes.push(node((
-            x,
-            y,
-          ), $item$).value)
+        nodes.push(node(
+          (x, y),
+          $item$,
+        ).value)
       }
     }
   }
@@ -611,7 +613,9 @@ snapshot_kind: text
   box(context {
     let options = options
 
-    options.em-size = measure(h(1em)).width
+    options.em-size = measure(
+      h(1em),
+    ).width
     let to-pt(len) = to-abs-length(
       len,
       options.em-size,
@@ -657,8 +661,8 @@ snapshot_kind: text
     // nodes and edges whose uv coordinates can be resolved without knowing the grid
     let rects-affecting-grid = nodes
       .filter(node => (
-          not is-nan-vector(node.pos.uv)
-        ))
+        not is-nan-vector(node.pos.uv)
+      ))
       .map(node => (
       center: node.pos.uv,
       size: node.size,
@@ -666,14 +670,14 @@ snapshot_kind: text
 
     let vertices-affecting-grid = edges
       .map(edge => {
-          resolve-edge-vertices(
-            edge,
-            ctx: ctx-with-uv-anchors + (
-              target-system: "uv",
-            ),
-            nodes,
-          )
-        })
+        resolve-edge-vertices(
+          edge,
+          ctx: ctx-with-uv-anchors + (
+            target-system: "uv",
+          ),
+          nodes,
+        )
+      })
       .join() + () // coerce none to ()
     vertices-affecting-grid = vertices-affecting-grid.filter(vert => (
       not is-nan-vector(vert)

--- a/tests/snapshots/assets__check_file@packages-fletcher-diagram.typ-40.snap
+++ b/tests/snapshots/assets__check_file@packages-fletcher-diagram.typ-40.snap
@@ -178,12 +178,14 @@ snapshot_kind: text
       let size = if grid.flip.xy {
         rect.size.at(axis)
       } else { rect.size.at(1 - axis) }
-      cell-sizes.at(axis).at(
-        indices.at(axis),
-      ) = calc.max(
-        cell-sizes.at(axis).at(
+      cell-sizes
+        .at(axis)
+        .at(
           indices.at(axis),
-        ),
+        ) = calc.max(
+        cell-sizes
+          .at(axis)
+          .at(indices.at(axis)),
         rect.size.at(axis),
       )
     }
@@ -213,22 +215,22 @@ snapshot_kind: text
   let centers = array
     .zip(grid.cell-sizes, grid.spacing)
     .map(((sizes, spacing)) => {
-    array
-      .zip(
-        cumsum(sizes),
-        sizes,
-        range(sizes.len()),
-      )
-      .map(((end, size, i)) => (
-      end - size / 2 + spacing * i
-    ))
-  })
+      array
+        .zip(
+          cumsum(sizes),
+          sizes,
+          range(sizes.len()),
+        )
+        .map(((end, size, i)) => (
+          end - size / 2 + spacing * i
+        ))
+    })
 
   let bounding-size = array
     .zip(centers, grid.cell-sizes)
     .map(((centers, sizes)) => (
-    centers.at(-1) + sizes.at(-1) / 2
-  ))
+      centers.at(-1) + sizes.at(-1) / 2
+    ))
 
   (
     centers: centers,
@@ -263,10 +265,10 @@ snapshot_kind: text
     .cell-sizes
     .zip(options.cell-size)
     .map((
-    (sizes, min-size),
-  ) => sizes.map(
-    calc.max.with(min-size),
-  ))
+      (sizes, min-size),
+    ) => sizes.map(
+      calc.max.with(min-size),
+    ))
 
   grid += compute-cell-centers(grid)
 
@@ -664,9 +666,9 @@ snapshot_kind: text
         not is-nan-vector(node.pos.uv)
       ))
       .map(node => (
-      center: node.pos.uv,
-      size: node.size,
-    ))
+        center: node.pos.uv,
+        size: node.size,
+      ))
 
     let vertices-affecting-grid = edges
       .map(edge => {

--- a/tests/snapshots/assets__check_file@packages-fletcher-diagram.typ-80.snap
+++ b/tests/snapshots/assets__check_file@packages-fletcher-diagram.typ-80.snap
@@ -532,12 +532,12 @@ snapshot_kind: text
 
     let vertices-affecting-grid = edges
       .map(edge => {
-          resolve-edge-vertices(
-            edge,
-            ctx: ctx-with-uv-anchors + (target-system: "uv"),
-            nodes,
-          )
-        })
+        resolve-edge-vertices(
+          edge,
+          ctx: ctx-with-uv-anchors + (target-system: "uv"),
+          nodes,
+        )
+      })
       .join() + () // coerce none to ()
     vertices-affecting-grid = vertices-affecting-grid.filter(vert => (
       not is-nan-vector(vert)

--- a/tests/snapshots/assets__check_file@packages-fletcher-diagram.typ-80.snap
+++ b/tests/snapshots/assets__check_file@packages-fletcher-diagram.typ-80.snap
@@ -162,17 +162,17 @@ snapshot_kind: text
 /// -> dictionary
 #let compute-cell-centers(grid) = {
   // (x: (c1x, c2x, ...), y: ...)
-  let centers = array.zip(grid.cell-sizes, grid.spacing).map((
-    (sizes, spacing),
-  ) => {
-    array.zip(cumsum(sizes), sizes, range(sizes.len())).map((
-      (end, size, i),
-    ) => end - size / 2 + spacing * i)
-  })
+  let centers = array
+    .zip(grid.cell-sizes, grid.spacing)
+    .map(((sizes, spacing)) => {
+      array
+        .zip(cumsum(sizes), sizes, range(sizes.len()))
+        .map(((end, size, i)) => end - size / 2 + spacing * i)
+    })
 
-  let bounding-size = array.zip(centers, grid.cell-sizes).map((
-    (centers, sizes),
-  ) => centers.at(-1) + sizes.at(-1) / 2)
+  let bounding-size = array
+    .zip(centers, grid.cell-sizes)
+    .map(((centers, sizes)) => centers.at(-1) + sizes.at(-1) / 2)
 
   (
     centers: centers,
@@ -195,9 +195,10 @@ snapshot_kind: text
   grid += compute-cell-sizes(grid, verts, rects)
 
   // enforce minimum cell size
-  grid.cell-sizes = grid.cell-sizes.zip(options.cell-size).map((
-    (sizes, min-size),
-  ) => sizes.map(calc.max.with(min-size)))
+  grid.cell-sizes = grid
+    .cell-sizes
+    .zip(options.cell-size)
+    .map(((sizes, min-size)) => sizes.map(calc.max.with(min-size)))
 
   grid += compute-cell-centers(grid)
 

--- a/tests/snapshots/assets__check_file@packages-fletcher-draw.typ-0.snap
+++ b/tests/snapshots/assets__check_file@packages-fletcher-draw.typ-0.snap
@@ -508,7 +508,10 @@ snapshot_kind: text
     let (
       δ-start,
       δ-stop,
-    ) = cap-offsets(edge, shift).map(arclen => (
+    ) = cap-offsets(
+      edge,
+      shift,
+    ).map(arclen => (
       -bend-dir * arclen / radius * 1rad
     ))
 
@@ -673,7 +676,10 @@ snapshot_kind: text
 
   let rounded-corners
   if edge.corner-radius != none {
-    rounded-corners = range(1, θs.len()).map(calculate-rounded-corner)
+    rounded-corners = range(
+      1,
+      θs.len(),
+    ).map(calculate-rounded-corner)
   }
 
   let lerp-scale(
@@ -831,12 +837,12 @@ snapshot_kind: text
     marks += edge
       .marks
       .map(mark => {
-          mark.pos = lerp-scale(
-            mark.pos,
-            i,
-          )
-          mark
-        })
+        mark.pos = lerp-scale(
+          mark.pos,
+          i,
+        )
+        mark
+      })
       .filter(mark => (
       mark.pos != none
     ))
@@ -927,15 +933,15 @@ snapshot_kind: text
     let anchor-points = anchor-names
       .map(calculate-anchors)
       .map(point => {
-          // funky disagreement between coordinate systems??
-          point.at(1) *= -1
-          vector-2d(
-            vector.scale(
-              point,
-              1cm,
-            ),
-          )
-        })
+        // funky disagreement between coordinate systems??
+        point.at(1) *= -1
+        vector-2d(
+          vector.scale(
+            point,
+            1cm,
+          ),
+        )
+      })
       .sorted(key: point => vector-len(
       vector.sub(
         point,
@@ -1755,7 +1761,10 @@ snapshot_kind: text
   ) {
     let snap-to-nodes = edge
       .snap-to
-      .zip(first-last(edge.vertices), first-last(edge.final-vertices))
+      .zip(
+        first-last(edge.vertices),
+        first-last(edge.final-vertices),
+      )
       .enumerate()
       .map((
       (
@@ -1829,16 +1838,16 @@ snapshot_kind: text
   seq
     .children
     .map(child => {
-        if child.func() == metadata {
-          let value = child.value
-          value.post = cetz
-            .draw
-            .hide
-            .with(bounds: bounds)
-          metadata(value)
-        } else {
-          child
-        }
-      })
+      if child.func() == metadata {
+        let value = child.value
+        value.post = cetz
+          .draw
+          .hide
+          .with(bounds: bounds)
+        metadata(value)
+      } else {
+        child
+      }
+    })
     .join()
 }

--- a/tests/snapshots/assets__check_file@packages-fletcher-draw.typ-0.snap
+++ b/tests/snapshots/assets__check_file@packages-fletcher-draw.typ-0.snap
@@ -32,60 +32,60 @@ snapshot_kind: text
       cetz
         .draw
         .group({
-        cetz
-          .draw
-          .translate(node
-          .pos
-          .xyz)
-        for (
-          i,
-          extrude,
-        ) in node
-          .extrude
-          .enumerate() {
           cetz
             .draw
-            .set-style(
-            fill: if i == 0 {
-              node.fill
-            },
-            stroke: node.stroke,
-          )
-          (
-            node.shape
-          )(
-            node,
+            .translate(node
+              .pos
+              .xyz)
+          for (
+            i,
             extrude,
-          )
-        }
-      })
+          ) in node
+            .extrude
+            .enumerate() {
+            cetz
+              .draw
+              .set-style(
+                fill: if i == 0 {
+                  node.fill
+                },
+                stroke: node.stroke,
+              )
+            (
+              node.shape
+            )(
+              node,
+              extrude,
+            )
+          }
+        })
     }
 
     if node.label != none {
       cetz
         .draw
         .content(
-        node
-          .pos
-          .xyz,
-        box(
-          // wrapping label in a box allows user to control its alignment
-          align(
-            center + horizon,
-            node.label,
+          node
+            .pos
+            .xyz,
+          box(
+            // wrapping label in a box allows user to control its alignment
+            align(
+              center + horizon,
+              node.label,
+            ),
+            stroke: if debug >= 3 {
+              DEBUG_COLOR2 + 0.25pt
+            },
+            width: node
+              .size
+              .at(0) - 2 * node.inset,
+            height: node
+              .size
+              .at(1) - 2 * node.inset,
           ),
-          stroke: if debug >= 3 {
-            DEBUG_COLOR2 + 0.25pt
-          },
-          width: node
-            .size
-            .at(0) - 2 * node.inset,
-          height: node
-            .size
-            .at(1) - 2 * node.inset,
-        ),
-        anchor: "center",
-      )
+          anchor: "center",
+        )
     }
   }
 
@@ -93,9 +93,9 @@ snapshot_kind: text
     result = cetz
       .draw
       .on-layer(
-      node.layer,
-      result,
-    )
+        node.layer,
+        result,
+      )
   }
 
   (
@@ -108,13 +108,13 @@ snapshot_kind: text
     cetz
       .draw
       .circle(
-      node
-        .pos
-        .xyz,
-      radius: 0.5pt,
-      fill: DEBUG_COLOR,
-      stroke: none,
-    )
+        node
+          .pos
+          .xyz,
+        radius: 0.5pt,
+        fill: DEBUG_COLOR,
+        stroke: none,
+      )
   }
 
   if debug >= 2 and node.radius != 0pt {
@@ -122,37 +122,37 @@ snapshot_kind: text
     cetz
       .draw
       .rect(
-      ..rect-at(
-        node
-          .pos
-          .xyz,
-        node.size,
-      ),
-      stroke: DEBUG_COLOR + .1pt,
-    )
+        ..rect-at(
+          node
+            .pos
+            .xyz,
+          node.size,
+        ),
+        stroke: DEBUG_COLOR + .1pt,
+      )
 
     // node anchoring outline (what edges snap to)
     cetz
       .draw
       .group({
-      cetz
-        .draw
-        .translate(node
-        .pos
-        .xyz)
-      cetz
-        .draw
-        .set-style(
-        stroke: DEBUG_COLOR2 + 0.25pt,
-        fill: none,
-      )
-      (
-        node.shape
-      )(
-        node,
-        node.outset,
-      )
-    })
+        cetz
+          .draw
+          .translate(node
+            .pos
+            .xyz)
+        cetz
+          .draw
+          .set-style(
+            stroke: DEBUG_COLOR2 + 0.25pt,
+            fill: none,
+          )
+        (
+          node.shape
+        )(
+          node,
+          node.outset,
+        )
+      })
   }
 }
 
@@ -223,33 +223,33 @@ snapshot_kind: text
   cetz
     .draw
     .content(
-    label-pos,
-    box(
-      {
-        set text(edge.label-size)
-        (
-          edge.label-wrapper
-        )(edge)
+      label-pos,
+      box(
+        {
+          set text(edge.label-size)
+          (
+            edge.label-wrapper
+          )(edge)
+        },
+        stroke: if debug >= 2 {
+          DEBUG_COLOR2 + 0.25pt
+        },
+      ),
+      angle: edge.label-angle,
+      anchor: if edge.label-anchor != auto {
+        edge.label-anchor
       },
-      stroke: if debug >= 2 {
-        DEBUG_COLOR2 + 0.25pt
-      },
-    ),
-    angle: edge.label-angle,
-    anchor: if edge.label-anchor != auto {
-      edge.label-anchor
-    },
-  )
+    )
 
   if debug >= 2 {
     cetz
       .draw
       .circle(
-      label-pos,
-      radius: 0.75pt,
-      stroke: none,
-      fill: DEBUG_COLOR2,
-    )
+        label-pos,
+        radius: 0.75pt,
+        stroke: none,
+        fill: DEBUG_COLOR2,
+      )
   }
 }
 
@@ -269,8 +269,8 @@ snapshot_kind: text
     let mark = edge
       .marks
       .find(mark => (
-      calc.abs(mark.pos - pos) < 1e-3
-    ))
+        calc.abs(mark.pos - pos) < 1e-3
+      ))
     if mark == none {
       return 0pt
     }
@@ -320,8 +320,8 @@ snapshot_kind: text
     edge
       .marks
       .find(mark => (
-      calc.abs(mark.pos - t) < 1e-3
-    )) != none
+        calc.abs(mark.pos - t) < 1e-3
+      )) != none
   )
 
   let decor = edge
@@ -384,36 +384,36 @@ snapshot_kind: text
     )
       .zip(offsets)
       .map((
-      (
-        point,
-        offset,
-      ),
-    ) => {
-      // Shift line sideways (for multi-stroke effect)
-      point = (
-        rel: (
-          θ + 90deg,
-          shift,
-        ),
-        to: point,
-      )
-      // Shift end points lengthways depending on marks
-      point = (
-        rel: (
-          θ,
+        (
+          point,
           offset,
         ),
-        to: point,
-      )
-      point
-    })
+      ) => {
+        // Shift line sideways (for multi-stroke effect)
+        point = (
+          rel: (
+            θ + 90deg,
+            shift,
+          ),
+          to: point,
+        )
+        // Shift end points lengthways depending on marks
+        point = (
+          rel: (
+            θ,
+            offset,
+          ),
+          to: point,
+        )
+        point
+      })
 
     let obj = cetz
       .draw
       .line(
-      ..points,
-      stroke: edge.stroke,
-    )
+        ..points,
+        stroke: edge.stroke,
+      )
 
     with-decorations(
       edge,
@@ -518,13 +518,13 @@ snapshot_kind: text
     let obj = cetz
       .draw
       .arc(
-      center,
-      radius: radius + shift,
-      start: start + δ-start,
-      stop: stop + δ-stop,
-      anchor: "origin",
-      stroke: edge.stroke,
-    )
+        center,
+        radius: radius + shift,
+        start: start + δ-start,
+        stop: stop + δ-stop,
+        anchor: "origin",
+        stroke: edge.stroke,
+      )
 
     with-decorations(
       edge,
@@ -802,28 +802,28 @@ snapshot_kind: text
             cetz
               .draw
               .arc(
-              arc-center,
-              radius: arc-radius - d,
-              start: start,
-              delta: delta,
-              anchor: "origin",
-              stroke: stroke-with-phase(phase + Δphase),
-            )
+                arc-center,
+                radius: arc-radius - d,
+                start: start,
+                delta: delta,
+                anchor: "origin",
+                stroke: stroke-with-phase(phase + Δphase),
+              )
           }
 
           if debug >= 4 {
             cetz
               .draw
               .on-layer(
-              1,
-              cetz
-                .draw
-                .circle(
-                arc-center,
-                radius: arc-radius - d,
-                stroke: debug-stroke,
-              ),
-            )
+                1,
+                cetz
+                  .draw
+                  .circle(
+                    arc-center,
+                    radius: arc-radius - d,
+                    stroke: debug-stroke,
+                  ),
+              )
           }
         }
 
@@ -844,8 +844,8 @@ snapshot_kind: text
         mark
       })
       .filter(mark => (
-      mark.pos != none
-    ))
+        mark.pos != none
+      ))
 
     let label-pos = lerp-scale(
       edge.label-pos,
@@ -884,9 +884,9 @@ snapshot_kind: text
     cetz
       .draw
       .line(
-      ..verts,
-      stroke: debug-stroke,
-    )
+        ..verts,
+        stroke: debug-stroke,
+      )
   }
 }
 
@@ -914,48 +914,48 @@ snapshot_kind: text
   cetz
     .draw
     .hide(
-    cetz
-      .draw
-      .intersections(
-      node-name,
-      objects,
-    ),
-  )
+      cetz
+        .draw
+        .intersections(
+          node-name,
+          objects,
+        ),
+    )
 
   cetz
     .draw
     .get-ctx(ctx => {
-    let calculate-anchors = ctx
-      .nodes
-      .at(node-name)
-      .anchors
-    let anchor-names = calculate-anchors(())
-    let anchor-points = anchor-names
-      .map(calculate-anchors)
-      .map(point => {
-        // funky disagreement between coordinate systems??
-        point.at(1) *= -1
-        vector-2d(
-          vector.scale(
+      let calculate-anchors = ctx
+        .nodes
+        .at(node-name)
+        .anchors
+      let anchor-names = calculate-anchors(())
+      let anchor-points = anchor-names
+        .map(calculate-anchors)
+        .map(point => {
+          // funky disagreement between coordinate systems??
+          point.at(1) *= -1
+          vector-2d(
+            vector.scale(
+              point,
+              1cm,
+            ),
+          )
+        })
+        .sorted(key: point => vector-len(
+          vector.sub(
             point,
-            1cm,
+            target,
           ),
-        )
-      })
-      .sorted(key: point => vector-len(
-      vector.sub(
-        point,
-        target,
-      ),
-    ))
+        ))
 
-    let anchor = anchor-points.at(
-      -1,
-      default: target,
-    )
+      let anchor = anchor-points.at(
+        -1,
+        default: target,
+      )
 
-    callback(anchor)
-  })
+      callback(anchor)
+    })
 }
 
 #let find-anchor-pair(
@@ -996,31 +996,31 @@ snapshot_kind: text
   let outline = cetz
     .draw
     .group({
-    cetz
-      .draw
-      .translate(node
-      .pos
-      .xyz)
-    (
-      node.shape
-    )(
-      node,
-      node.outset,
-    )
-  })
+      cetz
+        .draw
+        .translate(node
+          .pos
+          .xyz)
+      (
+        node.shape
+      )(
+        node,
+        node.outset,
+      )
+    })
   let dummy-line = cetz
     .draw
     .line(
-    node
-      .pos
-      .xyz,
-    (
-      rel: (
-        θ,
-        10 * node.radius,
+      node
+        .pos
+        .xyz,
+      (
+        rel: (
+          θ,
+          10 * node.radius,
+        ),
       ),
-    ),
-  )
+    )
 
   find-farthest-intersection(
     outline + dummy-line,
@@ -1119,9 +1119,9 @@ snapshot_kind: text
   let dummy-line = cetz
     .draw
     .line(
-    from,
-    to,
-  )
+      from,
+      to,
+    )
 
   let intersection-objects = nodes.map(nodes => {
     for node in (
@@ -1130,18 +1130,18 @@ snapshot_kind: text
       cetz
         .draw
         .group({
-        cetz
-          .draw
-          .translate(node
-          .pos
-          .xyz)
-        (
-          node.shape
-        )(
-          node,
-          node.outset,
-        )
-      })
+          cetz
+            .draw
+            .translate(node
+              .pos
+              .xyz)
+          (
+            node.shape
+          )(
+            node,
+            node.outset,
+          )
+        })
     }
     // if node == none { return }
     dummy-line
@@ -1193,53 +1193,53 @@ snapshot_kind: text
   )
     .zip(θs)
     .map((
-    (
-      point,
-      φ,
-    ),
-  ) => cetz
-    .draw
-    .line(
-    point,
-    vector.add(
-      point,
-      vector-polar(
-        10cm,
+      (
+        point,
         φ,
       ),
-    ), // ray emanating from node
-  ))
+    ) => cetz
+      .draw
+      .line(
+        point,
+        vector.add(
+          point,
+          vector-polar(
+            10cm,
+            φ,
+          ),
+        ), // ray emanating from node
+      ))
 
   let intersection-objects = nodes
     .zip(dummy-lines)
     .map((
-    (
-      nodes,
-      dummy-line,
-    ),
-  ) => {
-    for node in (
-      nodes
-    ) {
-      cetz
-        .draw
-        .group({
+      (
+        nodes,
+        dummy-line,
+      ),
+    ) => {
+      for node in (
+        nodes
+      ) {
         cetz
           .draw
-          .translate(node
-          .pos
-          .xyz)
-        (
-          node.shape
-        )(
-          node,
-          node.outset,
-        )
-      })
-    }
-    // if node == none { return }
-    dummy-line
-  })
+          .group({
+            cetz
+              .draw
+              .translate(node
+                .pos
+                .xyz)
+            (
+              node.shape
+            )(
+              node,
+              node.outset,
+            )
+          })
+      }
+      // if node == none { return }
+      dummy-line
+    })
 
   find-anchor-pair(
     intersection-objects,
@@ -1290,9 +1290,9 @@ snapshot_kind: text
     edge
       .final-vertices
       .slice(
-      0,
-      2,
-    ), // first two vertices
+        0,
+        2,
+      ), // first two vertices
     edge
       .final-vertices
       .slice(-2), // last two vertices
@@ -1305,33 +1305,33 @@ snapshot_kind: text
   let intersection-objects = nodes
     .zip(dummy-lines)
     .map((
-    (
-      nodes,
-      dummy-line,
-    ),
-  ) => {
-    for node in (
-      nodes
-    ) {
-      cetz
-        .draw
-        .group({
+      (
+        nodes,
+        dummy-line,
+      ),
+    ) => {
+      for node in (
+        nodes
+      ) {
         cetz
           .draw
-          .translate(node
-          .pos
-          .xyz)
-        (
-          node.shape
-        )(
-          node,
-          node.outset,
-        )
-      })
-    }
-    // if node == none { return }
-    dummy-line
-  })
+          .group({
+            cetz
+              .draw
+              .translate(node
+                .pos
+                .xyz)
+            (
+              node.shape
+            )(
+              node,
+              node.outset,
+            )
+          })
+      }
+      // if node == none { return }
+      dummy-line
+    })
 
   find-anchor-pair(
     intersection-objects,
@@ -1393,9 +1393,9 @@ snapshot_kind: text
     obj = cetz
       .draw
       .on-layer(
-      edge.layer,
-      obj,
-    )
+        edge.layer,
+        obj,
+      )
   }
 
   obj
@@ -1767,26 +1767,26 @@ snapshot_kind: text
       )
       .enumerate()
       .map((
-      (
-        i,
         (
-          given,
-          raw,
-          xyz,
+          i,
+          (
+            given,
+            raw,
+            xyz,
+          ),
         ),
-      ),
-    ) => {
-      let key = map-auto(
-        given,
-        if type(raw) == label {
-          raw
-        } else {
-          xyz
-        },
-      )
-      let node = node-finder(key)
-      node
-    })
+      ) => {
+        let key = map-auto(
+          given,
+          if type(raw) == label {
+            raw
+          } else {
+            xyz
+          },
+        )
+        let node = node-finder(key)
+        node
+      })
     draw-edge(
       edge,
       snap-to-nodes,

--- a/tests/snapshots/assets__check_file@packages-fletcher-draw.typ-120.snap
+++ b/tests/snapshots/assets__check_file@packages-fletcher-draw.typ-120.snap
@@ -468,9 +468,9 @@ snapshot_kind: text
     marks += edge
       .marks
       .map(mark => {
-          mark.pos = lerp-scale(mark.pos, i)
-          mark
-        })
+        mark.pos = lerp-scale(mark.pos, i)
+        mark
+      })
       .filter(mark => mark.pos != none)
 
     let label-pos = lerp-scale(edge.label-pos, i)
@@ -522,10 +522,10 @@ snapshot_kind: text
     let anchor-points = anchor-names
       .map(calculate-anchors)
       .map(point => {
-          // funky disagreement between coordinate systems??
-          point.at(1) *= -1
-          vector-2d(vector.scale(point, 1cm))
-        })
+        // funky disagreement between coordinate systems??
+        point.at(1) *= -1
+        vector-2d(vector.scale(point, 1cm))
+      })
       .sorted(key: point => vector-len(vector.sub(point, target)))
 
     let anchor = anchor-points.at(-1, default: target)
@@ -884,13 +884,13 @@ snapshot_kind: text
   seq
     .children
     .map(child => {
-        if child.func() == metadata {
-          let value = child.value
-          value.post = cetz.draw.hide.with(bounds: bounds)
-          metadata(value)
-        } else {
-          child
-        }
-      })
+      if child.func() == metadata {
+        let value = child.value
+        value.post = cetz.draw.hide.with(bounds: bounds)
+        metadata(value)
+      } else {
+        child
+      }
+    })
     .join()
 }

--- a/tests/snapshots/assets__check_file@packages-fletcher-draw.typ-120.snap
+++ b/tests/snapshots/assets__check_file@packages-fletcher-draw.typ-120.snap
@@ -24,30 +24,36 @@ snapshot_kind: text
 #let draw-node(node, debug: 0) = {
   let result = {
     if node.stroke != none or node.fill != none {
-      cetz.draw.group({
-        cetz.draw.translate(node.pos.xyz)
-        for (i, extrude) in node.extrude.enumerate() {
-          cetz.draw.set-style(
-            fill: if i == 0 { node.fill },
-            stroke: node.stroke,
-          )
-          (node.shape)(node, extrude)
-        }
-      })
+      cetz
+        .draw
+        .group({
+          cetz.draw.translate(node.pos.xyz)
+          for (i, extrude) in node.extrude.enumerate() {
+            cetz
+              .draw
+              .set-style(
+                fill: if i == 0 { node.fill },
+                stroke: node.stroke,
+              )
+            (node.shape)(node, extrude)
+          }
+        })
     }
 
     if node.label != none {
-      cetz.draw.content(
-        node.pos.xyz,
-        box(
-          // wrapping label in a box allows user to control its alignment
-          align(center + horizon, node.label),
-          stroke: if debug >= 3 { DEBUG_COLOR2 + 0.25pt },
-          width: node.size.at(0) - 2 * node.inset,
-          height: node.size.at(1) - 2 * node.inset,
-        ),
-        anchor: "center",
-      )
+      cetz
+        .draw
+        .content(
+          node.pos.xyz,
+          box(
+            // wrapping label in a box allows user to control its alignment
+            align(center + horizon, node.label),
+            stroke: if debug >= 3 { DEBUG_COLOR2 + 0.25pt },
+            width: node.size.at(0) - 2 * node.inset,
+            height: node.size.at(1) - 2 * node.inset,
+          ),
+          anchor: "center",
+        )
     }
   }
 
@@ -58,30 +64,38 @@ snapshot_kind: text
   // Draw debug stuff
   if debug >= 1 {
     // dot at node anchor
-    cetz.draw.circle(
-      node.pos.xyz,
-      radius: 0.5pt,
-      fill: DEBUG_COLOR,
-      stroke: none,
-    )
+    cetz
+      .draw
+      .circle(
+        node.pos.xyz,
+        radius: 0.5pt,
+        fill: DEBUG_COLOR,
+        stroke: none,
+      )
   }
 
   if debug >= 2 and node.radius != 0pt {
     // node bounding rectangle
-    cetz.draw.rect(
-      ..rect-at(node.pos.xyz, node.size),
-      stroke: DEBUG_COLOR + .1pt,
-    )
+    cetz
+      .draw
+      .rect(
+        ..rect-at(node.pos.xyz, node.size),
+        stroke: DEBUG_COLOR + .1pt,
+      )
 
     // node anchoring outline (what edges snap to)
-    cetz.draw.group({
-      cetz.draw.translate(node.pos.xyz)
-      cetz.draw.set-style(
-        stroke: DEBUG_COLOR2 + 0.25pt,
-        fill: none,
-      )
-      (node.shape)(node, node.outset)
-    })
+    cetz
+      .draw
+      .group({
+        cetz.draw.translate(node.pos.xyz)
+        cetz
+          .draw
+          .set-style(
+            stroke: DEBUG_COLOR2 + 0.25pt,
+            fill: none,
+          )
+        (node.shape)(node, node.outset)
+      })
   }
 }
 
@@ -128,26 +142,30 @@ snapshot_kind: text
 
   let label-pos = (to: curve-point, rel: (θ-normal, -edge.label-sep))
 
-  cetz.draw.content(
-    label-pos,
-    box(
-      {
-        set text(edge.label-size)
-        (edge.label-wrapper)(edge)
-      },
-      stroke: if debug >= 2 { DEBUG_COLOR2 + 0.25pt },
-    ),
-    angle: edge.label-angle,
-    anchor: if edge.label-anchor != auto { edge.label-anchor },
-  )
+  cetz
+    .draw
+    .content(
+      label-pos,
+      box(
+        {
+          set text(edge.label-size)
+          (edge.label-wrapper)(edge)
+        },
+        stroke: if debug >= 2 { DEBUG_COLOR2 + 0.25pt },
+      ),
+      angle: edge.label-angle,
+      anchor: if edge.label-anchor != auto { edge.label-anchor },
+    )
 
   if debug >= 2 {
-    cetz.draw.circle(
-      label-pos,
-      radius: 0.75pt,
-      stroke: none,
-      fill: DEBUG_COLOR2,
-    )
+    cetz
+      .draw
+      .circle(
+        label-pos,
+        radius: 0.75pt,
+        stroke: none,
+        fill: DEBUG_COLOR2,
+      )
   }
 }
 
@@ -211,18 +229,22 @@ snapshot_kind: text
   // Draw line(s), one for each extrusion shift
   for shift in edge.extrude {
     let offsets = cap-offsets(edge, shift)
-    let points = (from, to).zip(offsets).map(((point, offset)) => {
-      // Shift line sideways (for multi-stroke effect)
-      point = (rel: (θ + 90deg, shift), to: point)
-      // Shift end points lengthways depending on marks
-      point = (rel: (θ, offset), to: point)
-      point
-    })
+    let points = (from, to)
+      .zip(offsets)
+      .map(((point, offset)) => {
+        // Shift line sideways (for multi-stroke effect)
+        point = (rel: (θ + 90deg, shift), to: point)
+        // Shift end points lengthways depending on marks
+        point = (rel: (θ, offset), to: point)
+        point
+      })
 
-    let obj = cetz.draw.line(
-      ..points,
-      stroke: edge.stroke,
-    )
+    let obj = cetz
+      .draw
+      .line(
+        ..points,
+        stroke: edge.stroke,
+      )
 
     with-decorations(edge, obj)
   }
@@ -271,14 +293,16 @@ snapshot_kind: text
     // Adjust arc angles to accommodate for cap offsets
     let (δ-start, δ-stop) = cap-offsets(edge, shift).map(arclen => -bend-dir * arclen / radius * 1rad)
 
-    let obj = cetz.draw.arc(
-      center,
-      radius: radius + shift,
-      start: start + δ-start,
-      stop: stop + δ-stop,
-      anchor: "origin",
-      stroke: edge.stroke,
-    )
+    let obj = cetz
+      .draw
+      .arc(
+        center,
+        radius: radius + shift,
+        start: start + δ-start,
+        stop: stop + δ-stop,
+        anchor: "origin",
+        stroke: edge.stroke,
+      )
 
     with-decorations(edge, obj)
   }
@@ -436,25 +460,31 @@ snapshot_kind: text
 
         for d in edge.extrude {
           if delta != 0deg {
-            cetz.draw.arc(
-              arc-center,
-              radius: arc-radius - d,
-              start: start,
-              delta: delta,
-              anchor: "origin",
-              stroke: stroke-with-phase(phase + Δphase),
-            )
+            cetz
+              .draw
+              .arc(
+                arc-center,
+                radius: arc-radius - d,
+                start: start,
+                delta: delta,
+                anchor: "origin",
+                stroke: stroke-with-phase(phase + Δphase),
+              )
           }
 
           if debug >= 4 {
-            cetz.draw.on-layer(
-              1,
-              cetz.draw.circle(
-                arc-center,
-                radius: arc-radius - d,
-                stroke: debug-stroke,
-              ),
-            )
+            cetz
+              .draw
+              .on-layer(
+                1,
+                cetz
+                  .draw
+                  .circle(
+                    arc-center,
+                    radius: arc-radius - d,
+                    stroke: debug-stroke,
+                  ),
+              )
           }
         }
 
@@ -492,10 +522,12 @@ snapshot_kind: text
 
 
   if debug >= 4 {
-    cetz.draw.line(
-      ..verts,
-      stroke: debug-stroke,
-    )
+    cetz
+      .draw
+      .line(
+        ..verts,
+        stroke: debug-stroke,
+      )
   }
 }
 
@@ -516,22 +548,24 @@ snapshot_kind: text
   let node-name = "intersection-finder"
   cetz.draw.hide(cetz.draw.intersections(node-name, objects))
 
-  cetz.draw.get-ctx(ctx => {
-    let calculate-anchors = ctx.nodes.at(node-name).anchors
-    let anchor-names = calculate-anchors(())
-    let anchor-points = anchor-names
-      .map(calculate-anchors)
-      .map(point => {
-        // funky disagreement between coordinate systems??
-        point.at(1) *= -1
-        vector-2d(vector.scale(point, 1cm))
-      })
-      .sorted(key: point => vector-len(vector.sub(point, target)))
+  cetz
+    .draw
+    .get-ctx(ctx => {
+      let calculate-anchors = ctx.nodes.at(node-name).anchors
+      let anchor-names = calculate-anchors(())
+      let anchor-points = anchor-names
+        .map(calculate-anchors)
+        .map(point => {
+          // funky disagreement between coordinate systems??
+          point.at(1) *= -1
+          vector-2d(vector.scale(point, 1cm))
+        })
+        .sorted(key: point => vector-len(vector.sub(point, target)))
 
-    let anchor = anchor-points.at(-1, default: target)
+      let anchor = anchor-points.at(-1, default: target)
 
-    callback(anchor)
-  })
+      callback(anchor)
+    })
 }
 
 #let find-anchor-pair((from-group, to-group), (from-point, to-point), callback) = {
@@ -552,14 +586,18 @@ snapshot_kind: text
 
 /// Get the anchor point around a node outline at a certain angle.
 #let get-node-anchor(node, θ, callback) = {
-  let outline = cetz.draw.group({
-    cetz.draw.translate(node.pos.xyz)
-    (node.shape)(node, node.outset)
-  })
-  let dummy-line = cetz.draw.line(
-    node.pos.xyz,
-    (rel: (θ, 10 * node.radius)),
-  )
+  let outline = cetz
+    .draw
+    .group({
+      cetz.draw.translate(node.pos.xyz)
+      (node.shape)(node, node.outset)
+    })
+  let dummy-line = cetz
+    .draw
+    .line(
+      node.pos.xyz,
+      (rel: (θ, 10 * node.radius)),
+    )
 
   find-farthest-intersection(outline + dummy-line, node.pos.xyz, callback)
 }
@@ -594,17 +632,21 @@ snapshot_kind: text
   }
 
 
-  let dummy-line = cetz.draw.line(
-    from,
-    to,
-  )
+  let dummy-line = cetz
+    .draw
+    .line(
+      from,
+      to,
+    )
 
   let intersection-objects = nodes.map(nodes => {
     for node in nodes {
-      cetz.draw.group({
-        cetz.draw.translate(node.pos.xyz)
-        (node.shape)(node, node.outset)
-      })
+      cetz
+        .draw
+        .group({
+          cetz.draw.translate(node.pos.xyz)
+          (node.shape)(node, node.outset)
+        })
     }
     // if node == none { return }
     dummy-line
@@ -632,21 +674,29 @@ snapshot_kind: text
   let θ = angle-between(from, to)
   let θs = (θ + edge.bend, θ - edge.bend + 180deg)
 
-  let dummy-lines = (from, to).zip(θs).map(((point, φ)) => cetz.draw.line(
-    point,
-    vector.add(point, vector-polar(10cm, φ)), // ray emanating from node
-  ))
+  let dummy-lines = (from, to)
+    .zip(θs)
+    .map(((point, φ)) => cetz
+      .draw
+      .line(
+        point,
+        vector.add(point, vector-polar(10cm, φ)), // ray emanating from node
+      ))
 
-  let intersection-objects = nodes.zip(dummy-lines).map(((nodes, dummy-line)) => {
-    for node in nodes {
-      cetz.draw.group({
-        cetz.draw.translate(node.pos.xyz)
-        (node.shape)(node, node.outset)
-      })
-    }
-    // if node == none { return }
-    dummy-line
-  })
+  let intersection-objects = nodes
+    .zip(dummy-lines)
+    .map(((nodes, dummy-line)) => {
+      for node in nodes {
+        cetz
+          .draw
+          .group({
+            cetz.draw.translate(node.pos.xyz)
+            (node.shape)(node, node.outset)
+          })
+      }
+      // if node == none { return }
+      dummy-line
+    })
 
   find-anchor-pair(
     intersection-objects,
@@ -671,16 +721,20 @@ snapshot_kind: text
 
   let dummy-lines = end-segments.map(points => cetz.draw.line(..points))
 
-  let intersection-objects = nodes.zip(dummy-lines).map(((nodes, dummy-line)) => {
-    for node in nodes {
-      cetz.draw.group({
-        cetz.draw.translate(node.pos.xyz)
-        (node.shape)(node, node.outset)
-      })
-    }
-    // if node == none { return }
-    dummy-line
-  })
+  let intersection-objects = nodes
+    .zip(dummy-lines)
+    .map(((nodes, dummy-line)) => {
+      for node in nodes {
+        cetz
+          .draw
+          .group({
+            cetz.draw.translate(node.pos.xyz)
+            (node.shape)(node, node.outset)
+          })
+      }
+      // if node == none { return }
+      dummy-line
+    })
 
   find-anchor-pair(
     intersection-objects,
@@ -843,13 +897,15 @@ snapshot_kind: text
   let node-finder = find-snapping-nodes.with(grid, nodes)
   let first-last(x) = (x.at(0), x.at(-1))
   for edge in edges {
-    let snap-to-nodes = edge.snap-to.zip(first-last(edge.vertices), first-last(edge.final-vertices)).enumerate().map((
-      (i, (given, raw, xyz)),
-    ) => {
-      let key = map-auto(given, if type(raw) == label { raw } else { xyz })
-      let node = node-finder(key)
-      node
-    })
+    let snap-to-nodes = edge
+      .snap-to
+      .zip(first-last(edge.vertices), first-last(edge.final-vertices))
+      .enumerate()
+      .map(((i, (given, raw, xyz))) => {
+        let key = map-auto(given, if type(raw) == label { raw } else { xyz })
+        let node = node-finder(key)
+        node
+      })
     draw-edge(edge, snap-to-nodes, debug: debug)
   }
 

--- a/tests/snapshots/assets__check_file@packages-fletcher-draw.typ-40.snap
+++ b/tests/snapshots/assets__check_file@packages-fletcher-draw.typ-40.snap
@@ -367,10 +367,10 @@ snapshot_kind: text
   // Draw arc(s), one for each extrusion shift
   for shift in edge.extrude {
     // Adjust arc angles to accommodate for cap offsets
-    let (
-      δ-start,
-      δ-stop,
-    ) = cap-offsets(edge, shift).map(arclen => (
+    let (δ-start, δ-stop) = cap-offsets(
+      edge,
+      shift,
+    ).map(arclen => (
       -bend-dir * arclen / radius * 1rad
     ))
 
@@ -507,7 +507,10 @@ snapshot_kind: text
 
   let rounded-corners
   if edge.corner-radius != none {
-    rounded-corners = range(1, θs.len()).map(calculate-rounded-corner)
+    rounded-corners = range(
+      1,
+      θs.len(),
+    ).map(calculate-rounded-corner)
   }
 
   let lerp-scale(t, i) = {
@@ -640,12 +643,12 @@ snapshot_kind: text
     marks += edge
       .marks
       .map(mark => {
-          mark.pos = lerp-scale(
-            mark.pos,
-            i,
-          )
-          mark
-        })
+        mark.pos = lerp-scale(
+          mark.pos,
+          i,
+        )
+        mark
+      })
       .filter(mark => mark.pos != none)
 
     let label-pos = lerp-scale(
@@ -721,12 +724,12 @@ snapshot_kind: text
     let anchor-points = anchor-names
       .map(calculate-anchors)
       .map(point => {
-          // funky disagreement between coordinate systems??
-          point.at(1) *= -1
-          vector-2d(
-            vector.scale(point, 1cm),
-          )
-        })
+        // funky disagreement between coordinate systems??
+        point.at(1) *= -1
+        vector-2d(
+          vector.scale(point, 1cm),
+        )
+      })
       .sorted(key: point => vector-len(
       vector.sub(point, target),
     ))
@@ -1308,7 +1311,10 @@ snapshot_kind: text
   for edge in edges {
     let snap-to-nodes = edge
       .snap-to
-      .zip(first-last(edge.vertices), first-last(edge.final-vertices))
+      .zip(
+        first-last(edge.vertices),
+        first-last(edge.final-vertices),
+      )
       .enumerate()
       .map(((i, (given, raw, xyz))) => {
       let key = map-auto(
@@ -1363,16 +1369,16 @@ snapshot_kind: text
   seq
     .children
     .map(child => {
-        if child.func() == metadata {
-          let value = child.value
-          value.post = cetz
-            .draw
-            .hide
-            .with(bounds: bounds)
-          metadata(value)
-        } else {
-          child
-        }
-      })
+      if child.func() == metadata {
+        let value = child.value
+        value.post = cetz
+          .draw
+          .hide
+          .with(bounds: bounds)
+        metadata(value)
+      } else {
+        child
+      }
+    })
     .join()
 }

--- a/tests/snapshots/assets__check_file@packages-fletcher-draw.typ-40.snap
+++ b/tests/snapshots/assets__check_file@packages-fletcher-draw.typ-40.snap
@@ -24,53 +24,58 @@ snapshot_kind: text
 #let draw-node(node, debug: 0) = {
   let result = {
     if node.stroke != none or node.fill != none {
-      cetz.draw.group({
-        cetz.draw.translate(node
-          .pos
-          .xyz)
-        for (i, extrude) in node
-          .extrude
-          .enumerate() {
-          cetz.draw.set-style(
-            fill: if i == 0 {
-              node.fill
-            },
-            stroke: node.stroke,
-          )
-          (node.shape)(node, extrude)
-        }
-      })
+      cetz
+        .draw
+        .group({
+          cetz
+            .draw
+            .translate(node.pos.xyz)
+          for (i, extrude) in node
+            .extrude
+            .enumerate() {
+            cetz
+              .draw
+              .set-style(
+                fill: if i == 0 {
+                  node.fill
+                },
+                stroke: node.stroke,
+              )
+            (node.shape)(node, extrude)
+          }
+        })
     }
 
     if node.label != none {
-      cetz.draw.content(
-        node.pos.xyz,
-        box(
-          // wrapping label in a box allows user to control its alignment
-          align(
-            center + horizon,
-            node.label,
+      cetz
+        .draw
+        .content(
+          node.pos.xyz,
+          box(
+            // wrapping label in a box allows user to control its alignment
+            align(
+              center + horizon,
+              node.label,
+            ),
+            stroke: if debug >= 3 {
+              DEBUG_COLOR2 + 0.25pt
+            },
+            width: node
+              .size
+              .at(0) - 2 * node.inset,
+            height: node
+              .size
+              .at(1) - 2 * node.inset,
           ),
-          stroke: if debug >= 3 {
-            DEBUG_COLOR2 + 0.25pt
-          },
-          width: node
-            .size
-            .at(0) - 2 * node.inset,
-          height: node
-            .size
-            .at(1) - 2 * node.inset,
-        ),
-        anchor: "center",
-      )
+          anchor: "center",
+        )
     }
   }
 
   if node.layer != 0 {
-    result = cetz.draw.on-layer(
-      node.layer,
-      result,
-    )
+    result = cetz
+      .draw
+      .on-layer(node.layer, result)
   }
 
   (
@@ -80,33 +85,43 @@ snapshot_kind: text
   // Draw debug stuff
   if debug >= 1 {
     // dot at node anchor
-    cetz.draw.circle(
-      node.pos.xyz,
-      radius: 0.5pt,
-      fill: DEBUG_COLOR,
-      stroke: none,
-    )
+    cetz
+      .draw
+      .circle(
+        node.pos.xyz,
+        radius: 0.5pt,
+        fill: DEBUG_COLOR,
+        stroke: none,
+      )
   }
 
   if debug >= 2 and node.radius != 0pt {
     // node bounding rectangle
-    cetz.draw.rect(
-      ..rect-at(
-        node.pos.xyz,
-        node.size,
-      ),
-      stroke: DEBUG_COLOR + .1pt,
-    )
+    cetz
+      .draw
+      .rect(
+        ..rect-at(
+          node.pos.xyz,
+          node.size,
+        ),
+        stroke: DEBUG_COLOR + .1pt,
+      )
 
     // node anchoring outline (what edges snap to)
-    cetz.draw.group({
-      cetz.draw.translate(node.pos.xyz)
-      cetz.draw.set-style(
-        stroke: DEBUG_COLOR2 + 0.25pt,
-        fill: none,
-      )
-      (node.shape)(node, node.outset)
-    })
+    cetz
+      .draw
+      .group({
+        cetz
+          .draw
+          .translate(node.pos.xyz)
+        cetz
+          .draw
+          .set-style(
+            stroke: DEBUG_COLOR2 + 0.25pt,
+            fill: none,
+          )
+        (node.shape)(node, node.outset)
+      })
   }
 }
 
@@ -167,30 +182,34 @@ snapshot_kind: text
     rel: (θ-normal, -edge.label-sep),
   )
 
-  cetz.draw.content(
-    label-pos,
-    box(
-      {
-        set text(edge.label-size)
-        (edge.label-wrapper)(edge)
+  cetz
+    .draw
+    .content(
+      label-pos,
+      box(
+        {
+          set text(edge.label-size)
+          (edge.label-wrapper)(edge)
+        },
+        stroke: if debug >= 2 {
+          DEBUG_COLOR2 + 0.25pt
+        },
+      ),
+      angle: edge.label-angle,
+      anchor: if edge.label-anchor != auto {
+        edge.label-anchor
       },
-      stroke: if debug >= 2 {
-        DEBUG_COLOR2 + 0.25pt
-      },
-    ),
-    angle: edge.label-angle,
-    anchor: if edge.label-anchor != auto {
-      edge.label-anchor
-    },
-  )
+    )
 
   if debug >= 2 {
-    cetz.draw.circle(
-      label-pos,
-      radius: 0.75pt,
-      stroke: none,
-      fill: DEBUG_COLOR2,
-    )
+    cetz
+      .draw
+      .circle(
+        label-pos,
+        radius: 0.75pt,
+        stroke: none,
+        fill: DEBUG_COLOR2,
+      )
   }
 }
 
@@ -201,9 +220,11 @@ snapshot_kind: text
 // If `from < 0pt` and `to > 0pt`, the path length of the edge increases.
 #let cap-offsets(edge, y) = {
   (0, 1).map(pos => {
-    let mark = edge.marks.find(mark => (
-      calc.abs(mark.pos - pos) < 1e-3
-    ))
+    let mark = edge
+      .marks
+      .find(mark => (
+        calc.abs(mark.pos - pos) < 1e-3
+      ))
     if mark == none { return 0pt }
 
     let is-tip = (pos == 0) == mark.rev
@@ -231,9 +252,11 @@ snapshot_kind: text
   }
 
   let has-mark-at(t) = (
-    edge.marks.find(mark => (
-      calc.abs(mark.pos - t) < 1e-3
-    )) != none
+    edge
+      .marks
+      .find(mark => (
+        calc.abs(mark.pos - t) < 1e-3
+      )) != none
   )
 
   let decor = edge
@@ -278,23 +301,25 @@ snapshot_kind: text
     let points = (from, to)
       .zip(offsets)
       .map(((point, offset)) => {
-      // Shift line sideways (for multi-stroke effect)
-      point = (
-        rel: (θ + 90deg, shift),
-        to: point,
-      )
-      // Shift end points lengthways depending on marks
-      point = (
-        rel: (θ, offset),
-        to: point,
-      )
-      point
-    })
+        // Shift line sideways (for multi-stroke effect)
+        point = (
+          rel: (θ + 90deg, shift),
+          to: point,
+        )
+        // Shift end points lengthways depending on marks
+        point = (
+          rel: (θ, offset),
+          to: point,
+        )
+        point
+      })
 
-    let obj = cetz.draw.line(
-      ..points,
-      stroke: edge.stroke,
-    )
+    let obj = cetz
+      .draw
+      .line(
+        ..points,
+        stroke: edge.stroke,
+      )
 
     with-decorations(edge, obj)
   }
@@ -374,14 +399,16 @@ snapshot_kind: text
       -bend-dir * arclen / radius * 1rad
     ))
 
-    let obj = cetz.draw.arc(
-      center,
-      radius: radius + shift,
-      start: start + δ-start,
-      stop: stop + δ-stop,
-      anchor: "origin",
-      stroke: edge.stroke,
-    )
+    let obj = cetz
+      .draw
+      .arc(
+        center,
+        radius: radius + shift,
+        start: start + δ-start,
+        stop: stop + δ-stop,
+        anchor: "origin",
+        stroke: edge.stroke,
+      )
 
     with-decorations(edge, obj)
   }
@@ -611,25 +638,31 @@ snapshot_kind: text
 
         for d in edge.extrude {
           if delta != 0deg {
-            cetz.draw.arc(
-              arc-center,
-              radius: arc-radius - d,
-              start: start,
-              delta: delta,
-              anchor: "origin",
-              stroke: stroke-with-phase(phase + Δphase),
-            )
+            cetz
+              .draw
+              .arc(
+                arc-center,
+                radius: arc-radius - d,
+                start: start,
+                delta: delta,
+                anchor: "origin",
+                stroke: stroke-with-phase(phase + Δphase),
+              )
           }
 
           if debug >= 4 {
-            cetz.draw.on-layer(
-              1,
-              cetz.draw.circle(
-                arc-center,
-                radius: arc-radius - d,
-                stroke: debug-stroke,
-              ),
-            )
+            cetz
+              .draw
+              .on-layer(
+                1,
+                cetz
+                  .draw
+                  .circle(
+                    arc-center,
+                    radius: arc-radius - d,
+                    stroke: debug-stroke,
+                  ),
+              )
           }
         }
 
@@ -680,10 +713,12 @@ snapshot_kind: text
 
 
   if debug >= 4 {
-    cetz.draw.line(
-      ..verts,
-      stroke: debug-stroke,
-    )
+    cetz
+      .draw
+      .line(
+        ..verts,
+        stroke: debug-stroke,
+      )
   }
 }
 
@@ -708,39 +743,45 @@ snapshot_kind: text
   }
 
   let node-name = "intersection-finder"
-  cetz.draw.hide(
-    cetz.draw.intersections(
-      node-name,
-      objects,
-    ),
-  )
-
-  cetz.draw.get-ctx(ctx => {
-    let calculate-anchors = ctx
-      .nodes
-      .at(node-name)
-      .anchors
-    let anchor-names = calculate-anchors(())
-    let anchor-points = anchor-names
-      .map(calculate-anchors)
-      .map(point => {
-        // funky disagreement between coordinate systems??
-        point.at(1) *= -1
-        vector-2d(
-          vector.scale(point, 1cm),
-        )
-      })
-      .sorted(key: point => vector-len(
-      vector.sub(point, target),
-    ))
-
-    let anchor = anchor-points.at(
-      -1,
-      default: target,
+  cetz
+    .draw
+    .hide(
+      cetz
+        .draw
+        .intersections(
+          node-name,
+          objects,
+        ),
     )
 
-    callback(anchor)
-  })
+  cetz
+    .draw
+    .get-ctx(ctx => {
+      let calculate-anchors = ctx
+        .nodes
+        .at(node-name)
+        .anchors
+      let anchor-names = calculate-anchors(())
+      let anchor-points = anchor-names
+        .map(calculate-anchors)
+        .map(point => {
+          // funky disagreement between coordinate systems??
+          point.at(1) *= -1
+          vector-2d(
+            vector.scale(point, 1cm),
+          )
+        })
+        .sorted(key: point => vector-len(
+          vector.sub(point, target),
+        ))
+
+      let anchor = anchor-points.at(
+        -1,
+        default: target,
+      )
+
+      callback(anchor)
+    })
 }
 
 #let find-anchor-pair(
@@ -772,14 +813,18 @@ snapshot_kind: text
   θ,
   callback,
 ) = {
-  let outline = cetz.draw.group({
-    cetz.draw.translate(node.pos.xyz)
-    (node.shape)(node, node.outset)
-  })
-  let dummy-line = cetz.draw.line(
-    node.pos.xyz,
-    (rel: (θ, 10 * node.radius)),
-  )
+  let outline = cetz
+    .draw
+    .group({
+      cetz.draw.translate(node.pos.xyz)
+      (node.shape)(node, node.outset)
+    })
+  let dummy-line = cetz
+    .draw
+    .line(
+      node.pos.xyz,
+      (rel: (θ, 10 * node.radius)),
+    )
 
   find-farthest-intersection(
     outline + dummy-line,
@@ -846,19 +891,26 @@ snapshot_kind: text
   }
 
 
-  let dummy-line = cetz.draw.line(
-    from,
-    to,
-  )
+  let dummy-line = cetz
+    .draw
+    .line(
+      from,
+      to,
+    )
 
   let intersection-objects = nodes.map(nodes => {
     for node in nodes {
-      cetz.draw.group({
-        cetz.draw.translate(node
-          .pos
-          .xyz)
-        (node.shape)(node, node.outset)
-      })
+      cetz
+        .draw
+        .group({
+          cetz
+            .draw
+            .translate(node.pos.xyz)
+          (node.shape)(
+            node,
+            node.outset,
+          )
+        })
     }
     // if node == none { return }
     dummy-line
@@ -897,28 +949,35 @@ snapshot_kind: text
 
   let dummy-lines = (from, to)
     .zip(θs)
-    .map(((point, φ)) => cetz.draw.line(
-    point,
-    vector.add(
-      point,
-      vector-polar(10cm, φ),
-    ), // ray emanating from node
-  ))
+    .map(((point, φ)) => cetz
+      .draw
+      .line(
+        point,
+        vector.add(
+          point,
+          vector-polar(10cm, φ),
+        ), // ray emanating from node
+      ))
 
   let intersection-objects = nodes
     .zip(dummy-lines)
     .map(((nodes, dummy-line)) => {
-    for node in nodes {
-      cetz.draw.group({
-        cetz.draw.translate(node
-          .pos
-          .xyz)
-        (node.shape)(node, node.outset)
-      })
-    }
-    // if node == none { return }
-    dummy-line
-  })
+      for node in nodes {
+        cetz
+          .draw
+          .group({
+            cetz
+              .draw
+              .translate(node.pos.xyz)
+            (node.shape)(
+              node,
+              node.outset,
+            )
+          })
+      }
+      // if node == none { return }
+      dummy-line
+    })
 
   find-anchor-pair(
     intersection-objects,
@@ -954,10 +1013,12 @@ snapshot_kind: text
   )
 
   let end-segments = (
-    edge.final-vertices.slice(
-      0,
-      2,
-    ), // first two vertices
+    edge
+      .final-vertices
+      .slice(
+        0,
+        2,
+      ), // first two vertices
     edge
       .final-vertices
       .slice(-2), // last two vertices
@@ -970,17 +1031,22 @@ snapshot_kind: text
   let intersection-objects = nodes
     .zip(dummy-lines)
     .map(((nodes, dummy-line)) => {
-    for node in nodes {
-      cetz.draw.group({
-        cetz.draw.translate(node
-          .pos
-          .xyz)
-        (node.shape)(node, node.outset)
-      })
-    }
-    // if node == none { return }
-    dummy-line
-  })
+      for node in nodes {
+        cetz
+          .draw
+          .group({
+            cetz
+              .draw
+              .translate(node.pos.xyz)
+            (node.shape)(
+              node,
+              node.outset,
+            )
+          })
+      }
+      // if node == none { return }
+      dummy-line
+    })
 
   find-anchor-pair(
     intersection-objects,
@@ -1032,10 +1098,9 @@ snapshot_kind: text
   }
 
   if edge.layer != 0 {
-    obj = cetz.draw.on-layer(
-      edge.layer,
-      obj,
-    )
+    obj = cetz
+      .draw
+      .on-layer(edge.layer, obj)
   }
 
   obj
@@ -1317,15 +1382,15 @@ snapshot_kind: text
       )
       .enumerate()
       .map(((i, (given, raw, xyz))) => {
-      let key = map-auto(
-        given,
-        if type(raw) == label {
-          raw
-        } else { xyz },
-      )
-      let node = node-finder(key)
-      node
-    })
+        let key = map-auto(
+          given,
+          if type(raw) == label {
+            raw
+          } else { xyz },
+        )
+        let node = node-finder(key)
+        node
+      })
     draw-edge(
       edge,
       snap-to-nodes,

--- a/tests/snapshots/assets__check_file@packages-fletcher-draw.typ-80.snap
+++ b/tests/snapshots/assets__check_file@packages-fletcher-draw.typ-80.snap
@@ -24,30 +24,36 @@ snapshot_kind: text
 #let draw-node(node, debug: 0) = {
   let result = {
     if node.stroke != none or node.fill != none {
-      cetz.draw.group({
-        cetz.draw.translate(node.pos.xyz)
-        for (i, extrude) in node.extrude.enumerate() {
-          cetz.draw.set-style(
-            fill: if i == 0 { node.fill },
-            stroke: node.stroke,
-          )
-          (node.shape)(node, extrude)
-        }
-      })
+      cetz
+        .draw
+        .group({
+          cetz.draw.translate(node.pos.xyz)
+          for (i, extrude) in node.extrude.enumerate() {
+            cetz
+              .draw
+              .set-style(
+                fill: if i == 0 { node.fill },
+                stroke: node.stroke,
+              )
+            (node.shape)(node, extrude)
+          }
+        })
     }
 
     if node.label != none {
-      cetz.draw.content(
-        node.pos.xyz,
-        box(
-          // wrapping label in a box allows user to control its alignment
-          align(center + horizon, node.label),
-          stroke: if debug >= 3 { DEBUG_COLOR2 + 0.25pt },
-          width: node.size.at(0) - 2 * node.inset,
-          height: node.size.at(1) - 2 * node.inset,
-        ),
-        anchor: "center",
-      )
+      cetz
+        .draw
+        .content(
+          node.pos.xyz,
+          box(
+            // wrapping label in a box allows user to control its alignment
+            align(center + horizon, node.label),
+            stroke: if debug >= 3 { DEBUG_COLOR2 + 0.25pt },
+            width: node.size.at(0) - 2 * node.inset,
+            height: node.size.at(1) - 2 * node.inset,
+          ),
+          anchor: "center",
+        )
     }
   }
 
@@ -58,30 +64,38 @@ snapshot_kind: text
   // Draw debug stuff
   if debug >= 1 {
     // dot at node anchor
-    cetz.draw.circle(
-      node.pos.xyz,
-      radius: 0.5pt,
-      fill: DEBUG_COLOR,
-      stroke: none,
-    )
+    cetz
+      .draw
+      .circle(
+        node.pos.xyz,
+        radius: 0.5pt,
+        fill: DEBUG_COLOR,
+        stroke: none,
+      )
   }
 
   if debug >= 2 and node.radius != 0pt {
     // node bounding rectangle
-    cetz.draw.rect(
-      ..rect-at(node.pos.xyz, node.size),
-      stroke: DEBUG_COLOR + .1pt,
-    )
+    cetz
+      .draw
+      .rect(
+        ..rect-at(node.pos.xyz, node.size),
+        stroke: DEBUG_COLOR + .1pt,
+      )
 
     // node anchoring outline (what edges snap to)
-    cetz.draw.group({
-      cetz.draw.translate(node.pos.xyz)
-      cetz.draw.set-style(
-        stroke: DEBUG_COLOR2 + 0.25pt,
-        fill: none,
-      )
-      (node.shape)(node, node.outset)
-    })
+    cetz
+      .draw
+      .group({
+        cetz.draw.translate(node.pos.xyz)
+        cetz
+          .draw
+          .set-style(
+            stroke: DEBUG_COLOR2 + 0.25pt,
+            fill: none,
+          )
+        (node.shape)(node, node.outset)
+      })
   }
 }
 
@@ -128,26 +142,30 @@ snapshot_kind: text
 
   let label-pos = (to: curve-point, rel: (θ-normal, -edge.label-sep))
 
-  cetz.draw.content(
-    label-pos,
-    box(
-      {
-        set text(edge.label-size)
-        (edge.label-wrapper)(edge)
-      },
-      stroke: if debug >= 2 { DEBUG_COLOR2 + 0.25pt },
-    ),
-    angle: edge.label-angle,
-    anchor: if edge.label-anchor != auto { edge.label-anchor },
-  )
+  cetz
+    .draw
+    .content(
+      label-pos,
+      box(
+        {
+          set text(edge.label-size)
+          (edge.label-wrapper)(edge)
+        },
+        stroke: if debug >= 2 { DEBUG_COLOR2 + 0.25pt },
+      ),
+      angle: edge.label-angle,
+      anchor: if edge.label-anchor != auto { edge.label-anchor },
+    )
 
   if debug >= 2 {
-    cetz.draw.circle(
-      label-pos,
-      radius: 0.75pt,
-      stroke: none,
-      fill: DEBUG_COLOR2,
-    )
+    cetz
+      .draw
+      .circle(
+        label-pos,
+        radius: 0.75pt,
+        stroke: none,
+        fill: DEBUG_COLOR2,
+      )
   }
 }
 
@@ -213,18 +231,22 @@ snapshot_kind: text
   // Draw line(s), one for each extrusion shift
   for shift in edge.extrude {
     let offsets = cap-offsets(edge, shift)
-    let points = (from, to).zip(offsets).map(((point, offset)) => {
-      // Shift line sideways (for multi-stroke effect)
-      point = (rel: (θ + 90deg, shift), to: point)
-      // Shift end points lengthways depending on marks
-      point = (rel: (θ, offset), to: point)
-      point
-    })
+    let points = (from, to)
+      .zip(offsets)
+      .map(((point, offset)) => {
+        // Shift line sideways (for multi-stroke effect)
+        point = (rel: (θ + 90deg, shift), to: point)
+        // Shift end points lengthways depending on marks
+        point = (rel: (θ, offset), to: point)
+        point
+      })
 
-    let obj = cetz.draw.line(
-      ..points,
-      stroke: edge.stroke,
-    )
+    let obj = cetz
+      .draw
+      .line(
+        ..points,
+        stroke: edge.stroke,
+      )
 
     with-decorations(edge, obj)
   }
@@ -279,14 +301,16 @@ snapshot_kind: text
       -bend-dir * arclen / radius * 1rad
     ))
 
-    let obj = cetz.draw.arc(
-      center,
-      radius: radius + shift,
-      start: start + δ-start,
-      stop: stop + δ-stop,
-      anchor: "origin",
-      stroke: edge.stroke,
-    )
+    let obj = cetz
+      .draw
+      .arc(
+        center,
+        radius: radius + shift,
+        start: start + δ-start,
+        stop: stop + δ-stop,
+        anchor: "origin",
+        stroke: edge.stroke,
+      )
 
     with-decorations(edge, obj)
   }
@@ -454,25 +478,31 @@ snapshot_kind: text
 
         for d in edge.extrude {
           if delta != 0deg {
-            cetz.draw.arc(
-              arc-center,
-              radius: arc-radius - d,
-              start: start,
-              delta: delta,
-              anchor: "origin",
-              stroke: stroke-with-phase(phase + Δphase),
-            )
+            cetz
+              .draw
+              .arc(
+                arc-center,
+                radius: arc-radius - d,
+                start: start,
+                delta: delta,
+                anchor: "origin",
+                stroke: stroke-with-phase(phase + Δphase),
+              )
           }
 
           if debug >= 4 {
-            cetz.draw.on-layer(
-              1,
-              cetz.draw.circle(
-                arc-center,
-                radius: arc-radius - d,
-                stroke: debug-stroke,
-              ),
-            )
+            cetz
+              .draw
+              .on-layer(
+                1,
+                cetz
+                  .draw
+                  .circle(
+                    arc-center,
+                    radius: arc-radius - d,
+                    stroke: debug-stroke,
+                  ),
+              )
           }
         }
 
@@ -512,10 +542,12 @@ snapshot_kind: text
 
 
   if debug >= 4 {
-    cetz.draw.line(
-      ..verts,
-      stroke: debug-stroke,
-    )
+    cetz
+      .draw
+      .line(
+        ..verts,
+        stroke: debug-stroke,
+      )
   }
 }
 
@@ -536,22 +568,24 @@ snapshot_kind: text
   let node-name = "intersection-finder"
   cetz.draw.hide(cetz.draw.intersections(node-name, objects))
 
-  cetz.draw.get-ctx(ctx => {
-    let calculate-anchors = ctx.nodes.at(node-name).anchors
-    let anchor-names = calculate-anchors(())
-    let anchor-points = anchor-names
-      .map(calculate-anchors)
-      .map(point => {
-        // funky disagreement between coordinate systems??
-        point.at(1) *= -1
-        vector-2d(vector.scale(point, 1cm))
-      })
-      .sorted(key: point => vector-len(vector.sub(point, target)))
+  cetz
+    .draw
+    .get-ctx(ctx => {
+      let calculate-anchors = ctx.nodes.at(node-name).anchors
+      let anchor-names = calculate-anchors(())
+      let anchor-points = anchor-names
+        .map(calculate-anchors)
+        .map(point => {
+          // funky disagreement between coordinate systems??
+          point.at(1) *= -1
+          vector-2d(vector.scale(point, 1cm))
+        })
+        .sorted(key: point => vector-len(vector.sub(point, target)))
 
-    let anchor = anchor-points.at(-1, default: target)
+      let anchor = anchor-points.at(-1, default: target)
 
-    callback(anchor)
-  })
+      callback(anchor)
+    })
 }
 
 #let find-anchor-pair(
@@ -576,14 +610,18 @@ snapshot_kind: text
 
 /// Get the anchor point around a node outline at a certain angle.
 #let get-node-anchor(node, θ, callback) = {
-  let outline = cetz.draw.group({
-    cetz.draw.translate(node.pos.xyz)
-    (node.shape)(node, node.outset)
-  })
-  let dummy-line = cetz.draw.line(
-    node.pos.xyz,
-    (rel: (θ, 10 * node.radius)),
-  )
+  let outline = cetz
+    .draw
+    .group({
+      cetz.draw.translate(node.pos.xyz)
+      (node.shape)(node, node.outset)
+    })
+  let dummy-line = cetz
+    .draw
+    .line(
+      node.pos.xyz,
+      (rel: (θ, 10 * node.radius)),
+    )
 
   find-farthest-intersection(outline + dummy-line, node.pos.xyz, callback)
 }
@@ -618,17 +656,21 @@ snapshot_kind: text
   }
 
 
-  let dummy-line = cetz.draw.line(
-    from,
-    to,
-  )
+  let dummy-line = cetz
+    .draw
+    .line(
+      from,
+      to,
+    )
 
   let intersection-objects = nodes.map(nodes => {
     for node in nodes {
-      cetz.draw.group({
-        cetz.draw.translate(node.pos.xyz)
-        (node.shape)(node, node.outset)
-      })
+      cetz
+        .draw
+        .group({
+          cetz.draw.translate(node.pos.xyz)
+          (node.shape)(node, node.outset)
+        })
     }
     // if node == none { return }
     dummy-line
@@ -656,23 +698,29 @@ snapshot_kind: text
   let θ = angle-between(from, to)
   let θs = (θ + edge.bend, θ - edge.bend + 180deg)
 
-  let dummy-lines = (from, to).zip(θs).map(((point, φ)) => cetz.draw.line(
-    point,
-    vector.add(point, vector-polar(10cm, φ)), // ray emanating from node
-  ))
+  let dummy-lines = (from, to)
+    .zip(θs)
+    .map(((point, φ)) => cetz
+      .draw
+      .line(
+        point,
+        vector.add(point, vector-polar(10cm, φ)), // ray emanating from node
+      ))
 
-  let intersection-objects = nodes.zip(dummy-lines).map((
-    (nodes, dummy-line),
-  ) => {
-    for node in nodes {
-      cetz.draw.group({
-        cetz.draw.translate(node.pos.xyz)
-        (node.shape)(node, node.outset)
-      })
-    }
-    // if node == none { return }
-    dummy-line
-  })
+  let intersection-objects = nodes
+    .zip(dummy-lines)
+    .map(((nodes, dummy-line)) => {
+      for node in nodes {
+        cetz
+          .draw
+          .group({
+            cetz.draw.translate(node.pos.xyz)
+            (node.shape)(node, node.outset)
+          })
+      }
+      // if node == none { return }
+      dummy-line
+    })
 
   find-anchor-pair(
     intersection-objects,
@@ -700,18 +748,20 @@ snapshot_kind: text
 
   let dummy-lines = end-segments.map(points => cetz.draw.line(..points))
 
-  let intersection-objects = nodes.zip(dummy-lines).map((
-    (nodes, dummy-line),
-  ) => {
-    for node in nodes {
-      cetz.draw.group({
-        cetz.draw.translate(node.pos.xyz)
-        (node.shape)(node, node.outset)
-      })
-    }
-    // if node == none { return }
-    dummy-line
-  })
+  let intersection-objects = nodes
+    .zip(dummy-lines)
+    .map(((nodes, dummy-line)) => {
+      for node in nodes {
+        cetz
+          .draw
+          .group({
+            cetz.draw.translate(node.pos.xyz)
+            (node.shape)(node, node.outset)
+          })
+      }
+      // if node == none { return }
+      dummy-line
+    })
 
   find-anchor-pair(
     intersection-objects,
@@ -887,10 +937,10 @@ snapshot_kind: text
       .zip(first-last(edge.vertices), first-last(edge.final-vertices))
       .enumerate()
       .map(((i, (given, raw, xyz))) => {
-      let key = map-auto(given, if type(raw) == label { raw } else { xyz })
-      let node = node-finder(key)
-      node
-    })
+        let key = map-auto(given, if type(raw) == label { raw } else { xyz })
+        let node = node-finder(key)
+        node
+      })
     draw-edge(edge, snap-to-nodes, debug: debug)
   }
 

--- a/tests/snapshots/assets__check_file@packages-fletcher-draw.typ-80.snap
+++ b/tests/snapshots/assets__check_file@packages-fletcher-draw.typ-80.snap
@@ -486,9 +486,9 @@ snapshot_kind: text
     marks += edge
       .marks
       .map(mark => {
-          mark.pos = lerp-scale(mark.pos, i)
-          mark
-        })
+        mark.pos = lerp-scale(mark.pos, i)
+        mark
+      })
       .filter(mark => mark.pos != none)
 
     let label-pos = lerp-scale(edge.label-pos, i)
@@ -542,10 +542,10 @@ snapshot_kind: text
     let anchor-points = anchor-names
       .map(calculate-anchors)
       .map(point => {
-          // funky disagreement between coordinate systems??
-          point.at(1) *= -1
-          vector-2d(vector.scale(point, 1cm))
-        })
+        // funky disagreement between coordinate systems??
+        point.at(1) *= -1
+        vector-2d(vector.scale(point, 1cm))
+      })
       .sorted(key: point => vector-len(vector.sub(point, target)))
 
     let anchor = anchor-points.at(-1, default: target)
@@ -925,13 +925,13 @@ snapshot_kind: text
   seq
     .children
     .map(child => {
-        if child.func() == metadata {
-          let value = child.value
-          value.post = cetz.draw.hide.with(bounds: bounds)
-          metadata(value)
-        } else {
-          child
-        }
-      })
+      if child.func() == metadata {
+        let value = child.value
+        value.post = cetz.draw.hide.with(bounds: bounds)
+        metadata(value)
+      } else {
+        child
+      }
+    })
     .join()
 }

--- a/tests/snapshots/assets__check_file@packages-tidy-new-parser.typ-0.snap
+++ b/tests/snapshots/assets__check_file@packages-tidy-new-parser.typ-0.snap
@@ -49,7 +49,10 @@ snapshot_kind: text
     is-named,
   ) = {
     if is-named {
-      return split-once(arg, ":").map(str.trim)
+      return split-once(
+        arg,
+        ":",
+      ).map(str.trim)
     } else {
       return (
         arg.trim(),
@@ -78,7 +81,10 @@ snapshot_kind: text
           let (
             name,
             value,
-          ) = split-once(arg, ":").map(str.trim)
+          ) = split-once(
+            arg,
+            ":",
+          ).map(str.trim)
           args.push((
             name,
             value,
@@ -105,7 +111,10 @@ snapshot_kind: text
           let (
             name,
             value,
-          ) = split-once(arg, ":").map(str.trim)
+          ) = split-once(
+            arg,
+            ":",
+          ).map(str.trim)
           args.push((
             name,
             value,
@@ -216,7 +225,9 @@ snapshot_kind: text
 ) = {
   let description = lines
     .enumerate(start: first-line-number)
-    .map(eval-doc-comment-test.with(label-prefix: label-prefix))
+    .map(
+      eval-doc-comment-test.with(label-prefix: label-prefix),
+    )
     .join("\n")
 
   if description == none {
@@ -228,11 +239,17 @@ snapshot_kind: text
     let parts = description.split("->")
     types = parts
       .last()
-      .replace(",", "|")
+      .replace(
+        ",",
+        "|",
+      )
       .split("|")
       .map(str.trim)
     description = parts
-      .slice(0, -1)
+      .slice(
+        0,
+        -1,
+      )
       .join("->")
   }
 
@@ -307,7 +324,10 @@ snapshot_kind: text
     return line
   }
   return line
-    .slice(0, pos)
+    .slice(
+      0,
+      pos,
+    )
     .trim()
 }
 

--- a/tests/snapshots/assets__check_file@packages-tidy-new-parser.typ-0.snap
+++ b/tests/snapshots/assets__check_file@packages-tidy-new-parser.typ-0.snap
@@ -419,8 +419,8 @@ snapshot_kind: text
     state
       .unmatched-description
       .push(
-      line.slice(3),
-    )
+        line.slice(3),
+      )
   } else {
     state.unfinished-param += trim-trailing-comments(line)
 
@@ -455,16 +455,16 @@ snapshot_kind: text
       state
         .params
         .push((
-        name: args.first(),
-        desc-lines: state.unmatched-description,
-      ))
+          name: args.first(),
+          desc-lines: state.unmatched-description,
+        ))
       state.unmatched-description = ()
       state.params += args
         .slice(1)
         .map(arg => (
-        name: arg,
-        desc-lines: (),
-      ))
+          name: arg,
+          desc-lines: (),
+        ))
       state.unfinished-param = ""
     }
   }

--- a/tests/snapshots/assets__check_file@packages-tidy-new-parser.typ-40.snap
+++ b/tests/snapshots/assets__check_file@packages-tidy-new-parser.typ-40.snap
@@ -315,9 +315,9 @@ snapshot_kind: text
 
 #let parameter-parser(state, line) = {
   if line.starts-with("///") {
-    state.unmatched-description.push(
-      line.slice(3),
-    )
+    state
+      .unmatched-description
+      .push(line.slice(3))
   } else {
     state.unfinished-param += trim-trailing-comments(line)
 
@@ -347,17 +347,19 @@ snapshot_kind: text
         .unfinished-param
         .ends-with(",") or state.state == "finished"
     ) {
-      state.params.push((
-        name: args.first(),
-        desc-lines: state.unmatched-description,
-      ))
+      state
+        .params
+        .push((
+          name: args.first(),
+          desc-lines: state.unmatched-description,
+        ))
       state.unmatched-description = ()
       state.params += args
         .slice(1)
         .map(arg => (
-        name: arg,
-        desc-lines: (),
-      ))
+          name: arg,
+          desc-lines: (),
+        ))
       state.unfinished-param = ""
     }
   }

--- a/tests/snapshots/assets__check_file@packages-tidy-new-parser.typ-40.snap
+++ b/tests/snapshots/assets__check_file@packages-tidy-new-parser.typ-40.snap
@@ -39,7 +39,10 @@ snapshot_kind: text
     is-named,
   ) = {
     if is-named {
-      return split-once(arg, ":").map(str.trim)
+      return split-once(
+        arg,
+        ":",
+      ).map(str.trim)
     } else {
       return (arg.trim(),)
     }
@@ -64,7 +67,10 @@ snapshot_kind: text
           let (
             name,
             value,
-          ) = split-once(arg, ":").map(str.trim)
+          ) = split-once(
+            arg,
+            ":",
+          ).map(str.trim)
           args.push((name, value))
         } else {
           arg = arg.trim()
@@ -84,7 +90,10 @@ snapshot_kind: text
           let (
             name,
             value,
-          ) = split-once(arg, ":").map(str.trim)
+          ) = split-once(
+            arg,
+            ":",
+          ).map(str.trim)
           args.push((name, value))
         } else {
           arg = arg.trim()
@@ -158,7 +167,9 @@ snapshot_kind: text
 ) = {
   let description = lines
     .enumerate(start: first-line-number)
-    .map(eval-doc-comment-test.with(label-prefix: label-prefix))
+    .map(
+      eval-doc-comment-test.with(label-prefix: label-prefix),
+    )
     .join("\n")
 
   if description == none {

--- a/tests/snapshots/assets__check_file@packages-tidy-new-parser.typ-80.snap
+++ b/tests/snapshots/assets__check_file@packages-tidy-new-parser.typ-80.snap
@@ -257,10 +257,9 @@ snapshot_kind: text
     if args.len() > 0 and (
       state.unfinished-param.ends-with(",") or state.state == "finished"
     ) {
-      state.params.push((
-        name: args.first(),
-        desc-lines: state.unmatched-description,
-      ))
+      state
+        .params
+        .push((name: args.first(), desc-lines: state.unmatched-description))
       state.unmatched-description = ()
       state.params += args.slice(1).map(arg => (name: arg, desc-lines: ()))
       state.unfinished-param = ""

--- a/tests/snapshots/assets__check_file@packages-touying-core.typ-0.snap
+++ b/tests/snapshots/assets__check_file@packages-touying-core.typ-0.snap
@@ -1242,19 +1242,27 @@ snapshot_kind: text
   let result = ()
   let cover-arr = ()
   let children = it
-    .split(regex("(#meanwhile;?)|(meanwhile)"))
+    .split(
+      regex("(#meanwhile;?)|(meanwhile)"),
+    )
     .intersperse("touying-meanwhile")
     .map(s => s
-        .split(regex("(#pause;?)|(pause)"))
-        .intersperse("touying-pause"))
+      .split(
+        regex("(#pause;?)|(pause)"),
+      )
+      .intersperse("touying-pause"))
     .flatten()
     .map(s => s
-        .split(regex("(\\\\\\s)|(\\\\\\n)"))
-        .intersperse("\\\n"))
+      .split(
+        regex("(\\\\\\s)|(\\\\\\n)"),
+      )
+      .intersperse("\\\n"))
     .flatten()
     .map(s => s
-        .split(regex("&"))
-        .intersperse("&"))
+      .split(
+        regex("&"),
+      )
+      .intersperse("&"))
     .flatten()
   for child in (
     children
@@ -1368,19 +1376,27 @@ snapshot_kind: text
   let result = ()
   let cover-arr = ()
   let children = it
-    .split(regex("\\\\meanwhile"))
+    .split(
+      regex("\\\\meanwhile"),
+    )
     .intersperse("touying-meanwhile")
     .map(s => s
-        .split(regex("\\\\pause"))
-        .intersperse("touying-pause"))
+      .split(
+        regex("\\\\pause"),
+      )
+      .intersperse("touying-pause"))
     .flatten()
     .map(s => s
-        .split(regex("(\\\\\\\\\s)|(\\\\\\\\\n)"))
-        .intersperse("\\\\\n"))
+      .split(
+        regex("(\\\\\\\\\s)|(\\\\\\\\\n)"),
+      )
+      .intersperse("\\\\\n"))
     .flatten()
     .map(s => s
-        .split(regex("&"))
-        .intersperse("&"))
+      .split(
+        regex("&"),
+      )
+      .intersperse("&"))
     .flatten()
   for child in (
     children
@@ -2609,7 +2625,10 @@ snapshot_kind: text
         hide({
           set heading(offset: 0)
           let headings = self
-            .at("headings", default: ())
+            .at(
+              "headings",
+              default: (),
+            )
             .map(it => if it.has("label") {
             if str(it.label) in (
               "touying:hidden",
@@ -2723,47 +2742,55 @@ snapshot_kind: text
         context {
           self
             .frozen-states
-            .zip(utils
+            .zip(
+              utils
                 .saved-frozen-states
-                .get())
+                .get(),
+            )
             .map(pair => pair
-                .at(0)
-                .update(
-                pair.at(1),
-              ))
+              .at(0)
+              .update(
+              pair.at(1),
+            ))
             .sum(default: none)
           self
             .default-frozen-states
-            .zip(utils
+            .zip(
+              utils
                 .saved-default-frozen-states
-                .get())
+                .get(),
+            )
             .map(pair => pair
-                .at(0)
-                .update(
-                pair.at(1),
-              ))
+              .at(0)
+              .update(
+              pair.at(1),
+            ))
             .sum(default: none)
           self
             .frozen-counters
-            .zip(utils
+            .zip(
+              utils
                 .saved-frozen-counters
-                .get())
+                .get(),
+            )
             .map(pair => pair
-                .at(0)
-                .update(
-                pair.at(1),
-              ))
+              .at(0)
+              .update(
+              pair.at(1),
+            ))
             .sum(default: none)
           self
             .default-frozen-counters
-            .zip(utils
+            .zip(
+              utils
                 .saved-default-frozen-counters
-                .get())
+                .get(),
+            )
             .map(pair => pair
-                .at(0)
-                .update(
-                pair.at(1),
-              ))
+              .at(0)
+              .update(
+              pair.at(1),
+            ))
             .sum(default: none)
         }
       }

--- a/tests/snapshots/assets__check_file@packages-touying-core.typ-0.snap
+++ b/tests/snapshots/assets__check_file@packages-touying-core.typ-0.snap
@@ -896,8 +896,8 @@ snapshot_kind: text
       ..subslides-contents
         .pairs()
         .map(kv => utils.last-required-subslide(
-        kv.at(0),
-      )),
+          kv.at(0),
+        )),
     ),
     subslides-contents,
     position: position,
@@ -1314,9 +1314,9 @@ snapshot_kind: text
           let cover = eqt
             .scope
             .at(
-            "cover",
-            default: cover,
-          )
+              "cover",
+              default: cover,
+            )
           if args
             .pos()
             .len() != 0 {
@@ -1483,9 +1483,9 @@ snapshot_kind: text
       let kind = child
         .value
         .at(
-        "kind",
-        default: none,
-      )
+          "kind",
+          default: none,
+        )
       if kind == "touying-pause" {
         repetitions += 1
       } else if kind == "touying-meanwhile" {
@@ -1592,9 +1592,9 @@ snapshot_kind: text
           .body
           .value
           .at(
-          "kind",
-          default: none,
-        )
+            "kind",
+            default: none,
+          )
         if kind == "touying-pause" {
           repetitions += 1
           continue
@@ -1631,9 +1631,9 @@ snapshot_kind: text
         let kind = child
           .value
           .at(
-          "kind",
-          default: none,
-        )
+            "kind",
+            default: none,
+          )
         if kind == "touying-pause" {
           repetitions += 1
         } else if kind == "touying-meanwhile" {
@@ -2384,18 +2384,18 @@ snapshot_kind: text
     self
       .page
       .at(
-      "header",
-      default: none,
-    ),
+        "header",
+        default: none,
+      ),
   )
   let footer = utils.call-or-display(
     self,
     self
       .page
       .at(
-      "footer",
-      default: none,
-    ),
+        "footer",
+        default: none,
+      ),
   )
   // negative padding
   if self.at(
@@ -2630,48 +2630,48 @@ snapshot_kind: text
               default: (),
             )
             .map(it => if it.has("label") {
-            if str(it.label) in (
-              "touying:hidden",
-              "touying:unnumbered",
-              "touying:unoutlined",
-              "touying:unbookmarked",
-            ) {
-              let fields = it.fields()
-              let _ = fields.remove(
-                "label",
-                default: none,
-              )
-              let _ = fields.remove(
-                "body",
-                default: none,
-              )
-              if str(it.label) == "touying:hidden" {
-                fields.numbering = none
-                fields.outlined = false
-                fields.bookmarked = false
+              if str(it.label) in (
+                "touying:hidden",
+                "touying:unnumbered",
+                "touying:unoutlined",
+                "touying:unbookmarked",
+              ) {
+                let fields = it.fields()
+                let _ = fields.remove(
+                  "label",
+                  default: none,
+                )
+                let _ = fields.remove(
+                  "body",
+                  default: none,
+                )
+                if str(it.label) == "touying:hidden" {
+                  fields.numbering = none
+                  fields.outlined = false
+                  fields.bookmarked = false
+                }
+                if str(it.label) == "touying:unnumbered" {
+                  fields.numbering = none
+                }
+                if str(it.label) == "touying:unoutlined" {
+                  fields.outlined = false
+                }
+                if str(it.label) == "touying:unbookmarked" {
+                  fields.bookmarked = false
+                }
+                utils.label-it(
+                  heading(
+                    ..fields,
+                    it.body,
+                  ),
+                  it.label,
+                )
+              } else {
+                it
               }
-              if str(it.label) == "touying:unnumbered" {
-                fields.numbering = none
-              }
-              if str(it.label) == "touying:unoutlined" {
-                fields.outlined = false
-              }
-              if str(it.label) == "touying:unbookmarked" {
-                fields.bookmarked = false
-              }
-              utils.label-it(
-                heading(
-                  ..fields,
-                  it.body,
-                ),
-                it.label,
-              )
             } else {
               it
-            }
-          } else {
-            it
-          })
+            })
           headings.sum(default: none)
         }),
       )
@@ -2711,31 +2711,31 @@ snapshot_kind: text
           utils
             .saved-frozen-states
             .update(
-            self
-              .frozen-states
-              .map(s => s.get()),
-          )
+              self
+                .frozen-states
+                .map(s => s.get()),
+            )
           utils
             .saved-default-frozen-states
             .update(
-            self
-              .default-frozen-states
-              .map(s => s.get()),
-          )
+              self
+                .default-frozen-states
+                .map(s => s.get()),
+            )
           utils
             .saved-frozen-counters
             .update(
-            self
-              .frozen-counters
-              .map(s => s.get()),
-          )
+              self
+                .frozen-counters
+                .map(s => s.get()),
+            )
           utils
             .saved-default-frozen-counters
             .update(
-            self
-              .default-frozen-counters
-              .map(s => s.get()),
-          )
+              self
+                .default-frozen-counters
+                .map(s => s.get()),
+            )
         }
       } else {
         // restore the states and counters
@@ -2750,8 +2750,8 @@ snapshot_kind: text
             .map(pair => pair
               .at(0)
               .update(
-              pair.at(1),
-            ))
+                pair.at(1),
+              ))
             .sum(default: none)
           self
             .default-frozen-states
@@ -2763,8 +2763,8 @@ snapshot_kind: text
             .map(pair => pair
               .at(0)
               .update(
-              pair.at(1),
-            ))
+                pair.at(1),
+              ))
             .sum(default: none)
           self
             .frozen-counters
@@ -2776,8 +2776,8 @@ snapshot_kind: text
             .map(pair => pair
               .at(0)
               .update(
-              pair.at(1),
-            ))
+                pair.at(1),
+              ))
             .sum(default: none)
           self
             .default-frozen-counters
@@ -2789,8 +2789,8 @@ snapshot_kind: text
             .map(pair => pair
               .at(0)
               .update(
-              pair.at(1),
-            ))
+                pair.at(1),
+              ))
             .sum(default: none)
         }
       }

--- a/tests/snapshots/assets__check_file@packages-touying-core.typ-120.snap
+++ b/tests/snapshots/assets__check_file@packages-touying-core.typ-120.snap
@@ -1620,32 +1620,39 @@ snapshot_kind: text
       place(
         hide({
           set heading(offset: 0)
-          let headings = self.at("headings", default: ()).map(it => if it.has("label") {
-            if str(it.label) in ("touying:hidden", "touying:unnumbered", "touying:unoutlined", "touying:unbookmarked") {
-              let fields = it.fields()
-              let _ = fields.remove("label", default: none)
-              let _ = fields.remove("body", default: none)
-              if str(it.label) == "touying:hidden" {
-                fields.numbering = none
-                fields.outlined = false
-                fields.bookmarked = false
+          let headings = self
+            .at("headings", default: ())
+            .map(it => if it.has("label") {
+              if str(it.label) in (
+                "touying:hidden",
+                "touying:unnumbered",
+                "touying:unoutlined",
+                "touying:unbookmarked",
+              ) {
+                let fields = it.fields()
+                let _ = fields.remove("label", default: none)
+                let _ = fields.remove("body", default: none)
+                if str(it.label) == "touying:hidden" {
+                  fields.numbering = none
+                  fields.outlined = false
+                  fields.bookmarked = false
+                }
+                if str(it.label) == "touying:unnumbered" {
+                  fields.numbering = none
+                }
+                if str(it.label) == "touying:unoutlined" {
+                  fields.outlined = false
+                }
+                if str(it.label) == "touying:unbookmarked" {
+                  fields.bookmarked = false
+                }
+                utils.label-it(heading(..fields, it.body), it.label)
+              } else {
+                it
               }
-              if str(it.label) == "touying:unnumbered" {
-                fields.numbering = none
-              }
-              if str(it.label) == "touying:unoutlined" {
-                fields.outlined = false
-              }
-              if str(it.label) == "touying:unbookmarked" {
-                fields.bookmarked = false
-              }
-              utils.label-it(heading(..fields, it.body), it.label)
             } else {
               it
-            }
-          } else {
-            it
-          })
+            })
           headings.sum(default: none)
         }),
       )

--- a/tests/snapshots/assets__check_file@packages-touying-core.typ-40.snap
+++ b/tests/snapshots/assets__check_file@packages-touying-core.typ-40.snap
@@ -1196,19 +1196,25 @@ snapshot_kind: text
   let result = ()
   let cover-arr = ()
   let children = it
-    .split(regex("(#meanwhile;?)|(meanwhile)"))
+    .split(
+      regex("(#meanwhile;?)|(meanwhile)"),
+    )
     .intersperse("touying-meanwhile")
     .map(s => s
-        .split(regex("(#pause;?)|(pause)"))
-        .intersperse("touying-pause"))
+      .split(
+        regex("(#pause;?)|(pause)"),
+      )
+      .intersperse("touying-pause"))
     .flatten()
     .map(s => s
-        .split(regex("(\\\\\\s)|(\\\\\\n)"))
-        .intersperse("\\\n"))
+      .split(
+        regex("(\\\\\\s)|(\\\\\\n)"),
+      )
+      .intersperse("\\\n"))
     .flatten()
     .map(s => s
-        .split(regex("&"))
-        .intersperse("&"))
+      .split(regex("&"))
+      .intersperse("&"))
     .flatten()
   for child in children {
     if child == "touying-pause" {
@@ -1310,16 +1316,18 @@ snapshot_kind: text
     .split(regex("\\\\meanwhile"))
     .intersperse("touying-meanwhile")
     .map(s => s
-        .split(regex("\\\\pause"))
-        .intersperse("touying-pause"))
+      .split(regex("\\\\pause"))
+      .intersperse("touying-pause"))
     .flatten()
     .map(s => s
-        .split(regex("(\\\\\\\\\s)|(\\\\\\\\\n)"))
-        .intersperse("\\\\\n"))
+      .split(
+        regex("(\\\\\\\\\s)|(\\\\\\\\\n)"),
+      )
+      .intersperse("\\\\\n"))
     .flatten()
     .map(s => s
-        .split(regex("&"))
-        .intersperse("&"))
+      .split(regex("&"))
+      .intersperse("&"))
     .flatten()
   for child in children {
     if child == "touying-pause" {
@@ -2562,39 +2570,47 @@ snapshot_kind: text
         context {
           self
             .frozen-states
-            .zip(utils
+            .zip(
+              utils
                 .saved-frozen-states
-                .get())
+                .get(),
+            )
             .map(pair => pair
-                .at(0)
-                .update(pair.at(1)))
+              .at(0)
+              .update(pair.at(1)))
             .sum(default: none)
           self
             .default-frozen-states
-            .zip(utils
+            .zip(
+              utils
                 .saved-default-frozen-states
-                .get())
+                .get(),
+            )
             .map(pair => pair
-                .at(0)
-                .update(pair.at(1)))
+              .at(0)
+              .update(pair.at(1)))
             .sum(default: none)
           self
             .frozen-counters
-            .zip(utils
+            .zip(
+              utils
                 .saved-frozen-counters
-                .get())
+                .get(),
+            )
             .map(pair => pair
-                .at(0)
-                .update(pair.at(1)))
+              .at(0)
+              .update(pair.at(1)))
             .sum(default: none)
           self
             .default-frozen-counters
-            .zip(utils
+            .zip(
+              utils
                 .saved-default-frozen-counters
-                .get())
+                .get(),
+            )
             .map(pair => pair
-                .at(0)
-                .update(pair.at(1)))
+              .at(0)
+              .update(pair.at(1)))
             .sum(default: none)
         }
       }

--- a/tests/snapshots/assets__check_file@packages-touying-core.typ-40.snap
+++ b/tests/snapshots/assets__check_file@packages-touying-core.typ-40.snap
@@ -858,8 +858,8 @@ snapshot_kind: text
       ..subslides-contents
         .pairs()
         .map(kv => utils.last-required-subslide(
-        kv.at(0),
-      )),
+          kv.at(0),
+        )),
     ),
     subslides-contents,
     position: position,
@@ -1259,10 +1259,9 @@ snapshot_kind: text
       "$" + result.sum(default: "") + "$",
       scope: eqt.scope + (
         cover: (..args) => {
-          let cover = eqt.scope.at(
-            "cover",
-            default: cover,
-          )
+          let cover = eqt
+            .scope
+            .at("cover", default: cover)
           if args.pos().len() != 0 {
             cover(args.pos().first())
           }
@@ -1402,10 +1401,9 @@ snapshot_kind: text
   let cover-arr = ()
   for child in reducer.args.flatten() {
     if type(child) == content and child.func() == metadata and type(child.value) == dictionary {
-      let kind = child.value.at(
-        "kind",
-        default: none,
-      )
+      let kind = child
+        .value
+        .at("kind", default: none)
       if kind == "touying-pause" {
         repetitions += 1
       } else if kind == "touying-meanwhile" {
@@ -1497,10 +1495,10 @@ snapshot_kind: text
         .func() == metadata and type(it
         .body
         .value) == dictionary {
-        let kind = it.body.value.at(
-          "kind",
-          default: none,
-        )
+        let kind = it
+          .body
+          .value
+          .at("kind", default: none)
         if kind == "touying-pause" {
           repetitions += 1
           continue
@@ -1530,10 +1528,9 @@ snapshot_kind: text
     }
     for child in children {
       if type(child) == content and child.func() == metadata and type(child.value) == dictionary {
-        let kind = child.value.at(
-          "kind",
-          default: none,
-        )
+        let kind = child
+          .value
+          .at("kind", default: none)
         if kind == "touying-pause" {
           repetitions += 1
         } else if kind == "touying-meanwhile" {
@@ -2241,17 +2238,15 @@ snapshot_kind: text
 #let _get-header-footer(self) = {
   let header = utils.call-or-display(
     self,
-    self.page.at(
-      "header",
-      default: none,
-    ),
+    self
+      .page
+      .at("header", default: none),
   )
   let footer = utils.call-or-display(
     self,
-    self.page.at(
-      "footer",
-      default: none,
-    ),
+    self
+      .page
+      .at("footer", default: none),
   )
   // negative padding
   if self.at(
@@ -2460,48 +2455,48 @@ snapshot_kind: text
           let headings = self
             .at("headings", default: ())
             .map(it => if it.has("label") {
-            if str(it.label) in (
-              "touying:hidden",
-              "touying:unnumbered",
-              "touying:unoutlined",
-              "touying:unbookmarked",
-            ) {
-              let fields = it.fields()
-              let _ = fields.remove(
-                "label",
-                default: none,
-              )
-              let _ = fields.remove(
-                "body",
-                default: none,
-              )
-              if str(it.label) == "touying:hidden" {
-                fields.numbering = none
-                fields.outlined = false
-                fields.bookmarked = false
+              if str(it.label) in (
+                "touying:hidden",
+                "touying:unnumbered",
+                "touying:unoutlined",
+                "touying:unbookmarked",
+              ) {
+                let fields = it.fields()
+                let _ = fields.remove(
+                  "label",
+                  default: none,
+                )
+                let _ = fields.remove(
+                  "body",
+                  default: none,
+                )
+                if str(it.label) == "touying:hidden" {
+                  fields.numbering = none
+                  fields.outlined = false
+                  fields.bookmarked = false
+                }
+                if str(it.label) == "touying:unnumbered" {
+                  fields.numbering = none
+                }
+                if str(it.label) == "touying:unoutlined" {
+                  fields.outlined = false
+                }
+                if str(it.label) == "touying:unbookmarked" {
+                  fields.bookmarked = false
+                }
+                utils.label-it(
+                  heading(
+                    ..fields,
+                    it.body,
+                  ),
+                  it.label,
+                )
+              } else {
+                it
               }
-              if str(it.label) == "touying:unnumbered" {
-                fields.numbering = none
-              }
-              if str(it.label) == "touying:unoutlined" {
-                fields.outlined = false
-              }
-              if str(it.label) == "touying:unbookmarked" {
-                fields.bookmarked = false
-              }
-              utils.label-it(
-                heading(
-                  ..fields,
-                  it.body,
-                ),
-                it.label,
-              )
             } else {
               it
-            }
-          } else {
-            it
-          })
+            })
           headings.sum(default: none)
         }),
       )
@@ -2539,31 +2534,31 @@ snapshot_kind: text
           utils
             .saved-frozen-states
             .update(
-            self
-              .frozen-states
-              .map(s => s.get()),
-          )
+              self
+                .frozen-states
+                .map(s => s.get()),
+            )
           utils
             .saved-default-frozen-states
             .update(
-            self
-              .default-frozen-states
-              .map(s => s.get()),
-          )
+              self
+                .default-frozen-states
+                .map(s => s.get()),
+            )
           utils
             .saved-frozen-counters
             .update(
-            self
-              .frozen-counters
-              .map(s => s.get()),
-          )
+              self
+                .frozen-counters
+                .map(s => s.get()),
+            )
           utils
             .saved-default-frozen-counters
             .update(
-            self
-              .default-frozen-counters
-              .map(s => s.get()),
-          )
+              self
+                .default-frozen-counters
+                .map(s => s.get()),
+            )
         }
       } else {
         // restore the states and counters

--- a/tests/snapshots/assets__check_file@packages-touying-core.typ-80.snap
+++ b/tests/snapshots/assets__check_file@packages-touying-core.typ-80.snap
@@ -703,9 +703,9 @@ snapshot_kind: text
   touying-fn-wrapper(
     utils.alternatives-match,
     last-subslide: calc.max(
-      ..subslides-contents.pairs().map(kv => utils.last-required-subslide(
-        kv.at(0),
-      )),
+      ..subslides-contents
+        .pairs()
+        .map(kv => utils.last-required-subslide(kv.at(0))),
     ),
     subslides-contents,
     position: position,
@@ -1928,36 +1928,36 @@ snapshot_kind: text
           let headings = self
             .at("headings", default: ())
             .map(it => if it.has("label") {
-            if str(it.label) in (
-              "touying:hidden",
-              "touying:unnumbered",
-              "touying:unoutlined",
-              "touying:unbookmarked",
-            ) {
-              let fields = it.fields()
-              let _ = fields.remove("label", default: none)
-              let _ = fields.remove("body", default: none)
-              if str(it.label) == "touying:hidden" {
-                fields.numbering = none
-                fields.outlined = false
-                fields.bookmarked = false
+              if str(it.label) in (
+                "touying:hidden",
+                "touying:unnumbered",
+                "touying:unoutlined",
+                "touying:unbookmarked",
+              ) {
+                let fields = it.fields()
+                let _ = fields.remove("label", default: none)
+                let _ = fields.remove("body", default: none)
+                if str(it.label) == "touying:hidden" {
+                  fields.numbering = none
+                  fields.outlined = false
+                  fields.bookmarked = false
+                }
+                if str(it.label) == "touying:unnumbered" {
+                  fields.numbering = none
+                }
+                if str(it.label) == "touying:unoutlined" {
+                  fields.outlined = false
+                }
+                if str(it.label) == "touying:unbookmarked" {
+                  fields.bookmarked = false
+                }
+                utils.label-it(heading(..fields, it.body), it.label)
+              } else {
+                it
               }
-              if str(it.label) == "touying:unnumbered" {
-                fields.numbering = none
-              }
-              if str(it.label) == "touying:unoutlined" {
-                fields.outlined = false
-              }
-              if str(it.label) == "touying:unbookmarked" {
-                fields.bookmarked = false
-              }
-              utils.label-it(heading(..fields, it.body), it.label)
             } else {
               it
-            }
-          } else {
-            it
-          })
+            })
           headings.sum(default: none)
         }),
       )
@@ -1982,15 +1982,15 @@ snapshot_kind: text
         // save the states and counters
         context {
           utils.saved-frozen-states.update(self.frozen-states.map(s => s.get()))
-          utils.saved-default-frozen-states.update(
-            self.default-frozen-states.map(s => s.get()),
-          )
-          utils.saved-frozen-counters.update(
-            self.frozen-counters.map(s => s.get()),
-          )
-          utils.saved-default-frozen-counters.update(
-            self.default-frozen-counters.map(s => s.get()),
-          )
+          utils
+            .saved-default-frozen-states
+            .update(self.default-frozen-states.map(s => s.get()))
+          utils
+            .saved-frozen-counters
+            .update(self.frozen-counters.map(s => s.get()))
+          utils
+            .saved-default-frozen-counters
+            .update(self.default-frozen-counters.map(s => s.get()))
         }
       } else {
         // restore the states and counters

--- a/tests/snapshots/assets__check_file@packages-touying-utils.typ-0.snap
+++ b/tests/snapshots/assets__check_file@packages-touying-utils.typ-0.snap
@@ -480,8 +480,14 @@ snapshot_kind: text
       lbl,
     ) => titlecase(
       lbl
-        .replace(regex("^[^:]*:"), "")
-        .replace("_", " ")
+        .replace(
+          regex("^[^:]*:"),
+          "",
+        )
+        .replace(
+          "_",
+          " ",
+        )
         .replace(
         "-",
         " ",
@@ -760,8 +766,8 @@ snapshot_kind: text
           .text
           .split("\n")
           .map(l => (
-              "\n" + indent * " " + l
-            ))
+            "\n" + indent * " " + l
+          ))
           .sum(default: "") + "\n" + indent * " " + "```"
       } else {
         "`" + it.text + "`"
@@ -841,7 +847,9 @@ snapshot_kind: text
   if type(size) == ratio {
     to-convert = container-dimension * size
   }
-  measure(v(to-convert)).height
+  measure(
+    v(to-convert),
+  ).height
 }
 
 #let _limit-content-width(
@@ -1689,7 +1697,10 @@ snapshot_kind: text
     let raw-text = if type(note) == content and note.has("text") {
       note.text
     } else {
-      markup-text(note, mode: mode).trim()
+      markup-text(
+        note,
+        mode: mode,
+      ).trim()
     }
     pdfpc.speaker-note(raw-text)
   }

--- a/tests/snapshots/assets__check_file@packages-touying-utils.typ-0.snap
+++ b/tests/snapshots/assets__check_file@packages-touying-utils.typ-0.snap
@@ -336,9 +336,9 @@ snapshot_kind: text
   is-metadata(it) and type(it.value) == dictionary and it
     .value
     .at(
-    "kind",
-    default: none,
-  ) == kind
+      "kind",
+      default: none,
+    ) == kind
 }
 
 
@@ -489,9 +489,9 @@ snapshot_kind: text
           " ",
         )
         .replace(
-        "-",
-        " ",
-      ),
+          "-",
+          " ",
+        ),
     )
   }
   convert-label-to-short-heading = convert-label-to-short-heading.with(self: self)
@@ -719,11 +719,11 @@ snapshot_kind: text
       .info
       .date
       .display(
-      self.at(
-        "datetime-format",
-        default: auto,
-      ),
-    )
+        self.at(
+          "datetime-format",
+          default: auto,
+        ),
+      )
   } else {
     self
       .info

--- a/tests/snapshots/assets__check_file@packages-touying-utils.typ-40.snap
+++ b/tests/snapshots/assets__check_file@packages-touying-utils.typ-40.snap
@@ -615,12 +615,15 @@ snapshot_kind: text
     message: "self must have an info field",
   )
   if type(self.info.date) == datetime {
-    self.info.date.display(
-      self.at(
-        "datetime-format",
-        default: auto,
-      ),
-    )
+    self
+      .info
+      .date
+      .display(
+        self.at(
+          "datetime-format",
+          default: auto,
+        ),
+      )
   } else {
     self.info.date
   }

--- a/tests/snapshots/assets__check_file@packages-touying-utils.typ-40.snap
+++ b/tests/snapshots/assets__check_file@packages-touying-utils.typ-40.snap
@@ -661,8 +661,8 @@ snapshot_kind: text
           .text
           .split("\n")
           .map(l => (
-              "\n" + indent * " " + l
-            ))
+            "\n" + indent * " " + l
+          ))
           .sum(default: "") + "\n" + indent * " " + "```"
       } else {
         "`" + it.text + "`"
@@ -1522,7 +1522,10 @@ snapshot_kind: text
     let raw-text = if type(note) == content and note.has("text") {
       note.text
     } else {
-      markup-text(note, mode: mode).trim()
+      markup-text(
+        note,
+        mode: mode,
+      ).trim()
     }
     pdfpc.speaker-note(raw-text)
   }

--- a/tests/snapshots/assets__check_file@packages-touying-utils.typ-80.snap
+++ b/tests/snapshots/assets__check_file@packages-touying-utils.typ-80.snap
@@ -223,10 +223,9 @@ snapshot_kind: text
 
 /// Determine if a content is a metadata with a specific kind
 #let is-kind(it, kind) = {
-  is-metadata(it) and type(it.value) == dictionary and it.value.at(
-    "kind",
-    default: none,
-  ) == kind
+  is-metadata(it) and type(it.value) == dictionary and it
+    .value
+    .at("kind", default: none) == kind
 }
 
 

--- a/tests/snapshots/assets__check_file@tablex.typ-0.snap
+++ b/tests/snapshots/assets__check_file@tablex.typ-0.snap
@@ -362,8 +362,8 @@ snapshot_kind: text
   // maximum explicit 'y' specified
   let max_explicit_y = items
     .filter(c => (
-        c.y != auto
-      ))
+      c.y != auto
+    ))
     .fold(
     0,
     (
@@ -733,13 +733,19 @@ snapshot_kind: text
     let em = len.em
     // Measure with abs (and later multiply by the sign) so negative em works.
     // Otherwise it would return 0pt, and we would need to measure again with abs.
-    let measured-em = calc-sign(em) * measure(box(width: calc.abs(em) * 1em), styles).width
+    let measured-em = calc-sign(em) * measure(
+      box(width: calc.abs(em) * 1em),
+      styles,
+    ).width
 
     return pt + measured-em
   }
 
   // Fields not supported, so we have to measure twice when em can be negative.
-  let measured-pt = measure(box(width: len), styles).width
+  let measured-pt = measure(
+    box(width: len),
+    styles,
+  ).width
 
   // If the measured length is positive, `len` must have overall been positive.
   // There's nothing else to be done, so return the measured length.
@@ -752,7 +758,10 @@ snapshot_kind: text
   // Hence, `len` must either be `0pt` or negative.
   // We multiply `len` by -1 to get a positive length, draw a line and measure it, then negate
   // the measured length. This nicely handles the `0pt` case as well.
-  measured-pt = -measure(box(width: -len), styles).width
+  measured-pt = -measure(
+    box(width: -len),
+    styles,
+  ).width
   return measured-pt
 }
 
@@ -1093,9 +1102,12 @@ snapshot_kind: text
   grid: none,
   width: none,
 ) = {
-  width = default-if-none(grid, (
+  width = default-if-none(
+    grid,
+    (
       width: width,
-    )).width
+    ),
+  ).width
   width = calc.floor(width)
   (
     y * width
@@ -1215,7 +1227,9 @@ snapshot_kind: text
   grid,
   x,
 ) = {
-  range(grid-count-rows(grid)).map(y => grid-at(
+  range(
+    grid-count-rows(grid),
+  ).map(y => grid-at(
     grid,
     x,
     y,
@@ -2059,10 +2073,10 @@ snapshot_kind: text
   let all-frac-columns = columns
     .enumerate()
     .filter(i-col => (
-        type(
-          i-col.at(1),
-        ) == _fraction-type
-      ))
+      type(
+        i-col.at(1),
+      ) == _fraction-type
+    ))
     .map(i-col => i-col.at(0))
   for (
     i,
@@ -2070,7 +2084,10 @@ snapshot_kind: text
   ) in columns.enumerate() {
     if col == auto {
       // max cell width
-      let col_size = grid-get-column(grid, i).fold(
+      let col_size = grid-get-column(
+        grid,
+        i,
+      ).fold(
         0pt,
         (
           max,
@@ -2143,7 +2160,10 @@ snapshot_kind: text
               align_default: auto,
             )
 
-            let width = measure(cell-box, styles).width // + 2*cell_inset // the box already considers inset
+            let width = measure(
+              cell-box,
+              styles,
+            ).width // + 2*cell_inset // the box already considers inset
 
             // here, we are excluding from the width of this cell
             // at this column all width that was already covered by
@@ -2402,7 +2422,10 @@ snapshot_kind: text
   ) in rows.enumerate() {
     if row == auto {
       // max cell height
-      let row_size = grid-get-row(grid, i).fold(
+      let row_size = grid-get-row(
+        grid,
+        i,
+      ).fold(
         0pt,
         (
           max,
@@ -2459,7 +2482,10 @@ snapshot_kind: text
             // measure the cell's actual height,
             // with its calculated width
             // and with other constraints
-            let height = measure(cell-box, styles).height // + 2*cell_inset (box already considers inset)
+            let height = measure(
+              cell-box,
+              styles,
+            ).height // + 2*cell_inset (box already considers inset)
 
             // here, we are excluding from the height of this cell
             // at this row all height that was already covered by
@@ -2639,9 +2665,12 @@ snapshot_kind: text
   pre-gutter: false,
 ) = {
   let col-gutter = default-if-none(
-    default-if-none(gutter, (
+    default-if-none(
+      gutter,
+      (
         col: 0pt,
-      )).col,
+      ),
+    ).col,
     0pt,
   )
   end = default-if-none(
@@ -2684,9 +2713,12 @@ snapshot_kind: text
   pre-gutter: false,
 ) = {
   let row-gutter = default-if-none(
-    default-if-none(gutter, (
+    default-if-none(
+      gutter,
+      (
         row: 0pt,
-      )).row,
+      ),
+    ).row,
     0pt,
   )
   end = default-if-none(
@@ -2839,92 +2871,92 @@ snapshot_kind: text
 
   let hlines = hlines
     .filter(h => {
-        let y = h.y
+      let y = h.y
 
-        let in_top_or_bottom = y in (
-          cell.y,
-          cell.y + cell.rowspan,
-        )
+      let in_top_or_bottom = y in (
+        cell.y,
+        cell.y + cell.rowspan,
+      )
 
-        let hline_hasnt_already_ended = (
-          h.end in (
-            auto,
-            none,
-          ) // always goes towards the right
-          or h.end >= cell.x + cell.colspan // ends at or after this cell
-        )
+      let hline_hasnt_already_ended = (
+        h.end in (
+          auto,
+          none,
+        ) // always goes towards the right
+        or h.end >= cell.x + cell.colspan // ends at or after this cell
+      )
 
-        (
-          in_top_or_bottom and hline_hasnt_already_ended
-        )
-      })
+      (
+        in_top_or_bottom and hline_hasnt_already_ended
+      )
+    })
     .map(h => {
-        // get the intersection between the hline and the cell's x-span.
-        let span = get-included-span(
-          h.start,
-          h.end,
-          start: cell.x,
-          end: cell.x + cell.colspan,
-          limit: x_limit,
-        )
+      // get the intersection between the hline and the cell's x-span.
+      let span = get-included-span(
+        h.start,
+        h.end,
+        start: cell.x,
+        end: cell.x + cell.colspan,
+        limit: x_limit,
+      )
 
-        if span == none {
-          // no intersection!
-          none
-        } else {
-          v-or-hline-with-span(
-            h,
-            start: span.at(0),
-            end: span.at(1),
-          )
-        }
-      })
+      if span == none {
+        // no intersection!
+        none
+      } else {
+        v-or-hline-with-span(
+          h,
+          start: span.at(0),
+          end: span.at(1),
+        )
+      }
+    })
     .filter(x => (
     x != none
   ))
 
   let vlines = vlines
     .filter(v => {
-        let x = v.x
+      let x = v.x
 
-        let at_left_or_right = x in (
-          cell.x,
-          cell.x + cell.colspan,
-        )
+      let at_left_or_right = x in (
+        cell.x,
+        cell.x + cell.colspan,
+      )
 
-        let vline_hasnt_already_ended = (
-          v.end in (
-            auto,
-            none,
-          ) // always goes towards the bottom
-          or v.end >= cell.y + cell.rowspan // ends at or after this cell
-        )
+      let vline_hasnt_already_ended = (
+        v.end in (
+          auto,
+          none,
+        ) // always goes towards the bottom
+        or v.end >= cell.y + cell.rowspan // ends at or after this cell
+      )
 
-        (
-          at_left_or_right and vline_hasnt_already_ended
-        )
-      })
+      (
+        at_left_or_right and vline_hasnt_already_ended
+      )
+    })
     .map(v => {
-        // get the intersection between the hline and the cell's x-span.
-        let span = get-included-span(
-          v.start,
-          v.end,
-          start: cell.y,
-          end: cell.y + cell.rowspan,
-          limit: y_limit,
-        )
+      // get the intersection between the hline and the cell's x-span.
+      let span = get-included-span(
+        v.start,
+        v.end,
+        start: cell.y,
+        end: cell.y + cell.rowspan,
+        limit: y_limit,
+      )
 
-        if span == none {
-          // no intersection!
-          none
-        } else {
-          v-or-hline-with-span(
-            v,
-            start: span.at(0),
-            end: span.at(1),
-          )
-        }
-      })
+      if span == none {
+        // no intersection!
+        none
+      } else {
+        v-or-hline-with-span(
+          v,
+          start: span.at(0),
+          end: span.at(1),
+        )
+      }
+    })
     .filter(x => (
     x != none
   ))
@@ -3974,7 +4006,9 @@ snapshot_kind: text
         let hlines = hlines.filter(h => (
           this_row_group
             .hlines
-            .filter(is-same-hline.with(h))
+            .filter(
+              is-same-hline.with(h),
+            )
             .len() == 0
         ))
 
@@ -4099,7 +4133,10 @@ snapshot_kind: text
     } else {
       line
         .expand
-        .slice(0, 2)
+        .slice(
+          0,
+          2,
+        )
         .map(e => {
         if e == none {
           e
@@ -4161,26 +4198,32 @@ snapshot_kind: text
   let new_vlines = ()
 
   if auto-hlines {
-    new_hlines = range(0, row_len + 1)
+    new_hlines = range(
+      0,
+      row_len + 1,
+    )
       .filter(y => (
-          hlines
-            .filter(h => (
-                h.y == y
-              ))
-            .len() == 0
-        ))
+        hlines
+          .filter(h => (
+            h.y == y
+          ))
+          .len() == 0
+      ))
       .map(y => hlinex(y: y))
   }
 
   if auto-vlines {
-    new_vlines = range(0, col_len + 1)
+    new_vlines = range(
+      0,
+      col_len + 1,
+    )
       .filter(x => (
-          vlines
-            .filter(v => (
-                v.x == x
-              ))
-            .len() == 0
-        ))
+        vlines
+          .filter(v => (
+            v.x == x
+          ))
+          .len() == 0
+      ))
       .map(x => vlinex(x: x))
   }
 

--- a/tests/snapshots/assets__check_file@tablex.typ-0.snap
+++ b/tests/snapshots/assets__check_file@tablex.typ-0.snap
@@ -127,19 +127,19 @@ snapshot_kind: text
       fit-spans
         .keys()
         .all(k => (
-        k in (
-          "x",
-          "y",
-        )
-      )),
+          k in (
+            "x",
+            "y",
+          )
+        )),
       message: "Tablex error:" + error-prefix + " 'fit-spans', if a dictionary, must only have the keys x and y.",
     )
     assert(
       fit-spans
         .values()
         .all(v => (
-        type(v) == _bool-type
-      )),
+          type(v) == _bool-type
+        )),
       message: "Tablex error:" + error-prefix + " keys 'x' and 'y' in the 'fit-spans' dictionary must be booleans (true/false).",
     )
     for key in (
@@ -365,23 +365,23 @@ snapshot_kind: text
       c.y != auto
     ))
     .fold(
-    0,
-    (
-      acc,
-      cell,
-    ) => {
-      if (
-        is-tablex-cell(cell) and type(cell.y) in (
-          _int-type,
-          _float-type,
-        ) and cell.y > acc
-      ) {
-        cell.y
-      } else {
-        acc
-      }
-    },
-  )
+      0,
+      (
+        acc,
+        cell,
+      ) => {
+        if (
+          is-tablex-cell(cell) and type(cell.y) in (
+            _int-type,
+            _float-type,
+          ) and cell.y > acc
+        ) {
+          cell.y
+        } else {
+          acc
+        }
+      },
+    )
 
   for item in (
     items
@@ -1202,12 +1202,12 @@ snapshot_kind: text
     let cell-row = grid
       .items
       .slice(
-      first-row-pos,
-      calc.min(
-        len,
-        next-row-pos,
-      ),
-    )
+        first-row-pos,
+        calc.min(
+          len,
+          next-row-pos,
+        ),
+      )
     let cell-row-len = cell-row.len()
     if cell-row-len < grid.width {
       // the row isn't complete because the grid wasn't large enough.
@@ -1271,8 +1271,8 @@ snapshot_kind: text
     grid
       .items
       .push(
-      fill_with(grid),
-    )
+        fill_with(grid),
+      )
   }
   let new = grid-index-to-pos(
     grid,
@@ -1709,8 +1709,8 @@ snapshot_kind: text
     grid
       .items
       .push(
-      new_empty_cell(grid),
-    )
+        new_empty_cell(grid),
+      )
   }
 
   (
@@ -1894,10 +1894,10 @@ snapshot_kind: text
   let frac-tracks = tracks
     .enumerate()
     .filter(t => (
-    type(
-      t.at(1),
-    ) == _fraction-type
-  ))
+      type(
+        t.at(1),
+      ) == _fraction-type
+    ))
 
   let amount-frac = frac-tracks.fold(
     0,
@@ -2912,8 +2912,8 @@ snapshot_kind: text
       }
     })
     .filter(x => (
-    x != none
-  ))
+      x != none
+    ))
 
   let vlines = vlines
     .filter(v => {
@@ -2958,8 +2958,8 @@ snapshot_kind: text
       }
     })
     .filter(x => (
-    x != none
-  ))
+      x != none
+    ))
 
   (
     hlines: hlines,
@@ -3734,8 +3734,8 @@ snapshot_kind: text
             .row_group
             .hlines
             .filter(h => (
-            h.y == header_last_y + 1
-          ))
+              h.y == header_last_y + 1
+            ))
 
           hlines + hlines_below_header
         } else {
@@ -3999,9 +3999,9 @@ snapshot_kind: text
           .rows
           .last()
           .push((
-          cell: cell,
-          box: cell_box,
-        ))
+            cell: cell,
+            box: cell_box,
+          ))
 
         let hlines = hlines.filter(h => (
           this_row_group
@@ -4138,28 +4138,28 @@ snapshot_kind: text
           2,
         )
         .map(e => {
-        if e == none {
-          e
-        } else {
-          e = default-if-auto(
-            e,
-            0pt,
-          )
-          if type(e) not in (
-            _length-type,
-            _rel-len-type,
-            _ratio-type,
-          ) {
-            panic("'expand' argument to lines must be a pair (length, length).")
-          }
+          if e == none {
+            e
+          } else {
+            e = default-if-auto(
+              e,
+              0pt,
+            )
+            if type(e) not in (
+              _length-type,
+              _rel-len-type,
+              _ratio-type,
+            ) {
+              panic("'expand' argument to lines must be a pair (length, length).")
+            }
 
-          convert-length-to-pt(
-            e,
-            styles: styles,
-            page-size: page-size,
-          )
-        }
-      })
+            convert-length-to-pt(
+              e,
+              styles: styles,
+              page-size: page-size,
+            )
+          }
+        })
     }
 
     line
@@ -4410,12 +4410,12 @@ snapshot_kind: text
         grid
           .items
           .at(
-          grid-index-at(
-            cell.x,
-            cell.y,
-            grid: grid,
-          ),
-        ) = cell
+            grid-index-at(
+              cell.x,
+              cell.y,
+              grid: grid,
+            ),
+          ) = cell
       }
     }
   }
@@ -4482,12 +4482,12 @@ snapshot_kind: text
         grid
           .items
           .at(
-          grid-index-at(
-            cell.x,
-            cell.y,
-            grid: grid,
-          ),
-        ) = cell
+            grid-index-at(
+              cell.x,
+              cell.y,
+              grid: grid,
+            ),
+          ) = cell
       }
     }
   }

--- a/tests/snapshots/assets__check_file@tablex.typ-120.snap
+++ b/tests/snapshots/assets__check_file@tablex.typ-120.snap
@@ -251,16 +251,18 @@ snapshot_kind: text
   let len = 0
 
   // maximum explicit 'y' specified
-  let max_explicit_y = items.filter(c => c.y != auto).fold(
-    0,
-    (acc, cell) => {
-      if (is-tablex-cell(cell) and type(cell.y) in (_int-type, _float-type) and cell.y > acc) {
-        cell.y
-      } else {
-        acc
-      }
-    },
-  )
+  let max_explicit_y = items
+    .filter(c => c.y != auto)
+    .fold(
+      0,
+      (acc, cell) => {
+        if (is-tablex-cell(cell) and type(cell.y) in (_int-type, _float-type) and cell.y > acc) {
+          cell.y
+        } else {
+          acc
+        }
+      },
+    )
 
   for item in items {
     if is-tablex-cell(item) and item.x == auto and item.y == auto {
@@ -2675,18 +2677,21 @@ snapshot_kind: text
     line.expand = if line.expand == none {
       none
     } else {
-      line.expand.slice(0, 2).map(e => {
-        if e == none {
-          e
-        } else {
-          e = default-if-auto(e, 0pt)
-          if type(e) not in (_length-type, _rel-len-type, _ratio-type) {
-            panic("'expand' argument to lines must be a pair (length, length).")
-          }
+      line
+        .expand
+        .slice(0, 2)
+        .map(e => {
+          if e == none {
+            e
+          } else {
+            e = default-if-auto(e, 0pt)
+            if type(e) not in (_length-type, _rel-len-type, _ratio-type) {
+              panic("'expand' argument to lines must be a pair (length, length).")
+            }
 
-          convert-length-to-pt(e, styles: styles, page-size: page-size)
-        }
-      })
+            convert-length-to-pt(e, styles: styles, page-size: page-size)
+          }
+        })
     }
 
     line

--- a/tests/snapshots/assets__check_file@tablex.typ-120.snap
+++ b/tests/snapshots/assets__check_file@tablex.typ-120.snap
@@ -1904,54 +1904,54 @@ snapshot_kind: text
 
   let hlines = hlines
     .filter(h => {
-        let y = h.y
+      let y = h.y
 
-        let in_top_or_bottom = y in (cell.y, cell.y + cell.rowspan)
+      let in_top_or_bottom = y in (cell.y, cell.y + cell.rowspan)
 
-        let hline_hasnt_already_ended = (
-          h.end in (auto, none) // always goes towards the right
-          or h.end >= cell.x + cell.colspan // ends at or after this cell
-        )
+      let hline_hasnt_already_ended = (
+        h.end in (auto, none) // always goes towards the right
+        or h.end >= cell.x + cell.colspan // ends at or after this cell
+      )
 
-        (in_top_or_bottom and hline_hasnt_already_ended)
-      })
+      (in_top_or_bottom and hline_hasnt_already_ended)
+    })
     .map(h => {
-        // get the intersection between the hline and the cell's x-span.
-        let span = get-included-span(h.start, h.end, start: cell.x, end: cell.x + cell.colspan, limit: x_limit)
+      // get the intersection between the hline and the cell's x-span.
+      let span = get-included-span(h.start, h.end, start: cell.x, end: cell.x + cell.colspan, limit: x_limit)
 
-        if span == none {
-          // no intersection!
-          none
-        } else {
-          v-or-hline-with-span(h, start: span.at(0), end: span.at(1))
-        }
-      })
+      if span == none {
+        // no intersection!
+        none
+      } else {
+        v-or-hline-with-span(h, start: span.at(0), end: span.at(1))
+      }
+    })
     .filter(x => x != none)
 
   let vlines = vlines
     .filter(v => {
-        let x = v.x
+      let x = v.x
 
-        let at_left_or_right = x in (cell.x, cell.x + cell.colspan)
+      let at_left_or_right = x in (cell.x, cell.x + cell.colspan)
 
-        let vline_hasnt_already_ended = (
-          v.end in (auto, none) // always goes towards the bottom
-          or v.end >= cell.y + cell.rowspan // ends at or after this cell
-        )
+      let vline_hasnt_already_ended = (
+        v.end in (auto, none) // always goes towards the bottom
+        or v.end >= cell.y + cell.rowspan // ends at or after this cell
+      )
 
-        (at_left_or_right and vline_hasnt_already_ended)
-      })
+      (at_left_or_right and vline_hasnt_already_ended)
+    })
     .map(v => {
-        // get the intersection between the hline and the cell's x-span.
-        let span = get-included-span(v.start, v.end, start: cell.y, end: cell.y + cell.rowspan, limit: y_limit)
+      // get the intersection between the hline and the cell's x-span.
+      let span = get-included-span(v.start, v.end, start: cell.y, end: cell.y + cell.rowspan, limit: y_limit)
 
-        if span == none {
-          // no intersection!
-          none
-        } else {
-          v-or-hline-with-span(v, start: span.at(0), end: span.at(1))
-        }
-      })
+      if span == none {
+        // no intersection!
+        none
+      } else {
+        v-or-hline-with-span(v, start: span.at(0), end: span.at(1))
+      }
+    })
     .filter(x => x != none)
 
   (

--- a/tests/snapshots/assets__check_file@tablex.typ-40.snap
+++ b/tests/snapshots/assets__check_file@tablex.typ-40.snap
@@ -101,15 +101,17 @@ snapshot_kind: text
       message: "Tablex error:" + error-prefix + " 'fit-spans', if a dictionary, must not be empty.",
     )
     assert(
-      fit-spans.keys().all(k => (
-        k in ("x", "y")
-      )),
+      fit-spans
+        .keys()
+        .all(k => k in ("x", "y")),
       message: "Tablex error:" + error-prefix + " 'fit-spans', if a dictionary, must only have the keys x and y.",
     )
     assert(
-      fit-spans.values().all(v => (
-        type(v) == _bool-type
-      )),
+      fit-spans
+        .values()
+        .all(v => (
+          type(v) == _bool-type
+        )),
       message: "Tablex error:" + error-prefix + " keys 'x' and 'y' in the 'fit-spans' dictionary must be booleans (true/false).",
     )
     for key in ("x", "y") {
@@ -316,20 +318,20 @@ snapshot_kind: text
   let max_explicit_y = items
     .filter(c => c.y != auto)
     .fold(
-    0,
-    (acc, cell) => {
-      if (
-        is-tablex-cell(cell) and type(cell.y) in (
-          _int-type,
-          _float-type,
-        ) and cell.y > acc
-      ) {
-        cell.y
-      } else {
-        acc
-      }
-    },
-  )
+      0,
+      (acc, cell) => {
+        if (
+          is-tablex-cell(cell) and type(cell.y) in (
+            _int-type,
+            _float-type,
+          ) and cell.y > acc
+        ) {
+          cell.y
+        } else {
+          acc
+        }
+      },
+    )
 
   for item in items {
     if is-tablex-cell(item) and item.x == auto and item.y == auto {
@@ -1033,10 +1035,12 @@ snapshot_kind: text
   } else {
     // position right after the last cell in this row
     let next-row-pos = first-row-pos + grid.width
-    let cell-row = grid.items.slice(
-      first-row-pos,
-      calc.min(len, next-row-pos),
-    )
+    let cell-row = grid
+      .items
+      .slice(
+        first-row-pos,
+        calc.min(len, next-row-pos),
+      )
     let cell-row-len = cell-row.len()
     if cell-row-len < grid.width {
       // the row isn't complete because the grid wasn't large enough.
@@ -1478,9 +1482,9 @@ snapshot_kind: text
     grid.items.len(),
     grid.width,
   ) != 0 {
-    grid.items.push(
-      new_empty_cell(grid),
-    )
+    grid
+      .items
+      .push(new_empty_cell(grid))
   }
 
   (
@@ -1653,8 +1657,8 @@ snapshot_kind: text
   let frac-tracks = tracks
     .enumerate()
     .filter(t => (
-    type(t.at(1)) == _fraction-type
-  ))
+      type(t.at(1)) == _fraction-type
+    ))
 
   let amount-frac = frac-tracks.fold(
     0,
@@ -3333,8 +3337,8 @@ snapshot_kind: text
             .row_group
             .hlines
             .filter(h => (
-            h.y == header_last_y + 1
-          ))
+              h.y == header_last_y + 1
+            ))
 
           hlines + hlines_below_header
         } else {
@@ -3581,9 +3585,9 @@ snapshot_kind: text
           .rows
           .last()
           .push((
-          cell: cell,
-          box: cell_box,
-        ))
+            cell: cell,
+            box: cell_box,
+          ))
 
         let hlines = hlines.filter(h => (
           this_row_group
@@ -3702,26 +3706,29 @@ snapshot_kind: text
     line.expand = if line.expand == none {
       none
     } else {
-      line.expand.slice(0, 2).map(e => {
-        if e == none {
-          e
-        } else {
-          e = default-if-auto(e, 0pt)
-          if type(e) not in (
-            _length-type,
-            _rel-len-type,
-            _ratio-type,
-          ) {
-            panic("'expand' argument to lines must be a pair (length, length).")
-          }
+      line
+        .expand
+        .slice(0, 2)
+        .map(e => {
+          if e == none {
+            e
+          } else {
+            e = default-if-auto(e, 0pt)
+            if type(e) not in (
+              _length-type,
+              _rel-len-type,
+              _ratio-type,
+            ) {
+              panic("'expand' argument to lines must be a pair (length, length).")
+            }
 
-          convert-length-to-pt(
-            e,
-            styles: styles,
-            page-size: page-size,
-          )
-        }
-      })
+            convert-length-to-pt(
+              e,
+              styles: styles,
+              page-size: page-size,
+            )
+          }
+        })
     }
 
     line
@@ -3952,13 +3959,15 @@ snapshot_kind: text
         }
 
         cell.content = [#cell.content]
-        grid.items.at(
-          grid-index-at(
-            cell.x,
-            cell.y,
-            grid: grid,
-          ),
-        ) = cell
+        grid
+          .items
+          .at(
+            grid-index-at(
+              cell.x,
+              cell.y,
+              grid: grid,
+            ),
+          ) = cell
       }
     }
   }
@@ -4020,13 +4029,15 @@ snapshot_kind: text
         }
 
         cell.content = [#cell.content]
-        grid.items.at(
-          grid-index-at(
-            cell.x,
-            cell.y,
-            grid: grid,
-          ),
-        ) = cell
+        grid
+          .items
+          .at(
+            grid-index-at(
+              cell.x,
+              cell.y,
+              grid: grid,
+            ),
+          ) = cell
       }
     }
   }

--- a/tests/snapshots/assets__check_file@tablex.typ-40.snap
+++ b/tests/snapshots/assets__check_file@tablex.typ-40.snap
@@ -616,13 +616,19 @@ snapshot_kind: text
     let em = len.em
     // Measure with abs (and later multiply by the sign) so negative em works.
     // Otherwise it would return 0pt, and we would need to measure again with abs.
-    let measured-em = calc-sign(em) * measure(box(width: calc.abs(em) * 1em), styles).width
+    let measured-em = calc-sign(em) * measure(
+      box(width: calc.abs(em) * 1em),
+      styles,
+    ).width
 
     return pt + measured-em
   }
 
   // Fields not supported, so we have to measure twice when em can be negative.
-  let measured-pt = measure(box(width: len), styles).width
+  let measured-pt = measure(
+    box(width: len),
+    styles,
+  ).width
 
   // If the measured length is positive, `len` must have overall been positive.
   // There's nothing else to be done, so return the measured length.
@@ -635,7 +641,10 @@ snapshot_kind: text
   // Hence, `len` must either be `0pt` or negative.
   // We multiply `len` by -1 to get a positive length, draw a line and measure it, then negate
   // the measured length. This nicely handles the `0pt` case as well.
-  measured-pt = -measure(box(width: -len), styles).width
+  measured-pt = -measure(
+    box(width: -len),
+    styles,
+  ).width
   return measured-pt
 }
 
@@ -961,9 +970,10 @@ snapshot_kind: text
   grid: none,
   width: none,
 ) = {
-  width = default-if-none(grid, (
-      width: width,
-    )).width
+  width = default-if-none(
+    grid,
+    (width: width),
+  ).width
   width = calc.floor(width)
   (y * width) + calc-mod(x, width)
 }
@@ -1041,11 +1051,9 @@ snapshot_kind: text
 
 // Fetches an entire column of cells (all positions with the given x).
 #let grid-get-column(grid, x) = {
-  range(grid-count-rows(grid)).map(y => grid-at(
-    grid,
-    x,
-    y,
-  ))
+  range(
+    grid-count-rows(grid),
+  ).map(y => grid-at(grid, x, y))
 }
 
 // Expand grid to the given coords (add the missing cells)
@@ -1791,15 +1799,18 @@ snapshot_kind: text
   let all-frac-columns = columns
     .enumerate()
     .filter(i-col => (
-        type(
-          i-col.at(1),
-        ) == _fraction-type
-      ))
+      type(
+        i-col.at(1),
+      ) == _fraction-type
+    ))
     .map(i-col => i-col.at(0))
   for (i, col) in columns.enumerate() {
     if col == auto {
       // max cell width
-      let col_size = grid-get-column(grid, i).fold(
+      let col_size = grid-get-column(
+        grid,
+        i,
+      ).fold(
         0pt,
         (max, cell) => {
           if cell == none {
@@ -1867,7 +1878,10 @@ snapshot_kind: text
               align_default: auto,
             )
 
-            let width = measure(cell-box, styles).width // + 2*cell_inset // the box already considers inset
+            let width = measure(
+              cell-box,
+              styles,
+            ).width // + 2*cell_inset // the box already considers inset
 
             // here, we are excluding from the width of this cell
             // at this column all width that was already covered by
@@ -2110,7 +2124,10 @@ snapshot_kind: text
   for (i, row) in rows.enumerate() {
     if row == auto {
       // max cell height
-      let row_size = grid-get-row(grid, i).fold(
+      let row_size = grid-get-row(
+        grid,
+        i,
+      ).fold(
         0pt,
         (max, cell) => {
           if cell == none {
@@ -2162,7 +2179,10 @@ snapshot_kind: text
             // measure the cell's actual height,
             // with its calculated width
             // and with other constraints
-            let height = measure(cell-box, styles).height // + 2*cell_inset (box already considers inset)
+            let height = measure(
+              cell-box,
+              styles,
+            ).height // + 2*cell_inset (box already considers inset)
 
             // here, we are excluding from the height of this cell
             // at this row all height that was already covered by
@@ -2339,9 +2359,10 @@ snapshot_kind: text
   pre-gutter: false,
 ) = {
   let col-gutter = default-if-none(
-    default-if-none(gutter, (
-        col: 0pt,
-      )).col,
+    default-if-none(
+      gutter,
+      (col: 0pt),
+    ).col,
     0pt,
   )
   end = default-if-none(
@@ -2379,9 +2400,10 @@ snapshot_kind: text
   pre-gutter: false,
 ) = {
   let row-gutter = default-if-none(
-    default-if-none(gutter, (
-        row: 0pt,
-      )).row,
+    default-if-none(
+      gutter,
+      (row: 0pt),
+    ).row,
     0pt,
   )
   end = default-if-none(end, rows.len())
@@ -2508,90 +2530,90 @@ snapshot_kind: text
 
   let hlines = hlines
     .filter(h => {
-        let y = h.y
+      let y = h.y
 
-        let in_top_or_bottom = y in (
-          cell.y,
-          cell.y + cell.rowspan,
-        )
+      let in_top_or_bottom = y in (
+        cell.y,
+        cell.y + cell.rowspan,
+      )
 
-        let hline_hasnt_already_ended = (
-          h.end in (
-            auto,
-            none,
-          ) // always goes towards the right
-          or h.end >= cell.x + cell.colspan // ends at or after this cell
-        )
+      let hline_hasnt_already_ended = (
+        h.end in (
+          auto,
+          none,
+        ) // always goes towards the right
+        or h.end >= cell.x + cell.colspan // ends at or after this cell
+      )
 
-        (
-          in_top_or_bottom and hline_hasnt_already_ended
-        )
-      })
+      (
+        in_top_or_bottom and hline_hasnt_already_ended
+      )
+    })
     .map(h => {
-        // get the intersection between the hline and the cell's x-span.
-        let span = get-included-span(
-          h.start,
-          h.end,
-          start: cell.x,
-          end: cell.x + cell.colspan,
-          limit: x_limit,
-        )
+      // get the intersection between the hline and the cell's x-span.
+      let span = get-included-span(
+        h.start,
+        h.end,
+        start: cell.x,
+        end: cell.x + cell.colspan,
+        limit: x_limit,
+      )
 
-        if span == none {
-          // no intersection!
-          none
-        } else {
-          v-or-hline-with-span(
-            h,
-            start: span.at(0),
-            end: span.at(1),
-          )
-        }
-      })
+      if span == none {
+        // no intersection!
+        none
+      } else {
+        v-or-hline-with-span(
+          h,
+          start: span.at(0),
+          end: span.at(1),
+        )
+      }
+    })
     .filter(x => x != none)
 
   let vlines = vlines
     .filter(v => {
-        let x = v.x
+      let x = v.x
 
-        let at_left_or_right = x in (
-          cell.x,
-          cell.x + cell.colspan,
-        )
+      let at_left_or_right = x in (
+        cell.x,
+        cell.x + cell.colspan,
+      )
 
-        let vline_hasnt_already_ended = (
-          v.end in (
-            auto,
-            none,
-          ) // always goes towards the bottom
-          or v.end >= cell.y + cell.rowspan // ends at or after this cell
-        )
+      let vline_hasnt_already_ended = (
+        v.end in (
+          auto,
+          none,
+        ) // always goes towards the bottom
+        or v.end >= cell.y + cell.rowspan // ends at or after this cell
+      )
 
-        (
-          at_left_or_right and vline_hasnt_already_ended
-        )
-      })
+      (
+        at_left_or_right and vline_hasnt_already_ended
+      )
+    })
     .map(v => {
-        // get the intersection between the hline and the cell's x-span.
-        let span = get-included-span(
-          v.start,
-          v.end,
-          start: cell.y,
-          end: cell.y + cell.rowspan,
-          limit: y_limit,
-        )
+      // get the intersection between the hline and the cell's x-span.
+      let span = get-included-span(
+        v.start,
+        v.end,
+        start: cell.y,
+        end: cell.y + cell.rowspan,
+        limit: y_limit,
+      )
 
-        if span == none {
-          // no intersection!
-          none
-        } else {
-          v-or-hline-with-span(
-            v,
-            start: span.at(0),
-            end: span.at(1),
-          )
-        }
-      })
+      if span == none {
+        // no intersection!
+        none
+      } else {
+        v-or-hline-with-span(
+          v,
+          start: span.at(0),
+          end: span.at(1),
+        )
+      }
+    })
     .filter(x => x != none)
 
   (
@@ -3566,7 +3588,9 @@ snapshot_kind: text
         let hlines = hlines.filter(h => (
           this_row_group
             .hlines
-            .filter(is-same-hline.with(h))
+            .filter(
+              is-same-hline.with(h),
+            )
             .len() == 0
         ))
 
@@ -3738,20 +3762,20 @@ snapshot_kind: text
   if auto-hlines {
     new_hlines = range(0, row_len + 1)
       .filter(y => (
-          hlines
-            .filter(h => h.y == y)
-            .len() == 0
-        ))
+        hlines
+          .filter(h => h.y == y)
+          .len() == 0
+      ))
       .map(y => hlinex(y: y))
   }
 
   if auto-vlines {
     new_vlines = range(0, col_len + 1)
       .filter(x => (
-          vlines
-            .filter(v => v.x == x)
-            .len() == 0
-        ))
+        vlines
+          .filter(v => v.x == x)
+          .len() == 0
+      ))
       .map(x => vlinex(x: x))
   }
 

--- a/tests/snapshots/assets__check_file@tablex.typ-80.snap
+++ b/tests/snapshots/assets__check_file@tablex.typ-80.snap
@@ -255,21 +255,23 @@ snapshot_kind: text
   let len = 0
 
   // maximum explicit 'y' specified
-  let max_explicit_y = items.filter(c => c.y != auto).fold(
-    0,
-    (acc, cell) => {
-      if (
-        is-tablex-cell(cell) and type(cell.y) in (
-          _int-type,
-          _float-type,
-        ) and cell.y > acc
-      ) {
-        cell.y
-      } else {
-        acc
-      }
-    },
-  )
+  let max_explicit_y = items
+    .filter(c => c.y != auto)
+    .fold(
+      0,
+      (acc, cell) => {
+        if (
+          is-tablex-cell(cell) and type(cell.y) in (
+            _int-type,
+            _float-type,
+          ) and cell.y > acc
+        ) {
+          cell.y
+        } else {
+          acc
+        }
+      },
+    )
 
   for item in items {
     if is-tablex-cell(item) and item.x == auto and item.y == auto {
@@ -1307,9 +1309,9 @@ snapshot_kind: text
 // Calculate the size of fraction tracks (cols/rows) (1fr, 2fr, ...),
 // based on the remaining sizes (after fixed-size and auto columns)
 #let determine-frac-tracks(tracks, remaining: 0pt, gutter: none) = {
-  let frac-tracks = tracks.enumerate().filter(t => (
-    type(t.at(1)) == _fraction-type
-  ))
+  let frac-tracks = tracks
+    .enumerate()
+    .filter(t => type(t.at(1)) == _fraction-type)
 
   let amount-frac = frac-tracks.fold(0, (acc, el) => acc + (el.at(1) / 1fr))
 
@@ -2943,18 +2945,21 @@ snapshot_kind: text
     line.expand = if line.expand == none {
       none
     } else {
-      line.expand.slice(0, 2).map(e => {
-        if e == none {
-          e
-        } else {
-          e = default-if-auto(e, 0pt)
-          if type(e) not in (_length-type, _rel-len-type, _ratio-type) {
-            panic("'expand' argument to lines must be a pair (length, length).")
-          }
+      line
+        .expand
+        .slice(0, 2)
+        .map(e => {
+          if e == none {
+            e
+          } else {
+            e = default-if-auto(e, 0pt)
+            if type(e) not in (_length-type, _rel-len-type, _ratio-type) {
+              panic("'expand' argument to lines must be a pair (length, length).")
+            }
 
-          convert-length-to-pt(e, styles: styles, page-size: page-size)
-        }
-      })
+            convert-length-to-pt(e, styles: styles, page-size: page-size)
+          }
+        })
     }
 
     line

--- a/tests/snapshots/assets__check_file@tablex.typ-80.snap
+++ b/tests/snapshots/assets__check_file@tablex.typ-80.snap
@@ -492,7 +492,10 @@ snapshot_kind: text
     let em = len.em
     // Measure with abs (and later multiply by the sign) so negative em works.
     // Otherwise it would return 0pt, and we would need to measure again with abs.
-    let measured-em = calc-sign(em) * measure(box(width: calc.abs(em) * 1em), styles).width
+    let measured-em = calc-sign(em) * measure(
+      box(width: calc.abs(em) * 1em),
+      styles,
+    ).width
 
     return pt + measured-em
   }
@@ -1475,7 +1478,10 @@ snapshot_kind: text
               align_default: auto,
             )
 
-            let width = measure(cell-box, styles).width // + 2*cell_inset // the box already considers inset
+            let width = measure(
+              cell-box,
+              styles,
+            ).width // + 2*cell_inset // the box already considers inset
 
             // here, we are excluding from the width of this cell
             // at this column all width that was already covered by
@@ -1736,7 +1742,10 @@ snapshot_kind: text
             // measure the cell's actual height,
             // with its calculated width
             // and with other constraints
-            let height = measure(cell-box, styles).height // + 2*cell_inset (box already considers inset)
+            let height = measure(
+              cell-box,
+              styles,
+            ).height // + 2*cell_inset (box already considers inset)
 
             // here, we are excluding from the height of this cell
             // at this row all height that was already covered by
@@ -2018,66 +2027,66 @@ snapshot_kind: text
 
   let hlines = hlines
     .filter(h => {
-        let y = h.y
+      let y = h.y
 
-        let in_top_or_bottom = y in (cell.y, cell.y + cell.rowspan)
+      let in_top_or_bottom = y in (cell.y, cell.y + cell.rowspan)
 
-        let hline_hasnt_already_ended = (
-          h.end in (auto, none) // always goes towards the right
-          or h.end >= cell.x + cell.colspan // ends at or after this cell
-        )
+      let hline_hasnt_already_ended = (
+        h.end in (auto, none) // always goes towards the right
+        or h.end >= cell.x + cell.colspan // ends at or after this cell
+      )
 
-        (in_top_or_bottom and hline_hasnt_already_ended)
-      })
+      (in_top_or_bottom and hline_hasnt_already_ended)
+    })
     .map(h => {
-        // get the intersection between the hline and the cell's x-span.
-        let span = get-included-span(
-          h.start,
-          h.end,
-          start: cell.x,
-          end: cell.x + cell.colspan,
-          limit: x_limit,
-        )
+      // get the intersection between the hline and the cell's x-span.
+      let span = get-included-span(
+        h.start,
+        h.end,
+        start: cell.x,
+        end: cell.x + cell.colspan,
+        limit: x_limit,
+      )
 
-        if span == none {
-          // no intersection!
-          none
-        } else {
-          v-or-hline-with-span(h, start: span.at(0), end: span.at(1))
-        }
-      })
+      if span == none {
+        // no intersection!
+        none
+      } else {
+        v-or-hline-with-span(h, start: span.at(0), end: span.at(1))
+      }
+    })
     .filter(x => x != none)
 
   let vlines = vlines
     .filter(v => {
-        let x = v.x
+      let x = v.x
 
-        let at_left_or_right = x in (cell.x, cell.x + cell.colspan)
+      let at_left_or_right = x in (cell.x, cell.x + cell.colspan)
 
-        let vline_hasnt_already_ended = (
-          v.end in (auto, none) // always goes towards the bottom
-          or v.end >= cell.y + cell.rowspan // ends at or after this cell
-        )
+      let vline_hasnt_already_ended = (
+        v.end in (auto, none) // always goes towards the bottom
+        or v.end >= cell.y + cell.rowspan // ends at or after this cell
+      )
 
-        (at_left_or_right and vline_hasnt_already_ended)
-      })
+      (at_left_or_right and vline_hasnt_already_ended)
+    })
     .map(v => {
-        // get the intersection between the hline and the cell's x-span.
-        let span = get-included-span(
-          v.start,
-          v.end,
-          start: cell.y,
-          end: cell.y + cell.rowspan,
-          limit: y_limit,
-        )
+      // get the intersection between the hline and the cell's x-span.
+      let span = get-included-span(
+        v.start,
+        v.end,
+        start: cell.y,
+        end: cell.y + cell.rowspan,
+        limit: y_limit,
+      )
 
-        if span == none {
-          // no intersection!
-          none
-        } else {
-          v-or-hline-with-span(v, start: span.at(0), end: span.at(1))
-        }
-      })
+      if span == none {
+        // no intersection!
+        none
+      } else {
+        v-or-hline-with-span(v, start: span.at(0), end: span.at(1))
+      }
+    })
     .filter(x => x != none)
 
   (

--- a/tests/snapshots/assets__check_file@unit-code-chained-call-last-indent.typ-0.snap
+++ b/tests/snapshots/assets__check_file@unit-code-chained-call-last-indent.typ-0.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/unit/code/chained-call-last-indent.typ
+snapshot_kind: text
 ---
 #{
   let tree = (
@@ -22,14 +23,14 @@ input_file: tests/assets/unit/code/chained-call-last-indent.typ
     .slice(1)
     .enumerate()
     .map((
-    (
-      n,
+      (
+        n,
+        c,
+      ),
+    ) => build-node(
       c,
-    ),
-  ) => build-node(
-    c,
-    depth: depth + 1,
-    sibling: n,
-  ))
+      depth: depth + 1,
+      sibling: n,
+    ))
   children
 }

--- a/tests/snapshots/assets__check_file@unit-code-chained-call-last-indent.typ-40.snap
+++ b/tests/snapshots/assets__check_file@unit-code-chained-call-last-indent.typ-40.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/unit/code/chained-call-last-indent.typ
+snapshot_kind: text
 ---
 #{
   let tree = (1, 2, 3)
@@ -18,9 +19,9 @@ input_file: tests/assets/unit/code/chained-call-last-indent.typ
     .slice(1)
     .enumerate()
     .map(((n, c)) => build-node(
-    c,
-    depth: depth + 1,
-    sibling: n,
-  ))
+      c,
+      depth: depth + 1,
+      sibling: n,
+    ))
   children
 }

--- a/tests/snapshots/assets__check_file@unit-code-chained-call-last-indent.typ-80.snap
+++ b/tests/snapshots/assets__check_file@unit-code-chained-call-last-indent.typ-80.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/unit/code/chained-call-last-indent.typ
+snapshot_kind: text
 ---
 #{
   let tree = (1, 2, 3)
@@ -10,10 +11,9 @@ input_file: tests/assets/unit/code/chained-call-last-indent.typ
     repr(tree) + repr(depth) + repr(sibling)
   }
   let children
-  children = tree.slice(1).enumerate().map(((n, c)) => build-node(
-    c,
-    depth: depth + 1,
-    sibling: n,
-  ))
+  children = tree
+    .slice(1)
+    .enumerate()
+    .map(((n, c)) => build-node(c, depth: depth + 1, sibling: n))
   children
 }

--- a/tests/snapshots/assets__check_file@unit-code-chained-call.typ-0.snap
+++ b/tests/snapshots/assets__check_file@unit-code-chained-call.typ-0.snap
@@ -40,13 +40,13 @@ snapshot_kind: text
     ))
     .rev()
     .find((
-    (
-      _,
-      v,
-    ),
-  ) => (
-    v <= page
-  ))
+      (
+        _,
+        v,
+      ),
+    ) => (
+      v <= page
+    ))
 }
 
 #a.b()[c][d].eeeeeeeeeeeeeee().fffffffff()
@@ -57,15 +57,15 @@ snapshot_kind: text
   )
     .rev()
     .map((
-    (
+      (
+        n,
+        c,
+      ),
+    ) => f(
       n,
       c,
-    ),
-  ) => f(
-    n,
-    c,
-    1,
-  ))
+      1,
+    ))
 }
 
 #{
@@ -85,16 +85,52 @@ snapshot_kind: text
     .row_group-long-long-long-long
     .hlines-long-long-long-long
     .filter(h => (
-    h.y == header_last_y + 1
-  ))
+      h.y == header_last_y + 1
+    ))
 
   let hlines_below_header = first-row-group-long-long
     .row_group-long-long-long-long
     .hlines-long-long-long-long
     .filter((
-    h,
-    _,
-  ) => (
-    h.y == header_last_y + 1
-  ))
+      h,
+      _,
+    ) => (
+      h.y == header_last_y + 1
+    ))
+}
+
+#{
+  aaaaaaaa(
+    bbbbbbb,
+    ccccccc,
+  )
+    .ddddddddd()()
+    .eeeeeeeee[]
+    .ffffffffff
+
+
+  let points = (
+    from,
+    to,
+  )
+    .zip(offsets)
+    .map((
+      (
+        point,
+        offset,
+      ),
+    ) => (
+      none
+    ))
+
+  (
+    (
+      1,
+      2,
+    ),
+    2,
+    3,
+  ).rev()
+
+  import cetz.draw: *
 }

--- a/tests/snapshots/assets__check_file@unit-code-chained-call.typ-0.snap
+++ b/tests/snapshots/assets__check_file@unit-code-chained-call.typ-0.snap
@@ -29,13 +29,15 @@ snapshot_kind: text
   let (
     title,
     _,
-  ) = query(heading.where(level: 1))
+  ) = query(
+    heading.where(level: 1),
+  )
     .map(e => (
-        e.body,
-        e
-          .location()
-          .page(),
-      ))
+      e.body,
+      e
+        .location()
+        .page(),
+    ))
     .rev()
     .find((
     (
@@ -70,12 +72,12 @@ snapshot_kind: text
   padding
     .pairs()
     .map((
-        k,
-        x,
-      ) => (
-        k,
-        x * 1.5,
-      ))
+      k,
+      x,
+    ) => (
+      k,
+      x * 1.5,
+    ))
     .to-dict()
 }
 #{

--- a/tests/snapshots/assets__check_file@unit-code-chained-call.typ-120.snap
+++ b/tests/snapshots/assets__check_file@unit-code-chained-call.typ-120.snap
@@ -17,9 +17,10 @@ snapshot_kind: text
 }
 
 #{
-  let (title, _) = query(heading.where(level: 1)).map(e => (e.body, e.location().page())).rev().find(((_, v)) => (
-    v <= page
-  ))
+  let (title, _) = query(heading.where(level: 1))
+    .map(e => (e.body, e.location().page()))
+    .rev()
+    .find(((_, v)) => v <= page)
 }
 
 #a.b()[c][d].eeeeeeeeeeeeeee().fffffffff()
@@ -37,8 +38,36 @@ snapshot_kind: text
     .hlines-long-long-long-long
     .filter(h => (h.y == header_last_y + 1))
 
-  let hlines_below_header = first-row-group-long-long.row_group-long-long-long-long.hlines-long-long-long-long.filter((
-    h,
-    _,
-  ) => (h.y == header_last_y + 1))
+  let hlines_below_header = first-row-group-long-long
+    .row_group-long-long-long-long
+    .hlines-long-long-long-long
+    .filter((h, _) => (h.y == header_last_y + 1))
+}
+
+#{
+  aaaaaaaa(bbbbbbb, ccccccc).ddddddddd()().eeeeeeeee[].ffffffffff
+
+
+  let points = (
+    from,
+    to,
+  )
+    .zip(offsets)
+    .map((
+      (
+        point,
+        offset,
+      ),
+    ) => none)
+
+  (
+    (
+      1,
+      2,
+    ),
+    2,
+    3,
+  ).rev()
+
+  import cetz.draw: *
 }

--- a/tests/snapshots/assets__check_file@unit-code-chained-call.typ-40.snap
+++ b/tests/snapshots/assets__check_file@unit-code-chained-call.typ-40.snap
@@ -54,13 +54,44 @@ snapshot_kind: text
     .row_group-long-long-long-long
     .hlines-long-long-long-long
     .filter(h => (
-    h.y == header_last_y + 1
-  ))
+      h.y == header_last_y + 1
+    ))
 
   let hlines_below_header = first-row-group-long-long
     .row_group-long-long-long-long
     .hlines-long-long-long-long
     .filter((h, _) => (
-    h.y == header_last_y + 1
-  ))
+      h.y == header_last_y + 1
+    ))
+}
+
+#{
+  aaaaaaaa(bbbbbbb, ccccccc)
+    .ddddddddd()()
+    .eeeeeeeee[]
+    .ffffffffff
+
+
+  let points = (
+    from,
+    to,
+  )
+    .zip(offsets)
+    .map((
+      (
+        point,
+        offset,
+      ),
+    ) => none)
+
+  (
+    (
+      1,
+      2,
+    ),
+    2,
+    3,
+  ).rev()
+
+  import cetz.draw: *
 }

--- a/tests/snapshots/assets__check_file@unit-code-chained-call.typ-40.snap
+++ b/tests/snapshots/assets__check_file@unit-code-chained-call.typ-40.snap
@@ -26,14 +26,13 @@ snapshot_kind: text
 }
 
 #{
-  let (
-    title,
-    _,
-  ) = query(heading.where(level: 1))
+  let (title, _) = query(
+    heading.where(level: 1),
+  )
     .map(e => (
-        e.body,
-        e.location().page(),
-      ))
+      e.body,
+      e.location().page(),
+    ))
     .rev()
     .find(((_, v)) => v <= page)
 }

--- a/tests/snapshots/assets__check_file@unit-code-chained-call.typ-80.snap
+++ b/tests/snapshots/assets__check_file@unit-code-chained-call.typ-80.snap
@@ -43,3 +43,31 @@ snapshot_kind: text
     .hlines-long-long-long-long
     .filter((h, _) => (h.y == header_last_y + 1))
 }
+
+#{
+  aaaaaaaa(bbbbbbb, ccccccc).ddddddddd()().eeeeeeeee[].ffffffffff
+
+
+  let points = (
+    from,
+    to,
+  )
+    .zip(offsets)
+    .map((
+      (
+        point,
+        offset,
+      ),
+    ) => none)
+
+  (
+    (
+      1,
+      2,
+    ),
+    2,
+    3,
+  ).rev()
+
+  import cetz.draw: *
+}

--- a/tests/snapshots/assets__check_file@unit-code-dot-chain.typ-0.snap
+++ b/tests/snapshots/assets__check_file@unit-code-dot-chain.typ-0.snap
@@ -31,7 +31,7 @@ snapshot_kind: text
       default: 0,
     )
     .at(
-    4,
-    default: 0,
-  )
+      4,
+      default: 0,
+    )
 }

--- a/tests/snapshots/assets__check_file@unit-code-dot-chain.typ-0.snap
+++ b/tests/snapshots/assets__check_file@unit-code-dot-chain.typ-0.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/unit/code/dot-chain.typ
+snapshot_kind: text
 ---
 #{
   let a = (
@@ -17,9 +18,18 @@ input_file: tests/assets/unit/code/dot-chain.typ
     ),
   )
   a
-    .at(1, default: 0)
-    .at(1, default: 0)
-    .at(1, default: 0)
+    .at(
+      1,
+      default: 0,
+    )
+    .at(
+      1,
+      default: 0,
+    )
+    .at(
+      1,
+      default: 0,
+    )
     .at(
     4,
     default: 0,

--- a/tests/snapshots/assets__check_file@unit-code-show-closure-paren-complex.typ-0.snap
+++ b/tests/snapshots/assets__check_file@unit-code-show-closure-paren-complex.typ-0.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/unit/code/show-closure-paren-complex.typ
+snapshot_kind: text
 ---
 #show raw.where(block: false): it => if it.text.starts-with("<") and it.text.ends-with(">") {
   set text(1.2em)
@@ -9,9 +10,9 @@ input_file: tests/assets/unit/code/show-closure-paren-complex.typ
     it
       .text
       .slice(
-      1,
-      -1,
-    ),
+        1,
+        -1,
+      ),
   )
 } else {
   it

--- a/tests/snapshots/assets__check_file@unit-code-single-arg-closure.typ-0.snap
+++ b/tests/snapshots/assets__check_file@unit-code-single-arg-closure.typ-0.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/unit/code/single-arg-closure.typ
+snapshot_kind: text
 ---
 #{
   let row_len = 10
@@ -15,11 +16,14 @@ input_file: tests/assets/unit/code/single-arg-closure.typ
       y: 2,
     ),
   )
-  let new_hlines = range(0, row_len + 1).filter(y => (
+  let new_hlines = range(
+    0,
+    row_len + 1,
+  ).filter(y => (
     hlines
       .filter(h => (
-          h.y == y
-        ))
+        h.y == y
+      ))
       .len() == 0
   ))
   new_hlines

--- a/tests/snapshots/assets__check_file@unit-code-single-arg-closure.typ-40.snap
+++ b/tests/snapshots/assets__check_file@unit-code-single-arg-closure.typ-40.snap
@@ -2,6 +2,7 @@
 source: tests/assets.rs
 expression: doc_string
 input_file: tests/assets/unit/code/single-arg-closure.typ
+snapshot_kind: text
 ---
 #{
   let row_len = 10
@@ -9,7 +10,10 @@ input_file: tests/assets/unit/code/single-arg-closure.typ
     (h: 1, y: 1),
     (h: 2, y: 2),
   )
-  let new_hlines = range(0, row_len + 1).filter(y => (
+  let new_hlines = range(
+    0,
+    row_len + 1,
+  ).filter(y => (
     hlines
       .filter(h => h.y == y)
       .len() == 0


### PR DESCRIPTION
This PR includes:

- fix: Args of chained calls are no longer conservatively formatted with structure kept.
- fix: If the access chain starts with a func-call, the args of that func-call are not correctly indented.
- ~change: Enter code mode in expressions with parentheses (array, dict, args, ...). This allows for more linebreaks outside codeblocks.~