### PR TITLE
fix: do not always add end-of-file newline

### DIFF
--- a/crates/typstyle-core/src/lib.rs
+++ b/crates/typstyle-core/src/lib.rs
@@ -82,8 +82,10 @@ pub fn strip_trailing_whitespace(s: &str) -> String {
         .lines()
         .map(|line| line.trim_end())
         .collect::<Vec<_>>()
-        .join("\n");
-    res + "\n"
+        .join("\n")
+        .trim()
+        .to_owned();
+    res
 }
 
 #[cfg(all(target_arch = "wasm32", feature = "wasm"))]


### PR DESCRIPTION
Introduced in c6cae33, `typstyle` would always add a `\n` at the end of the file,  leading to the unwanted effect of an ever-extending `\n` sequence.

The expected results are:
1. if there's no `\n` at the end of the file, add one;
2. if there are more than one `\n`s, shrink to one;
3. probably remove `\n`s at the start of the file.

This PR fixes that.