### PR TITLE
fix: cli check behavior and format-all args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,6 +530,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "comemo"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4020,9 +4030,12 @@ dependencies = [
 name = "typstyle"
 version = "0.12.12"
 dependencies = [
+ "anstream",
  "anyhow",
  "clap",
  "clap_complete",
+ "colored",
+ "log",
  "typst-syntax",
  "typstyle-core",
  "vergen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,17 +21,21 @@ typstyle-consistency = { path = "crates/typstyle-consistency" }
 # Used in core
 typst-syntax = "0.12.0"
 
+ecow = "0.2.3"
 itertools = "0.13.0"
 pretty = "0.12.3"
 rustc-hash = "2.0"
+wasm-bindgen = { version = "0.2" }
 
 # Use in CLI
 anyhow = "1"
-ecow = "0.2.3"
-wasm-bindgen = { version = "0.2" }
 clap = { version = "4.5.20", features = ["derive", "env"] }
-walkdir = { version = "2" }
 clap_complete = { version = "4.5.36" }
+walkdir = { version = "2" }
+
+log = "0.4"
+anstream = "0.6"
+colored = "2.2"
 
 # Used in tests
 insta = { version = "1.41.1" }

--- a/README.md
+++ b/README.md
@@ -34,20 +34,48 @@ Beautiful and reliable typst code formatter
 Usage: typstyle.exe [OPTIONS] [INPUT]... [COMMAND]
 
 Commands:
-  format-all  Format all files in-place in the given directory
-  help        Print this message or the help of the given subcommand(s)
+  format-all   Format all files in-place in the given directory
+  help         Print this message or the help of the given subcommand(s)
 
 Arguments:
   [INPUT]...  Path to the input files, if not provided, read from stdin. If multiple files are provided, they will be processed in order
 
 Options:
+  -i, --inplace  Format the file in place
+      --check    Run in 'check' mode. Exits with 0 if input is formatted correctly. Exits with 1 if formatting is required
+  -h, --help     Print help
+  -V, --version  Print version
+
+Format Configuration:
   -c, --column <COLUMN>  The column width of the output [default: 80]
-  -a, --ast              Print the AST of the input file
-  -p, --pretty-doc       Print the pretty document
-  -i, --inplace          Format the file in place
-      --check            Run in 'check' mode. Exits with 0 if input is formatted correctly. Exits with 1 if formatting is required
-  -h, --help             Print help
-  -V, --version          Print version
+
+Debug Options:
+  -a, --ast         Print the AST of the input file
+  -p, --pretty-doc  Print the pretty document
+
+Log Levels:
+  -v, --verbose  Enable verbose logging
+  -q, --quiet    Print diagnostics, but nothing else
+```
+
+```txt
+Format all files in-place in the given directory
+
+Usage: typstyle.exe format-all [OPTIONS] [DIRECTORY]
+
+Arguments:
+  [DIRECTORY]  The directory to format. If not provided, the current directory is used
+
+Options:
+      --check  Run in 'check' mode. Exits with 0 if input is formatted correctly. Exits with 1 if formatting is required
+  -h, --help   Print help
+
+Format Configuration:
+  -c, --column <COLUMN>  The column width of the output [default: 80]
+
+Log Levels:
+  -v, --verbose  Enable verbose logging
+  -q, --quiet    Print diagnostics, but nothing else
 ```
 
 #### Examples

--- a/crates/typstyle-core/Cargo.toml
+++ b/crates/typstyle-core/Cargo.toml
@@ -6,6 +6,7 @@ version.workspace = true
 license.workspace = true
 edition.workspace = true
 homepage.workspace = true
+readme.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 

--- a/crates/typstyle/Cargo.toml
+++ b/crates/typstyle/Cargo.toml
@@ -6,6 +6,7 @@ version.workspace = true
 license.workspace = true
 edition.workspace = true
 homepage.workspace = true
+readme.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
@@ -23,13 +24,17 @@ typst-syntax.workspace = true
 
 anyhow.workspace = true
 clap.workspace = true
-clap_complete = { workspace = true, optional = true}
+clap_complete = { workspace = true, optional = true }
 walkdir.workspace = true
+
+log.workspace = true
+anstream.workspace = true
+colored.workspace = true
 
 [build-dependencies]
 anyhow.workspace = true
 vergen.workspace = true
-vergen-gitcl = { workspace = true, optional = true}
+vergen-gitcl = { workspace = true, optional = true }
 
 [features]
 default = ["git-info", "completion"]

--- a/crates/typstyle/src/cli.rs
+++ b/crates/typstyle/src/cli.rs
@@ -3,7 +3,11 @@ use std::{path::PathBuf, sync::LazyLock};
 use clap::{error::ErrorKind, Args, CommandFactory, Parser, Subcommand};
 
 #[derive(Parser)]
-#[command(name = "typstyle", author, version, about, long_version(LONG_VERSION.as_str()))]
+#[command(
+  name = "typstyle",
+  about = "Beautiful and reliable typst code formatter",
+  author, version, long_version(LONG_VERSION.as_str())
+)]
 pub struct CliArguments {
     #[command(subcommand)]
     pub command: Option<Command>,
@@ -24,6 +28,9 @@ pub struct CliArguments {
 
     #[command(flatten)]
     pub debug: DebugArgs,
+
+    #[command(flatten)]
+    pub log_level: LogLevelArgs,
 }
 
 impl CliArguments {
@@ -48,6 +55,7 @@ pub enum Command {
     },
     #[cfg(feature = "completion")]
     /// Generate shell completions for the given shell to stdout
+    #[command(hide = true)]
     Completions {
         /// The shell to generate completions for
         #[arg(value_enum)]
@@ -58,19 +66,47 @@ pub enum Command {
 #[derive(Args)]
 pub struct StyleArgs {
     /// The column width of the output
-    #[arg(short, long, default_value_t = 80, global = true)]
+    #[arg(
+        short,
+        long,
+        default_value_t = 80,
+        global = true,
+        help_heading = "Format Configuration"
+    )]
     pub column: usize,
 }
 
 #[derive(Args)]
 pub struct DebugArgs {
     /// Print the AST of the input file
-    #[arg(short, long, default_value_t = false)]
+    #[arg(short, long, default_value_t = false, help_heading = "Debug Options")]
     pub ast: bool,
 
     /// Print the pretty document
-    #[arg(short, long, default_value_t = false)]
+    #[arg(short, long, default_value_t = false, help_heading = "Debug Options")]
     pub pretty_doc: bool,
+}
+
+#[derive(Args)]
+pub struct LogLevelArgs {
+    /// Enable verbose logging.
+    #[arg(
+        short,
+        long,
+        global = true,
+        group = "verbosity",
+        help_heading = "Log Levels"
+    )]
+    pub verbose: bool,
+    /// Print diagnostics, but nothing else.
+    #[arg(
+        short,
+        long,
+        global = true,
+        group = "verbosity",
+        help_heading = "Log Levels"
+    )]
+    pub quiet: bool,
 }
 
 static NONE: &str = "None";

--- a/crates/typstyle/src/fmt.rs
+++ b/crates/typstyle/src/fmt.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use anyhow::{bail, Context, Result};
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 use typst_syntax::Source;
 use walkdir::{DirEntry, WalkDir};
 
@@ -86,7 +86,7 @@ pub fn format_all(directory: &Option<PathBuf>, args: &CliArguments) -> Result<Fo
         status = FormatStatus::Changed;
 
         if args.check {
-            info!("Would reformat: {}", entry.path().display());
+            debug!("Would reformat: {}", entry.path().display());
             summary.format_count += 1
         } else {
             // Attempt to overwrite the file with the formatted content

--- a/crates/typstyle/src/logging.rs
+++ b/crates/typstyle/src/logging.rs
@@ -1,0 +1,35 @@
+use colored::Colorize;
+use log::{Level, LevelFilter, Metadata, Record};
+
+pub struct SimpleLogger;
+
+impl log::Log for SimpleLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= log::max_level()
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            match record.level() {
+                Level::Error => {
+                    anstream::eprintln!("{}{} {}", "error".bold().red(), ":".bold(), record.args())
+                }
+                Level::Warn => anstream::eprintln!(
+                    "{}{} {}",
+                    "warn".bold().yellow(),
+                    ":".bold(),
+                    record.args()
+                ),
+                _ => anstream::println!("{}", record.args()),
+            }
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+pub fn init() {
+    log::set_logger(&SimpleLogger)
+        .map(|_| log::set_max_level(LevelFilter::Info))
+        .expect("failed to init logging");
+}

--- a/crates/typstyle/src/main.rs
+++ b/crates/typstyle/src/main.rs
@@ -26,10 +26,17 @@ impl Termination for CliResults {
 }
 
 fn main() -> CliResults {
-    logging::init();
-
     let args = CliArguments::parse();
     args.validate_input();
+
+    logging::init();
+    log::set_max_level(if args.log_level.verbose {
+        log::LevelFilter::Debug
+    } else if args.log_level.quiet {
+        log::LevelFilter::Error
+    } else {
+        log::LevelFilter::Info
+    });
 
     // Should put the formatter into check mode
     let check = args.check;

--- a/crates/typstyle/src/main.rs
+++ b/crates/typstyle/src/main.rs
@@ -1,11 +1,13 @@
 mod cli;
 mod fmt;
+mod logging;
 
 use std::process::{ExitCode, Termination};
 
 use anyhow::Result;
 use clap::Parser;
 use fmt::{format_all, format_many, format_one, FormatStatus};
+use log::error;
 
 use crate::cli::CliArguments;
 
@@ -24,7 +26,10 @@ impl Termination for CliResults {
 }
 
 fn main() -> CliResults {
+    logging::init();
+
     let args = CliArguments::parse();
+    args.validate_input();
 
     // Should put the formatter into check mode
     let check = args.check;
@@ -32,7 +37,7 @@ fn main() -> CliResults {
         Ok(FormatStatus::Changed) if check => CliResults::Bad,
         Ok(_) => CliResults::Good,
         Err(e) => {
-            eprintln!("{e}");
+            error!("{e}");
             CliResults::Bad
         }
     }


### PR DESCRIPTION
- (feature) Add simple logging. Verbosity can be customized.
- (feature) Validate args before execution. `--inplace` conflicts with `--check`. `--inplace` with no input is rejected.
- (feature) Display duration in `format-all` command.
- (fix) Run with `--check` now will not modify files.
- (fix) `format-all` command now correctly has `--column` and `--check` args.
- (fix) Missing readme in crates.
- (chore) Update CLI usage in README.