### PR TITLE
fix: do not add additional end-of-file newline

### DIFF
--- a/crates/typstyle/src/fmt.rs
+++ b/crates/typstyle/src/fmt.rs
@@ -181,7 +181,7 @@ pub fn format_one(input: Option<&PathBuf>, args: &CliArguments) -> Result<Format
         }
         FormatResult::Changed(res) | FormatResult::Unchanged(res) => {
             if !args.inplace && !args.check {
-                println!("{}", res);
+                print!("{}", res);
             }
         }
         FormatResult::Erroneous => {

--- a/crates/typstyle/tests/test_format.rs
+++ b/crates/typstyle/tests/test_format.rs
@@ -13,7 +13,6 @@ fn test_one() {
     ----- stdout -----
     #let a = 0
 
-
     ----- stderr -----
     ");
 
@@ -46,7 +45,6 @@ fn test_one_quiet() {
     exit_code: 0
     ----- stdout -----
     #let a = 0
-
 
     ----- stderr -----
     ");
@@ -81,9 +79,7 @@ fn test_two_0() {
     exit_code: 0
     ----- stdout -----
     #let a = 0
-
     #let b = 1
-
 
     ----- stderr -----
     ");
@@ -102,9 +98,7 @@ fn test_two_1() {
     exit_code: 0
     ----- stdout -----
     #let a = 0
-
     #let b = 1
-
 
     ----- stderr -----
     ");
@@ -123,9 +117,7 @@ fn test_two_2() {
     exit_code: 0
     ----- stdout -----
     #let a = 0
-
     #let b = 1
-
 
     ----- stderr -----
     ");

--- a/crates/typstyle/tests/test_format_stdin.rs
+++ b/crates/typstyle/tests/test_format_stdin.rs
@@ -14,7 +14,6 @@ fn test_nothing() {
     ----- stdout -----
 
 
-
     ----- stderr -----
     ");
 }
@@ -28,7 +27,6 @@ fn test_stdin() {
     exit_code: 0
     ----- stdout -----
     #let x = (1 + 2)
-
 
     ----- stderr -----
     ");
@@ -60,7 +58,6 @@ fn test_stdin_column() {
       1
         + 2
     )
-
 
     ----- stderr -----
     ");
@@ -144,7 +141,6 @@ fn test_stdin_debug_ast() {
         ],
     ]
     #let x = (1 + 2)
-
 
     ----- stderr -----
     "##);


### PR DESCRIPTION
As discussed in #205, this PR fixes the printing and prevent typstyle from adding unintended additional end-of-file newlines.