### PR TITLE
feat: use braces instead of parentheses for multiline closure bodies

### DIFF
--- a/tests/fixtures/packages/snap/codly.typ-0.snap
+++ b/tests/fixtures/packages/snap/codly.typ-0.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/packages/codly.typ
-snapshot_kind: text
 ---
 /*
  * This test case is copied from [codly]
@@ -479,9 +478,9 @@ snapshot_kind: text
     } else {
       highlights
         .sorted(
-          key: x => (
+          key: x => {
             x.line
-          ),
+          },
         )
         .map(x => {
           if (
@@ -1319,9 +1318,9 @@ snapshot_kind: text
     ) {
       (
         ..,
-      ) => (
+      ) => {
         none
-      )
+      }
     } else if (
       fn
         == auto
@@ -1633,9 +1632,9 @@ snapshot_kind: text
       fn
         == none
     ) {
-      _ => (
+      _ => {
         none
-      )
+      }
     } else {
       fn
     }
@@ -1665,9 +1664,9 @@ snapshot_kind: text
     } else {
       annotations
         .sorted(
-          key: x => (
+          key: x => {
             x.start
-          ),
+          },
         )
         .map(x => {
           if (
@@ -1752,13 +1751,13 @@ snapshot_kind: text
 
   // Get the widest annotation.
   let annot-bodies-width = annotations
-    .map(x => (
+    .map(x => {
       x.content
-    ))
+    })
     .map(measure)
-    .map(x => (
+    .map(x => {
       x.width
-    ))
+    })
   let num = annotation-format(
     annotations.len(),
   )

--- a/tests/fixtures/packages/snap/fletcher-diagram.typ-0.snap
+++ b/tests/fixtures/packages/snap/fletcher-diagram.typ-0.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/packages/fletcher-diagram.typ
-snapshot_kind: text
 ---
 /*
  * This test case is copied from [typst-fletcher]
@@ -179,9 +178,9 @@ snapshot_kind: text
   rects = expand-fractional-rects(rects)
 
   // all points in diagram that should be spanned by coordinate grid
-  let points = rects.map(r => (
+  let points = rects.map(r => {
     r.center
-  ))
+  })
   points += verts
 
   if (
@@ -931,13 +930,13 @@ snapshot_kind: text
 
     // nodes and edges whose uv coordinates can be resolved without knowing the grid
     let rects-affecting-grid = nodes
-      .filter(node => (
+      .filter(node => {
         not is-nan-vector(
           node
             .pos
             .uv,
         )
-      ))
+      })
       .map(node => (
         center: node
           .pos
@@ -960,9 +959,9 @@ snapshot_kind: text
         .join()
         + ()
     ) // coerce none to ()
-    vertices-affecting-grid = vertices-affecting-grid.filter(vert => (
+    vertices-affecting-grid = vertices-affecting-grid.filter(vert => {
       not is-nan-vector(vert)
-    ))
+    })
 
 
     // determine diagram's elastic grid layout

--- a/tests/fixtures/packages/snap/fletcher-diagram.typ-40.snap
+++ b/tests/fixtures/packages/snap/fletcher-diagram.typ-40.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/packages/fletcher-diagram.typ
-snapshot_kind: text
 ---
 /*
  * This test case is copied from [typst-fletcher]
@@ -654,9 +653,9 @@ snapshot_kind: text
 
     // nodes and edges whose uv coordinates can be resolved without knowing the grid
     let rects-affecting-grid = nodes
-      .filter(node => (
+      .filter(node => {
         not is-nan-vector(node.pos.uv)
-      ))
+      })
       .map(node => (
         center: node.pos.uv,
         size: node.size,
@@ -675,9 +674,9 @@ snapshot_kind: text
         .join()
         + ()
     ) // coerce none to ()
-    vertices-affecting-grid = vertices-affecting-grid.filter(vert => (
+    vertices-affecting-grid = vertices-affecting-grid.filter(vert => {
       not is-nan-vector(vert)
-    ))
+    })
 
 
     // determine diagram's elastic grid layout

--- a/tests/fixtures/packages/snap/fletcher-diagram.typ-80.snap
+++ b/tests/fixtures/packages/snap/fletcher-diagram.typ-80.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/packages/fletcher-diagram.typ
-snapshot_kind: text
 ---
 /*
  * This test case is copied from [typst-fletcher]
@@ -541,9 +540,9 @@ snapshot_kind: text
         .join()
         + ()
     ) // coerce none to ()
-    vertices-affecting-grid = vertices-affecting-grid.filter(vert => (
+    vertices-affecting-grid = vertices-affecting-grid.filter(vert => {
       not is-nan-vector(vert)
-    ))
+    })
 
 
     // determine diagram's elastic grid layout

--- a/tests/fixtures/packages/snap/fletcher-draw.typ-0.snap
+++ b/tests/fixtures/packages/snap/fletcher-draw.typ-0.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/packages/fletcher-draw.typ
-snapshot_kind: text
 ---
 /*
  * This test case is copied from [typst-fletcher]
@@ -2136,9 +2135,9 @@ snapshot_kind: text
     ) {
       // filter out nodes with lower snap priority
       let max-snap-priority = calc.max(
-        ..candidates.map(node => (
+        ..candidates.map(node => {
           node.snap
-        )),
+        }),
       )
       candidates = candidates.filter(node => (
         node.snap

--- a/tests/fixtures/packages/snap/fletcher-draw.typ-40.snap
+++ b/tests/fixtures/packages/snap/fletcher-draw.typ-40.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/packages/fletcher-draw.typ
-snapshot_kind: text
 ---
 /*
  * This test case is copied from [typst-fletcher]
@@ -1327,9 +1326,9 @@ snapshot_kind: text
     if candidates.len() > 0 {
       // filter out nodes with lower snap priority
       let max-snap-priority = calc.max(
-        ..candidates.map(node => (
+        ..candidates.map(node => {
           node.snap
-        )),
+        }),
       )
       candidates = candidates.filter(node => (
         node.snap == max-snap-priority

--- a/tests/fixtures/packages/snap/tablex.typ-0.snap
+++ b/tests/fixtures/packages/snap/tablex.typ-0.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/packages/tablex.typ
-snapshot_kind: text
 ---
 // Welcome to tablex!
 // Feel free to contribute with any features you think are missing.
@@ -35,9 +34,9 @@ snapshot_kind: text
 #let _int-type = type(5)
 #let _float-type = type(5.0)
 #let _fraction-type = type(5fr)
-#let _function-type = type(x => (
+#let _function-type = type(x => {
   x
-))
+})
 #let _content-type = type([])
 // note: since 0.8.0, alignment and 2d alignment are the same
 // but keep it like this for pre-0.8.0
@@ -805,9 +804,9 @@ snapshot_kind: text
     init_function
       == none
   ) {
-    init_function = () => (
+    init_function = () => {
       element
-    )
+    }
   }
 
   range(amount).map(i => init_function())
@@ -1632,9 +1631,9 @@ snapshot_kind: text
   grid,
   x,
   y,
-  fill_with: grid => (
+  fill_with: grid => {
     none
-  ),
+  },
 ) = {
   let rows = grid-count-rows(grid)
   let rowws = rows

--- a/tests/fixtures/packages/touying/snap/core.typ-0.snap
+++ b/tests/fixtures/packages/touying/snap/core.typ-0.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/packages/touying/core.typ
-snapshot_kind: text
 ---
 /*
  * This test case is copied from [touying]
@@ -1299,9 +1298,9 @@ snapshot_kind: text
 /// - `note` is the content of the speaker note.
 #let speaker-note(
   mode: "typ",
-  setting: it => (
+  setting: it => {
     it
-  ),
+  },
   note,
 ) = {
   touying-fn-wrapper(
@@ -1462,9 +1461,9 @@ snapshot_kind: text
 /// - `..args` is the arguments of the reducer function.
 #let touying-reducer(
   reduce: arr => arr.sum(),
-  cover: arr => (
+  cover: arr => {
     none
-  ),
+  },
   ..args,
 ) = utils.label-it(
   metadata((
@@ -2846,9 +2845,9 @@ snapshot_kind: text
       and type(margin)
         != relative
   ) {
-    return it => (
+    return it => {
       it
-    )
+    }
   }
   let cell = block.with(
     width: 100%,
@@ -3251,9 +3250,9 @@ snapshot_kind: text
   self: none,
   config: (:),
   repeat: auto,
-  setting: body => (
+  setting: body => {
     body
-  ),
+  },
   composer: auto,
   ..bodies,
 ) = {
@@ -3775,9 +3774,9 @@ snapshot_kind: text
 #let slide(
   config: (:),
   repeat: auto,
-  setting: body => (
+  setting: body => {
     body
-  ),
+  },
   composer: auto,
   ..bodies,
 ) = touying-slide-wrapper(self => {
@@ -3818,9 +3817,9 @@ snapshot_kind: text
 #let empty-slide(
   config: (:),
   repeat: auto,
-  setting: body => (
+  setting: body => {
     body
-  ),
+  },
   composer: auto,
   ..bodies,
 ) = touying-slide-wrapper(self => {

--- a/tests/fixtures/packages/touying/snap/utils.typ-0.snap
+++ b/tests/fixtures/packages/touying/snap/utils.typ-0.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/packages/touying/utils.typ
-snapshot_kind: text
 ---
 /*
  * This test case is copied from [touying]
@@ -716,9 +715,9 @@ snapshot_kind: text
   hierachical: true,
   depth: 9999,
   style: (
-    setting: body => (
+    setting: body => {
       body
-    ),
+    },
     numbered: true,
     current-heading,
   ) => setting({
@@ -833,9 +832,9 @@ snapshot_kind: text
   level: auto,
   hierachical: true,
   depth: 9999,
-  setting: body => (
+  setting: body => {
     body
-  ),
+  },
   ..sty,
 ) = (
   context {
@@ -2020,14 +2019,14 @@ snapshot_kind: text
     context {
       let sizes = contents.map(c => measure(c))
       let max-width = calc.max(
-        ..sizes.map(sz => (
+        ..sizes.map(sz => {
           sz.width
-        )),
+        }),
       )
       let max-height = calc.max(
-        ..sizes.map(sz => (
+        ..sizes.map(sz => {
           sz.height
-        )),
+        }),
       )
       for (
         subslides,
@@ -2210,9 +2209,9 @@ snapshot_kind: text
 #let speaker-note(
   self: none,
   mode: "typ",
-  setting: it => (
+  setting: it => {
     it
-  ),
+  },
   note,
 ) = {
   if self.at(

--- a/tests/fixtures/typstfmt/snap/82-non-converge-list.typ-0.snap
+++ b/tests/fixtures/typstfmt/snap/82-non-converge-list.typ-0.snap
@@ -1,13 +1,12 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/typstfmt/82-non-converge-list.typ
-snapshot_kind: text
 ---
 #let f(
   t,
-) = (
+) = {
   t
-)
+}
 We have next things:
 - thing 1;
 - thing 2;

--- a/tests/fixtures/unit/chain/snap/binary-0.typ-0.snap
+++ b/tests/fixtures/unit/chain/snap/binary-0.typ-0.snap
@@ -1,14 +1,13 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/chain/binary-0.typ
-snapshot_kind: text
 ---
 #{
   let f(
     x,
-  ) = (
+  ) = {
     x
-  )
+  }
   f(
     "Unsupported content type "
       + type(content)

--- a/tests/fixtures/unit/chain/snap/call.typ-0.snap
+++ b/tests/fixtures/unit/chain/snap/call.typ-0.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/chain/call.typ
-snapshot_kind: text
 ---
 #{
   a
@@ -138,9 +137,9 @@ snapshot_kind: text
         point,
         offset,
       ),
-    ) => (
+    ) => {
       none
-    ))
+    })
 
   (
     (

--- a/tests/fixtures/unit/code/snap/closure-simple.typ-0.snap
+++ b/tests/fixtures/unit/code/snap/closure-simple.typ-0.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/code/closure-simple.typ
-snapshot_kind: text
 ---
 #show raw: it => {
   it
@@ -36,9 +35,9 @@ snapshot_kind: text
 #set heading(
   numbering: (
     ..num,
-  ) => (
+  ) => {
     none
-  ),
+  },
 )
 
 #show raw.where(
@@ -61,15 +60,15 @@ snapshot_kind: text
     n,
     c,
   ),
-) => (
+) => {
   none
-))
+})
 
 #a.map((
   n,
   c,
-) => (
+) => {
   none
-))
+})
 
 #range(amount).map(i => init_function())

--- a/tests/fixtures/unit/code/snap/perf-nest.typ-0.snap
+++ b/tests/fixtures/unit/code/snap/perf-nest.typ-0.snap
@@ -1,13 +1,12 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/code/perf-nest.typ
-snapshot_kind: text
 ---
 #let f(
   ..arg,
-) = (
+) = {
   arg
-)
+}
 
 #f(
   f(

--- a/tests/fixtures/unit/code/snap/show-chain.typ-0.snap
+++ b/tests/fixtures/unit/code/snap/show-chain.typ-0.snap
@@ -1,16 +1,15 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/code/show-chain.typ
-snapshot_kind: text
 ---
 #let a = (
   b: (
     f: (
       body,
       theme: auto,
-    ) => (
+    ) => {
       none
-    ),
+    },
   ),
 )
 #let c = a.b

--- a/tests/fixtures/unit/comment/snap/in-closure.typ-0.snap
+++ b/tests/fixtures/unit/comment/snap/in-closure.typ-0.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/comment/in-closure.typ
-snapshot_kind: text
 ---
 #let conf(
   title: none, //comments
@@ -14,28 +13,28 @@ snapshot_kind: text
   doc
 }
 
-#let f() /* 0 */ = /* 1 */ () => /* 2 */ (
+#let f() /* 0 */ = /* 1 */ () => /* 2 */ {
   none
-)
+}
 #let g(
   ..,
-) /* 0 */ = /* 1 */ () => /* 2 */ (
+) /* 0 */ = /* 1 */ () => /* 2 */ {
   none
-)
+}
 #let h(
   ..,
 ) /* 0 */ = /* 1 */ () => /* 2 */ {
   none
 }
 
-#let f = /* 0 */ () /* 1 */ => /* 2 */ (
+#let f = /* 0 */ () /* 1 */ => /* 2 */ {
   none
-)
+}
 #let g = /* 0 */ (
   ..,
-) /* 1 */ => /* 2 */ (
+) /* 1 */ => /* 2 */ {
   none
-)
+}
 #let h = /* 0 */ (
   ..,
 ) /* 1 */ => /* 2 */ {

--- a/tests/fixtures/unit/comment/snap/in-closure.typ-40.snap
+++ b/tests/fixtures/unit/comment/snap/in-closure.typ-40.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/comment/in-closure.typ
-snapshot_kind: text
 ---
 #let conf(
   title: none, //comments
@@ -12,9 +11,9 @@ snapshot_kind: text
   doc, // all comments will be kept by typstyle
 ) = { doc }
 
-#let f() /* 0 */ = /* 1 */ () => /* 2 */ (
+#let f() /* 0 */ = /* 1 */ () => /* 2 */ {
   none
-)
+}
 #let g(
   ..,
 ) /* 0 */ = /* 1 */ () => /* 2 */ none
@@ -24,9 +23,9 @@ snapshot_kind: text
   none
 }
 
-#let f = /* 0 */ () /* 1 */ => /* 2 */ (
+#let f = /* 0 */ () /* 1 */ => /* 2 */ {
   none
-)
+}
 #let g = /* 0 */ (
   ..,
 ) /* 1 */ => /* 2 */ none

--- a/tests/fixtures/unit/comment/snap/in-showset.typ-0.snap
+++ b/tests/fixtures/unit/comment/snap/in-showset.typ-0.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/comment/in-showset.typ
-snapshot_kind: text
 ---
 #show: none
 #show "foo": "bar"
@@ -28,9 +27,9 @@ snapshot_kind: text
   numbering/* 2 */: /* 3 */ (
     /* 4 */
     ../* 5 */num, /* 6 */
-  ) /* 1 */ => (
+  ) /* 1 */ => {
     none
-  ),
+  },
 )
 #set /* 0 */ text(
   /* 1 */

--- a/tests/fixtures/unit/func/snap/func_call.typ-0.snap
+++ b/tests/fixtures/unit/func/snap/func_call.typ-0.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/func/func_call.typ
-snapshot_kind: text
 ---
 #text[123]
 
@@ -19,9 +18,9 @@ snapshot_kind: text
 
 #let f = (
   ..args,
-) => (
+) => {
   args
-)
+}
 #f({
   "aaaaaaaaaaaaaaaaaaaaa"
 })

--- a/tests/fixtures/unit/func/snap/spread.typ-0.snap
+++ b/tests/fixtures/unit/func/snap/spread.typ-0.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/func/spread.typ
-snapshot_kind: text
 ---
 #let tree(
   root,
@@ -17,6 +16,6 @@ snapshot_kind: text
 
 #let f = (
   ..,
-) => (
+) => {
   1
-)
+}


### PR DESCRIPTION
Use braces (`{}`) instead of parens (`()`) when the closure body is not a chainable binary expression. e.g.

```typst
#fun(() => {
  aaa
})
instead of
#fun(() => (
  aaa
))
```

Braces are more intuitive and align with the behavior of other languages.
I exclude binary expressions to avoid double nesting.

PERFORMANCE CONSIDERATION: The code block has extra evaluation burden.