### PR TITLE
refactor: create Typstyle with config and get tab spaces from config

### DIFF
--- a/crates/typstyle-core/benches/pretty_print.rs
+++ b/crates/typstyle-core/benches/pretty_print.rs
@@ -2,7 +2,7 @@ use std::fs;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use typst_syntax::Source;
-use typstyle_core::{attr::AttrStore, Typstyle};
+use typstyle_core::{attr::AttrStore, PrinterConfig, Typstyle};
 
 fn bench_attrs(c: &mut Criterion, id: &str, path: &str) {
     c.bench_function(id, |b| {
@@ -14,8 +14,8 @@ fn bench_attrs(c: &mut Criterion, id: &str, path: &str) {
 
 fn bench_pretty(c: &mut Criterion, id: &str, path: &str) {
     fn pretty_print_source(source: Source) -> String {
-        let t = Typstyle::new_with_src(source, 80);
-        t.pretty_print()
+        let cfg = PrinterConfig::new_with_width(80);
+        Typstyle::new_with_src(source, cfg).pretty_print()
     }
 
     c.bench_function(id, |b| {

--- a/crates/typstyle-core/src/lib.rs
+++ b/crates/typstyle-core/src/lib.rs
@@ -17,27 +17,33 @@ use typst_syntax::Source;
 #[derive(Debug, Clone)]
 pub struct Typstyle {
     source: Source,
-    width: usize,
+    config: PrinterConfig,
 }
 
 impl Typstyle {
     /// Create a new Typstyle instance from a string.
     /// # Example
     /// ```rust
-    /// use typstyle_core::Typstyle;
+    /// use typstyle_core::{PrinterConfig, Typstyle};
     /// let content = "#{1+1}";
-    /// let res = Typstyle::new_with_content(content.to_string(), 80).pretty_print();
+    /// let res = Typstyle::new_with_content(content.to_string(), PrinterConfig {
+    ///     max_width: 80,
+    ///     ..Default::default()
+    /// }).pretty_print();
     /// ```
-    pub fn new_with_content(content: String, width: usize) -> Self {
+    pub fn new_with_content(content: String, config: PrinterConfig) -> Self {
         // We should ensure that the source tree is spanned.
-        Self::new_with_src(Source::detached(content), width)
+        Self::new_with_src(Source::detached(content), config)
     }
 
     /// Create a new Typstyle instance from a [`Source`].
     ///
     /// This is useful when you have a [`Source`] instance and you can avoid reparsing the content.
-    pub fn new_with_src(src: Source, width: usize) -> Self {
-        Self { source: src, width }
+    pub fn new_with_src(src: Source, config: PrinterConfig) -> Self {
+        Self {
+            source: src,
+            config,
+        }
     }
 
     /// Pretty print the content to a string.
@@ -46,15 +52,11 @@ impl Typstyle {
         if root.erroneous() {
             return self.source.text().to_string();
         }
-        let config = PrinterConfig {
-            max_width: self.width,
-            ..Default::default()
-        };
         let attr_store = AttrStore::new(root);
-        let printer = PrettyPrinter::new(config, attr_store);
+        let printer = PrettyPrinter::new(self.config.clone(), attr_store);
         let markup = root.cast().unwrap();
         let doc = printer.convert_markup(markup);
-        let result = doc.pretty(self.width).to_string();
+        let result = doc.pretty(self.config.max_width).to_string();
         strip_trailing_whitespace(&result)
     }
 }

--- a/crates/typstyle-core/src/pretty/chain.rs
+++ b/crates/typstyle-core/src/pretty/chain.rs
@@ -211,7 +211,7 @@ impl<'a> ChainStylist<'a> {
         if use_simple_layout {
             (first_doc + follow_docs).group()
         } else {
-            (first_doc + (follow_docs).nest(2)).group()
+            (first_doc + (follow_docs).nest(self.printer.config.tab_spaces as isize)).group()
         }
     }
 }

--- a/crates/typstyle-core/src/pretty/config.rs
+++ b/crates/typstyle-core/src/pretty/config.rs
@@ -1,6 +1,8 @@
 /// Configuration Options for Typstyle Printer.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PrinterConfig {
+    /// Number of spaces per tab
+    pub tab_spaces: usize,
     /// Maximum width of each line.
     pub max_width: usize,
     /// The ratio of max width for chains. Not precise.
@@ -12,6 +14,7 @@ pub struct PrinterConfig {
 impl Default for PrinterConfig {
     fn default() -> Self {
         Self {
+            tab_spaces: 2,
             max_width: 80,
             chain_width_ratio: 0.6,
             blank_lines_upper_bound: 2,
@@ -20,6 +23,13 @@ impl Default for PrinterConfig {
 }
 
 impl PrinterConfig {
+    pub fn new_with_width(max_width: usize) -> Self {
+        Self {
+            max_width,
+            ..Default::default()
+        }
+    }
+
     pub fn chain_width(&self) -> usize {
         (self.max_width as f32 * self.chain_width_ratio) as usize
     }

--- a/crates/typstyle-core/src/pretty/func_call.rs
+++ b/crates/typstyle-core/src/pretty/func_call.rs
@@ -111,7 +111,7 @@ impl<'a> PrettyPrinter<'a> {
                 self.convert_arg(child)
             })
             .print_doc();
-        inner.nest(2).parens()
+        inner.nest(self.config.tab_spaces as isize).parens()
     }
 
     /// Handle additional content blocks

--- a/crates/typstyle-core/src/pretty/list.rs
+++ b/crates/typstyle-core/src/pretty/list.rs
@@ -260,6 +260,7 @@ impl<'a> ListStylist<'a> {
 
         let is_single = self.item_count == 1;
         let sep = arena.text(sty.separator);
+        let indent = self.printer.config.tab_spaces;
         let fold_style = if self.has_line_comment {
             FoldStyle::Never
         } else {
@@ -277,7 +278,9 @@ impl<'a> ListStylist<'a> {
                         Item::Linebreak(n) => inner += arena.hardline().repeat_n(n),
                     }
                 }
-                (arena.hardline() + inner).nest(2).enclose(delim.0, delim.1)
+                (arena.hardline() + inner)
+                    .nest(indent as isize)
+                    .enclose(delim.0, delim.1)
             }
             FoldStyle::Always => {
                 let mut inner = arena.nil();
@@ -344,7 +347,7 @@ impl<'a> ListStylist<'a> {
                 if is_single && sty.omit_delim_single {
                     inner.group()
                 } else {
-                    inner = (arena.line_() + inner).nest(2);
+                    inner = (arena.line_() + inner).nest(indent as isize);
                     if sty.omit_delim_flat {
                         inner
                             .enclose(

--- a/crates/typstyle-core/src/pretty/markup.rs
+++ b/crates/typstyle-core/src/pretty/markup.rs
@@ -106,7 +106,10 @@ impl<'a> PrettyPrinter<'a> {
             if child.kind() == SyntaxKind::ListMarker {
                 FlowItem::spaced(self.arena.text(child.text().as_str()))
             } else if let Some(markup) = child.cast() {
-                FlowItem::spaced(self.convert_markup_stripped(markup).nest(2))
+                FlowItem::spaced(
+                    self.convert_markup_stripped(markup)
+                        .nest(self.config.tab_spaces as isize),
+                )
             } else {
                 FlowItem::none()
             }
@@ -118,7 +121,10 @@ impl<'a> PrettyPrinter<'a> {
             if child.kind() == SyntaxKind::EnumMarker {
                 FlowItem::spaced(self.arena.text(child.text().as_str()))
             } else if let Some(markup) = child.cast() {
-                FlowItem::spaced(self.convert_markup_stripped(markup).nest(2))
+                FlowItem::spaced(
+                    self.convert_markup_stripped(markup)
+                        .nest(self.config.tab_spaces as isize),
+                )
             } else {
                 FlowItem::none()
             }
@@ -134,7 +140,7 @@ impl<'a> PrettyPrinter<'a> {
             } else if let Some(markup) = child.cast() {
                 // Here we can safely strip the space. Should never turn space into line.
                 let doc = self.convert_markup_stripped(markup);
-                FlowItem::spaced(doc.nest(2))
+                FlowItem::spaced(doc.nest(self.config.tab_spaces as isize))
             } else {
                 FlowItem::none()
             }

--- a/crates/typstyle-core/src/pretty/mod.rs
+++ b/crates/typstyle-core/src/pretty/mod.rs
@@ -245,9 +245,9 @@ impl<'a> PrettyPrinter<'a> {
             } else {
                 self.arena.line()
             };
-            doc = (block_sep.clone() + doc).nest(2) + block_sep;
+            doc = (block_sep.clone() + doc).nest(self.config.tab_spaces as isize) + block_sep;
         } else {
-            doc = doc.nest(2);
+            doc = doc.nest(self.config.tab_spaces as isize);
         }
         doc.enclose("$", "$")
     }
@@ -275,7 +275,10 @@ impl<'a> PrettyPrinter<'a> {
     }
 
     fn convert_content_block(&'a self, content_block: ContentBlock<'a>) -> ArenaDoc<'a> {
-        let content = self.convert_markup(content_block.body()).group().nest(2);
+        let content = self
+            .convert_markup(content_block.body())
+            .group()
+            .nest(self.config.tab_spaces as isize);
         content.brackets()
     }
 
@@ -368,7 +371,7 @@ impl<'a> PrettyPrinter<'a> {
                 self.arena.nil()
             },
         )
-        .nest(2)
+        .nest(self.config.tab_spaces as isize)
         .enclose(open, close)
     }
 

--- a/crates/typstyle-core/src/pretty/parened_expr.rs
+++ b/crates/typstyle-core/src/pretty/parened_expr.rs
@@ -35,7 +35,7 @@ impl<'a> PrettyPrinter<'a> {
             return self.convert_expr(expr);
         }
         let _g = self.with_mode(Mode::CodeCont);
-        optional_paren(&self.arena, self.convert_expr(expr))
+        optional_paren(&self.arena, self.convert_expr(expr), self.config.tab_spaces)
     }
 
     /// Parenthesize the body if necessary.
@@ -52,15 +52,15 @@ impl<'a> PrettyPrinter<'a> {
         // - If without paren, the entire expression is in one line, thus safe.
         // - If with paren, surely safe.
         let _g = self.with_mode(Mode::CodeCont);
-        optional_paren(&self.arena, body())
+        optional_paren(&self.arena, body(), self.config.tab_spaces)
     }
 }
 
 /// Wrap the body with parentheses if the body is layouted on multiple lines.
-fn optional_paren<'a>(arena: &'a Arena<'a>, body: ArenaDoc<'a>) -> ArenaDoc<'a> {
+fn optional_paren<'a>(arena: &'a Arena<'a>, body: ArenaDoc<'a>, indent: usize) -> ArenaDoc<'a> {
     let open = (arena.text("(") + arena.line()).flat_alt(arena.nil());
     let close = (arena.line() + arena.text(")")).flat_alt(arena.nil());
-    ((open + body).nest(2) + close).group()
+    ((open + body).nest(indent as isize) + close).group()
 }
 
 /// Checks if parentheses are needed for an expression that may span multiple lines.

--- a/crates/typstyle-core/src/pretty/table.rs
+++ b/crates/typstyle-core/src/pretty/table.rs
@@ -22,7 +22,7 @@ const HEADER_FOOTER: [&str; 4] = ["table.header", "table.footer", "grid.header",
 
 impl<'a> PrettyPrinter<'a> {
     pub(super) fn convert_table(&'a self, table: FuncCall<'a>, columns: usize) -> ArenaDoc<'a> {
-        let mut doc = self.arena.text("(") + self.arena.hardline();
+        let mut doc = self.arena.hardline();
         for named in table.args().items().filter_map(|node| match node {
             Arg::Named(named) => Some(named),
             _ => None,
@@ -95,7 +95,7 @@ impl<'a> PrettyPrinter<'a> {
                     self.arena.nil()
                 });
         }
-        doc.nest(2) + self.arena.hardline() + ")"
+        (doc.nest(self.config.tab_spaces as isize) + self.arena.hardline()).parens()
     }
 }
 

--- a/crates/typstyle/src/main.rs
+++ b/crates/typstyle/src/main.rs
@@ -89,7 +89,8 @@ fn execute(args: CliArguments) -> Result<FormatStatus> {
                         let Ok(content) = std::fs::read_to_string(entry.path()) else {
                             continue;
                         };
-                        let res = Typstyle::new_with_content(content.clone(), width).pretty_print();
+                        let cfg = PrinterConfig::new_with_width(width);
+                        let res = Typstyle::new_with_content(content.clone(), cfg).pretty_print();
 
                         // Check if the file is changed.
                         changed |= res != content;

--- a/tests/src/repo-e2e.rs
+++ b/tests/src/repo-e2e.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, collections::HashSet, fs, path::Path};
 use anyhow::Context;
 use libtest_mimic::{Failed, Trial};
 use typstyle_consistency::{cmp::compare_docs, universe::make_universe_formatted};
-use typstyle_core::Typstyle;
+use typstyle_core::{PrinterConfig, Typstyle};
 
 #[derive(Debug, Clone)]
 struct Testcase {
@@ -190,8 +190,9 @@ fn check_testcase(testcase: &Testcase, testcase_dir: &Path) -> anyhow::Result<()
         &entrypoint,
         &testcase.blacklist,
         |content, rel_path| {
-            let doc = Typstyle::new_with_content(content, 80).pretty_print();
-            let second_format = Typstyle::new_with_content(doc.clone(), 80).pretty_print();
+            let cfg = PrinterConfig::new_with_width(80);
+            let doc = Typstyle::new_with_content(content, cfg.clone()).pretty_print();
+            let second_format = Typstyle::new_with_content(doc.clone(), cfg).pretty_print();
             pretty_assertions::assert_eq!(
                 doc,
                 second_format,

--- a/tests/src/unit.rs
+++ b/tests/src/unit.rs
@@ -1,7 +1,7 @@
 use std::{env, error::Error, ffi::OsStr, fs, path::Path};
 
 use libtest_mimic::{Failed, Trial};
-use typstyle_core::Typstyle;
+use typstyle_core::{PrinterConfig, Typstyle};
 
 /// Creates one test for each `.typ` file in the current directory or
 /// sub-directories of the current directory.
@@ -92,7 +92,8 @@ fn remove_crlf(content: String) -> String {
 fn check_file(path: &Path, width: usize) -> Result<(), Failed> {
     let content = read_content(path)?;
 
-    let formatted = Typstyle::new_with_content(content, width).pretty_print();
+    let cfg = PrinterConfig::new_with_width(width);
+    let formatted = Typstyle::new_with_content(content, cfg).pretty_print();
     let snap_name = format!("{}-{width}", path.file_name().unwrap().to_str().unwrap());
 
     insta::with_settings!({
@@ -109,8 +110,9 @@ fn check_file(path: &Path, width: usize) -> Result<(), Failed> {
 fn check_convergence(path: &Path, width: usize) -> Result<(), Failed> {
     let content = read_content(path)?;
 
-    let first_pass = Typstyle::new_with_content(content, width).pretty_print();
-    let second_pass = Typstyle::new_with_content(first_pass.clone(), width).pretty_print();
+    let cfg = PrinterConfig::new_with_width(width);
+    let first_pass = Typstyle::new_with_content(content, cfg.clone()).pretty_print();
+    let second_pass = Typstyle::new_with_content(first_pass.clone(), cfg).pretty_print();
     pretty_assertions::assert_str_eq!(
         first_pass,
         second_pass,
@@ -125,7 +127,8 @@ fn check_output_consistency(path: &Path, width: usize) -> Result<(), Failed> {
 
     let content = read_content(path)?;
 
-    let formatted_src = Typstyle::new_with_content(content.clone(), width).pretty_print();
+    let cfg = PrinterConfig::new_with_width(width);
+    let formatted_src = Typstyle::new_with_content(content.clone(), cfg).pretty_print();
 
     compare_docs(
         "",


### PR DESCRIPTION
Although we do not mean to expose `tab_spaces` to CLI users at the moment, it is fine to use configurable values instead of magic numbers. This can also benefit lib users.

Considering that we may add more printing methods to `Typstyle` (in the upcoming partial formatting), which all require configs, I think it is better to replace the existing `width` param with config for extensibility. This is an API break.