### PR TITLE
Add `--tab-width`, which sets number of spaces for levels of indentation in the output

### DIFF
--- a/crates/typstyle-core/src/config.rs
+++ b/crates/typstyle-core/src/config.rs
@@ -30,6 +30,11 @@ impl Config {
         self
     }
 
+    pub fn with_tab_spaces(mut self, tab_spaces: usize) -> Self {
+        self.tab_spaces = tab_spaces;
+        self
+    }
+
     pub fn chain_width(&self) -> usize {
         const CHAIN_WIDTH_RATIO: f32 = 0.6;
         (self.max_width as f32 * CHAIN_WIDTH_RATIO) as usize

--- a/crates/typstyle/src/cli.rs
+++ b/crates/typstyle/src/cli.rs
@@ -74,6 +74,16 @@ pub struct StyleArgs {
         help_heading = "Format Configuration"
     )]
     pub column: usize,
+
+    /// Spaces per level of indentation in the output
+    #[arg(
+        short,
+        long,
+        default_value_t = 2,
+        global = true,
+        help_heading = "Format Configuration"
+    )]
+    pub tab_width: usize,
 }
 
 #[derive(Args)]

--- a/crates/typstyle/src/fmt.rs
+++ b/crates/typstyle/src/fmt.rs
@@ -70,7 +70,9 @@ pub fn format_all(directory: &Option<PathBuf>, args: &CliArguments) -> Result<Fo
         let Ok(content) = std::fs::read_to_string(entry.path()) else {
             continue;
         };
-        let cfg = Config::new().with_width(args.style.column);
+        let cfg = Config::new()
+            .with_width(args.style.column)
+            .with_tab_spaces(args.style.tab_width);
         let Ok(res) = Typstyle::new(cfg).format_content(&content) else {
             warn!("Failed to format: {}", entry.path().display());
             continue;
@@ -215,7 +217,9 @@ fn format_debug(content: String, args: &CliArguments) -> FormatResult {
         println!("{:#?}", root);
     }
 
-    let config = Config::new().with_width(args.style.column);
+    let config = Config::new()
+        .with_width(args.style.column)
+        .with_tab_spaces(args.style.tab_width);
     let res = match Typstyle::new(config).format_source_inspect(&source, |doc| {
         if args.debug.pretty_doc {
             println!("{:#?}", doc);

--- a/crates/typstyle/tests/test_format_all.rs
+++ b/crates/typstyle/tests/test_format_all.rs
@@ -217,7 +217,7 @@ for i in range(0, 5) {
     success: true
     exit_code: 0
     ----- stdout -----
-    Successfully formatted 1 files (0 unchanged) in [DURATION]
+    Successfully formatted 1 file (0 unchanged) in [DURATION]
 
     ----- stderr -----
     ");

--- a/crates/typstyle/tests/test_format_all.rs
+++ b/crates/typstyle/tests/test_format_all.rs
@@ -202,6 +202,38 @@ fn test_all_column() {
 }
 
 #[test]
+fn test_all_tab_width() {
+    let space = Workspace::new();
+    space.write(
+        "a.typ",
+        "#let f(x) = {
+for i in range(0, 5) {
+     x = x + i
+    }
+}",
+    );
+
+    typstyle_cmd_snapshot!(space.cli().arg("format-all").arg("-t=4").arg("-v"), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    Successfully formatted 1 files (0 unchanged) in [DURATION]
+
+    ----- stderr -----
+    ");
+
+    assert_eq!(
+        space.read_string("a.typ"),
+        "#let f(x) = {
+    for i in range(0, 5) {
+        x = x + i
+    }
+}
+"
+    );
+}
+
+#[test]
 fn test_dir_all_check() {
     let space = Workspace::new();
     space.write("a.typ", "#let a  =  0");


### PR DESCRIPTION
This PR closes #116 and #122.

Although `typstyle` is opinionated, tab width is a common setting to expose to the user in other opinionated formatters.