### PR TITLE
fix: escape hatch not effective in some cases

### DIFF
--- a/crates/typstyle-core/src/attr.rs
+++ b/crates/typstyle-core/src/attr.rs
@@ -156,7 +156,7 @@ impl AttrStore {
                 continue;
             }
             // no format nodes with @typstyle off
-            if child_kind != SyntaxKind::Space && disable_next {
+            if disable_next && !matches!(child_kind, SyntaxKind::Space | SyntaxKind::Hash) {
                 self.set_format_disabled(child);
                 disable_next = false;
                 continue;

--- a/crates/typstyle-core/src/pretty/code_list.rs
+++ b/crates/typstyle-core/src/pretty/code_list.rs
@@ -10,6 +10,13 @@ use super::{
 
 impl<'a> PrettyPrinter<'a> {
     pub(super) fn convert_code_block(&'a self, code_block: CodeBlock<'a>) -> ArenaDoc<'a> {
+        if self
+            .attr_store
+            .is_format_disabled(code_block.body().to_untyped())
+        {
+            return self.format_disabled(code_block.to_untyped());
+        }
+
         let _g = self.with_mode(Mode::Code);
 
         let mut nodes = vec![];

--- a/tests/fixtures/unit/off/after-hash.typ
+++ b/tests/fixtures/unit/off/after-hash.typ
@@ -1,0 +1,14 @@
+  /* @typstyle off */
+#let x   =  1  +  2
+#let  y  =  3  *    4
+
+#[
+    /* @typstyle off */
+#let x   =  1  +  2
+]
+
+#[
+    /* @typstyle off */
+#let x   =  1  +  2
+    #let  y  =  3  *    4
+]

--- a/tests/fixtures/unit/off/block-single.typ
+++ b/tests/fixtures/unit/off/block-single.typ
@@ -1,0 +1,24 @@
+#if true {
+  // @typstyle off
+  let x = (
+  "A message that will be split into multiple lines to ensure that each"
+  +" line does not exceed sixty characters in length. This is a common"
+  +" practice to improve readability and maintainability of the code."
+  )
+}
+
+#{
+  // @typstyle off
+  let x = (
+  "A message that will be split into multiple lines to ensure that each"
+  +" line does not exceed sixty characters in length. This is a common"
+  +" practice to improve readability and maintainability of the code."
+  )
+}
+
+// @typstyle off
+#let x = (
+  "A message that will be split into multiple lines to ensure that each"
+  +" line does not exceed sixty characters in length. This is a common"
+  +" practice to improve readability and maintainability of the code."
+  )

--- a/tests/fixtures/unit/off/snap/after-hash.typ-0.snap
+++ b/tests/fixtures/unit/off/snap/after-hash.typ-0.snap
@@ -1,0 +1,25 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/off/after-hash.typ
+snapshot_kind: text
+---
+/* @typstyle off */
+#let x   =  1  +  2
+#let y = (
+  3
+    * 4
+)
+
+#[
+  /* @typstyle off */
+  #let x   =  1  +  2
+]
+
+#[
+  /* @typstyle off */
+  #let x   =  1  +  2
+  #let y = (
+    3
+      * 4
+  )
+]

--- a/tests/fixtures/unit/off/snap/after-hash.typ-120.snap
+++ b/tests/fixtures/unit/off/snap/after-hash.typ-120.snap
@@ -1,0 +1,19 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/off/after-hash.typ
+snapshot_kind: text
+---
+/* @typstyle off */
+#let x   =  1  +  2
+#let y = 3 * 4
+
+#[
+  /* @typstyle off */
+  #let x   =  1  +  2
+]
+
+#[
+  /* @typstyle off */
+  #let x   =  1  +  2
+  #let y = 3 * 4
+]

--- a/tests/fixtures/unit/off/snap/after-hash.typ-40.snap
+++ b/tests/fixtures/unit/off/snap/after-hash.typ-40.snap
@@ -1,0 +1,19 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/off/after-hash.typ
+snapshot_kind: text
+---
+/* @typstyle off */
+#let x   =  1  +  2
+#let y = 3 * 4
+
+#[
+  /* @typstyle off */
+  #let x   =  1  +  2
+]
+
+#[
+  /* @typstyle off */
+  #let x   =  1  +  2
+  #let y = 3 * 4
+]

--- a/tests/fixtures/unit/off/snap/after-hash.typ-80.snap
+++ b/tests/fixtures/unit/off/snap/after-hash.typ-80.snap
@@ -1,0 +1,19 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/off/after-hash.typ
+snapshot_kind: text
+---
+/* @typstyle off */
+#let x   =  1  +  2
+#let y = 3 * 4
+
+#[
+  /* @typstyle off */
+  #let x   =  1  +  2
+]
+
+#[
+  /* @typstyle off */
+  #let x   =  1  +  2
+  #let y = 3 * 4
+]

--- a/tests/fixtures/unit/off/snap/block-single.typ-0.snap
+++ b/tests/fixtures/unit/off/snap/block-single.typ-0.snap
@@ -1,0 +1,29 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/off/block-single.typ
+snapshot_kind: text
+---
+#if true {
+  // @typstyle off
+  let x = (
+  "A message that will be split into multiple lines to ensure that each"
+  +" line does not exceed sixty characters in length. This is a common"
+  +" practice to improve readability and maintainability of the code."
+  )
+}
+
+#{
+  // @typstyle off
+  let x = (
+  "A message that will be split into multiple lines to ensure that each"
+  +" line does not exceed sixty characters in length. This is a common"
+  +" practice to improve readability and maintainability of the code."
+  )
+}
+
+// @typstyle off
+#let x = (
+  "A message that will be split into multiple lines to ensure that each"
+  +" line does not exceed sixty characters in length. This is a common"
+  +" practice to improve readability and maintainability of the code."
+  )

--- a/tests/fixtures/unit/off/snap/block-single.typ-120.snap
+++ b/tests/fixtures/unit/off/snap/block-single.typ-120.snap
@@ -1,0 +1,29 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/off/block-single.typ
+snapshot_kind: text
+---
+#if true {
+  // @typstyle off
+  let x = (
+  "A message that will be split into multiple lines to ensure that each"
+  +" line does not exceed sixty characters in length. This is a common"
+  +" practice to improve readability and maintainability of the code."
+  )
+}
+
+#{
+  // @typstyle off
+  let x = (
+  "A message that will be split into multiple lines to ensure that each"
+  +" line does not exceed sixty characters in length. This is a common"
+  +" practice to improve readability and maintainability of the code."
+  )
+}
+
+// @typstyle off
+#let x = (
+  "A message that will be split into multiple lines to ensure that each"
+  +" line does not exceed sixty characters in length. This is a common"
+  +" practice to improve readability and maintainability of the code."
+  )

--- a/tests/fixtures/unit/off/snap/block-single.typ-40.snap
+++ b/tests/fixtures/unit/off/snap/block-single.typ-40.snap
@@ -1,0 +1,29 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/off/block-single.typ
+snapshot_kind: text
+---
+#if true {
+  // @typstyle off
+  let x = (
+  "A message that will be split into multiple lines to ensure that each"
+  +" line does not exceed sixty characters in length. This is a common"
+  +" practice to improve readability and maintainability of the code."
+  )
+}
+
+#{
+  // @typstyle off
+  let x = (
+  "A message that will be split into multiple lines to ensure that each"
+  +" line does not exceed sixty characters in length. This is a common"
+  +" practice to improve readability and maintainability of the code."
+  )
+}
+
+// @typstyle off
+#let x = (
+  "A message that will be split into multiple lines to ensure that each"
+  +" line does not exceed sixty characters in length. This is a common"
+  +" practice to improve readability and maintainability of the code."
+  )

--- a/tests/fixtures/unit/off/snap/block-single.typ-80.snap
+++ b/tests/fixtures/unit/off/snap/block-single.typ-80.snap
@@ -1,0 +1,29 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/off/block-single.typ
+snapshot_kind: text
+---
+#if true {
+  // @typstyle off
+  let x = (
+  "A message that will be split into multiple lines to ensure that each"
+  +" line does not exceed sixty characters in length. This is a common"
+  +" practice to improve readability and maintainability of the code."
+  )
+}
+
+#{
+  // @typstyle off
+  let x = (
+  "A message that will be split into multiple lines to ensure that each"
+  +" line does not exceed sixty characters in length. This is a common"
+  +" practice to improve readability and maintainability of the code."
+  )
+}
+
+// @typstyle off
+#let x = (
+  "A message that will be split into multiple lines to ensure that each"
+  +" line does not exceed sixty characters in length. This is a common"
+  +" practice to improve readability and maintainability of the code."
+  )

--- a/tests/fixtures/unit/off/snap/through.typ-0.snap
+++ b/tests/fixtures/unit/off/snap/through.typ-0.snap
@@ -1,0 +1,9 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/off/through.typ
+snapshot_kind: text
+---
+/* @typstyle off */
+#1
+#let aaa = 123
+#let bbb = 123

--- a/tests/fixtures/unit/off/snap/through.typ-120.snap
+++ b/tests/fixtures/unit/off/snap/through.typ-120.snap
@@ -1,0 +1,9 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/off/through.typ
+snapshot_kind: text
+---
+/* @typstyle off */
+#1
+#let aaa = 123
+#let bbb = 123

--- a/tests/fixtures/unit/off/snap/through.typ-40.snap
+++ b/tests/fixtures/unit/off/snap/through.typ-40.snap
@@ -1,0 +1,9 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/off/through.typ
+snapshot_kind: text
+---
+/* @typstyle off */
+#1
+#let aaa = 123
+#let bbb = 123

--- a/tests/fixtures/unit/off/snap/through.typ-80.snap
+++ b/tests/fixtures/unit/off/snap/through.typ-80.snap
@@ -1,0 +1,9 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/off/through.typ
+snapshot_kind: text
+---
+/* @typstyle off */
+#1
+#let aaa = 123
+#let bbb = 123

--- a/tests/fixtures/unit/off/through.typ
+++ b/tests/fixtures/unit/off/through.typ
@@ -1,0 +1,4 @@
+/* @typstyle off */
+#1
+#let   aaa  =  123
+#let   bbb  =  123


### PR DESCRIPTION
Fixes #182:

- If `@typstyle off` appears before the first expression in a code block, it will not take effect, since this comment is not inside the `Code` that expressions lie in.
- `@typstyle off` does not apply to the expression after hash (`#`).