### PR TITLE
feat: reorder import items if no comment or duplication

### DIFF
--- a/crates/typstyle-core/src/config.rs
+++ b/crates/typstyle-core/src/config.rs
@@ -8,6 +8,9 @@ pub struct Config {
     pub max_width: usize,
     /// Maximum number of blank lines which can be put between items.
     pub blank_lines_upper_bound: usize,
+    /// Whether to reorder import items.
+    /// When enabled, import items will be sorted alphabetically.
+    pub reorder_import_items: bool,
 }
 
 impl Default for Config {
@@ -16,6 +19,7 @@ impl Default for Config {
             tab_spaces: 2,
             max_width: 80,
             blank_lines_upper_bound: 2,
+            reorder_import_items: false,
         }
     }
 }

--- a/crates/typstyle-core/src/pretty/code_list.rs
+++ b/crates/typstyle-core/src/pretty/code_list.rs
@@ -1,4 +1,4 @@
-use typst_syntax::{ast::*, SyntaxKind, SyntaxNode};
+use typst_syntax::{ast::*, SyntaxKind};
 
 use super::{
     list::{ListStyle, ListStylist},
@@ -143,28 +143,6 @@ impl<'a> PrettyPrinter<'a> {
             .always_fold_if(|| is_single_simple)
             .print_doc(ListStyle {
                 omit_delim_single: is_single_simple,
-                ..Default::default()
-            })
-    }
-
-    pub(super) fn convert_import_items(
-        &'a self,
-        import_items_nodes: Vec<&'a SyntaxNode>,
-    ) -> ArenaDoc<'a> {
-        // Note that `ImportItem` does not implement `AstNode`.
-        ListStylist::new(self)
-            .process_iterable_impl(import_items_nodes.into_iter(), |child| match child.kind() {
-                SyntaxKind::RenamedImportItem => child
-                    .cast()
-                    .map(|item| self.convert_import_item_renamed(item)),
-                SyntaxKind::ImportItemPath => {
-                    child.cast().map(|item| self.convert_import_item_path(item))
-                }
-                _ => Option::None,
-            })
-            .print_doc(ListStyle {
-                omit_delim_flat: true,
-                omit_delim_empty: true,
                 ..Default::default()
             })
     }

--- a/crates/typstyle/src/cli.rs
+++ b/crates/typstyle/src/cli.rs
@@ -84,6 +84,15 @@ pub struct StyleArgs {
         help_heading = "Format Configuration"
     )]
     pub tab_width: usize,
+
+    /// Whether to reorder import items.
+    #[arg(
+        long,
+        default_value_t = false,
+        global = true,
+        help_heading = "Format Configuration"
+    )]
+    pub reorder_import_items: bool,
 }
 
 #[derive(Args)]

--- a/crates/typstyle/tests/test_format_all.rs
+++ b/crates/typstyle/tests/test_format_all.rs
@@ -202,38 +202,6 @@ fn test_all_column() {
 }
 
 #[test]
-fn test_all_tab_width() {
-    let space = Workspace::new();
-    space.write(
-        "a.typ",
-        "#let f(x) = {
-for i in range(0, 5) {
-     x = x + i
-    }
-}",
-    );
-
-    typstyle_cmd_snapshot!(space.cli().args(["format-all", "-t=4", "-v"]), @r"
-    success: true
-    exit_code: 0
-    ----- stdout -----
-    Successfully formatted 1 file (0 unchanged) in [DURATION]
-
-    ----- stderr -----
-    ");
-
-    assert_eq!(
-        space.read_string("a.typ"),
-        "#let f(x) = {
-    for i in range(0, 5) {
-        x = x + i
-    }
-}
-"
-    );
-}
-
-#[test]
 fn test_dir_all_check() {
     let space = Workspace::new();
     space.write("a.typ", "#let a  =  0");

--- a/crates/typstyle/tests/test_style_args.rs
+++ b/crates/typstyle/tests/test_style_args.rs
@@ -1,0 +1,51 @@
+mod common;
+
+use common::{typstyle_cmd_snapshot, Workspace};
+
+#[test]
+fn test_tab_width() {
+    let space = Workspace::new();
+
+    let stdin = "#let f(x) = {
+for i in range(0, 5) {
+     x = x + i
+ }
+}";
+
+    typstyle_cmd_snapshot!(space.cli().args(["-t=4"]).pass_stdin(stdin), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    #let f(x) = {
+        for i in range(0, 5) {
+            x = x + i
+        }
+    }
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn test_reorder_import_items() {
+    let space = Workspace::new();
+
+    let stdin = r#"#import "module.typ": xyz, func as renamed, h.i.j, a.b.c"#;
+
+    typstyle_cmd_snapshot!(space.cli().pass_stdin(stdin), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    #import "module.typ": xyz, func as renamed, h.i.j, a.b.c
+
+    ----- stderr -----
+    "#);
+    typstyle_cmd_snapshot!(space.cli().args(["--reorder-import-items"]).pass_stdin(stdin), @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    #import "module.typ": a.b.c, func as renamed, h.i.j, xyz
+
+    ----- stderr -----
+    "#);
+}

--- a/tests/fixtures/unit/code/import-reorder.typ
+++ b/tests/fixtures/unit/code/import-reorder.typ
@@ -1,0 +1,38 @@
+/// typstyle: reorder-import-items
+
+// Single import with mixed styles in random order
+#import "module.typ": xyz, func as renamed, h.i.j, a.b.c, widget as tool, m.n, z.y.x, beta, p.q as custom, alpha, x.y as short, gamma, j.k.l as util
+
+// Multiple imports from same module, should ideally be merged and reordered
+#import "common.typ": format
+#import "common.typ": layout as l, render
+#import "common.typ": style.color, transform as t
+#import "common.typ": data.table, data.chart as graph
+
+// Imports with special names and deep nesting
+#import "special.typ": _hidden, a.b.c.d.e.f, _private.func as _f, x-y-z as x_y_z, very.deep.nested.module.function as fn
+
+// Conflicting names that should be preserved
+#import "math.typ": sum
+#import "stats.typ": sum as statistical_sum
+
+// Empty and single item imports
+#import "empty.typ":
+#import "single.typ": only_item
+#import "wildcard.typ": *
+
+// Case 1: Import with comments between items - should not reorder
+#import "commented.typ": (bbb, aaa,
+  // This comment should prevent reordering
+)
+#import "commented.typ": ddd,  /* Another comment type */ ccc
+
+// Case 2: Import with duplicate item names - should not reorder
+// Same name imported twice
+#import "duplicates.typ": helper, widget, helper, formatter
+
+// Same name imported directly and via alias
+#import "alias-duplicates.typ": config, settings as config, template
+
+// Two aliases with the same target name
+#import "same-alias.typ": render, format as util, transform as util, aliases

--- a/tests/fixtures/unit/code/snap/import-reorder.typ-0.snap
+++ b/tests/fixtures/unit/code/snap/import-reorder.typ-0.snap
@@ -1,0 +1,99 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/code/import-reorder.typ
+---
+/// typstyle: reorder-import-items
+
+// Single import with mixed styles in random order
+#import "module.typ": (
+  a.b.c,
+  alpha,
+  beta,
+  func as renamed,
+  gamma,
+  h.i.j,
+  j.k.l as util,
+  m.n,
+  p.q as custom,
+  widget as tool,
+  x.y as short,
+  xyz,
+  z.y.x,
+)
+
+// Multiple imports from same module, should ideally be merged and reordered
+#import "common.typ": (
+  format,
+)
+#import "common.typ": (
+  layout as l,
+  render,
+)
+#import "common.typ": (
+  style.color,
+  transform as t,
+)
+#import "common.typ": (
+  data.chart as graph,
+  data.table,
+)
+
+// Imports with special names and deep nesting
+#import "special.typ": (
+  _hidden,
+  _private.func as _f,
+  a.b.c.d.e.f,
+  very.deep.nested.module.function as fn,
+  x-y-z as x_y_z,
+)
+
+// Conflicting names that should be preserved
+#import "math.typ": (
+  sum,
+)
+#import "stats.typ": (
+  sum as statistical_sum,
+)
+
+// Empty and single item imports
+#import "empty.typ":
+#import "single.typ": (
+  only_item,
+)
+#import "wildcard.typ": *
+
+// Case 1: Import with comments between items - should not reorder
+#import "commented.typ": (
+  bbb,
+  aaa,
+  // This comment should prevent reordering
+)
+#import "commented.typ": (
+  ddd,
+  /* Another comment type */
+  ccc,
+)
+
+// Case 2: Import with duplicate item names - should not reorder
+// Same name imported twice
+#import "duplicates.typ": (
+  helper,
+  widget,
+  helper,
+  formatter,
+)
+
+// Same name imported directly and via alias
+#import "alias-duplicates.typ": (
+  config,
+  settings as config,
+  template,
+)
+
+// Two aliases with the same target name
+#import "same-alias.typ": (
+  render,
+  format as util,
+  transform as util,
+  aliases,
+)

--- a/tests/fixtures/unit/code/snap/import-reorder.typ-120.snap
+++ b/tests/fixtures/unit/code/snap/import-reorder.typ-120.snap
@@ -1,0 +1,58 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/code/import-reorder.typ
+---
+/// typstyle: reorder-import-items
+
+// Single import with mixed styles in random order
+#import "module.typ": (
+  a.b.c,
+  alpha,
+  beta,
+  func as renamed,
+  gamma,
+  h.i.j,
+  j.k.l as util,
+  m.n,
+  p.q as custom,
+  widget as tool,
+  x.y as short,
+  xyz,
+  z.y.x,
+)
+
+// Multiple imports from same module, should ideally be merged and reordered
+#import "common.typ": format
+#import "common.typ": layout as l, render
+#import "common.typ": style.color, transform as t
+#import "common.typ": data.chart as graph, data.table
+
+// Imports with special names and deep nesting
+#import "special.typ": _hidden, _private.func as _f, a.b.c.d.e.f, very.deep.nested.module.function as fn, x-y-z as x_y_z
+
+// Conflicting names that should be preserved
+#import "math.typ": sum
+#import "stats.typ": sum as statistical_sum
+
+// Empty and single item imports
+#import "empty.typ":
+#import "single.typ": only_item
+#import "wildcard.typ": *
+
+// Case 1: Import with comments between items - should not reorder
+#import "commented.typ": (
+  bbb,
+  aaa,
+  // This comment should prevent reordering
+)
+#import "commented.typ": ddd, /* Another comment type */ ccc
+
+// Case 2: Import with duplicate item names - should not reorder
+// Same name imported twice
+#import "duplicates.typ": helper, widget, helper, formatter
+
+// Same name imported directly and via alias
+#import "alias-duplicates.typ": config, settings as config, template
+
+// Two aliases with the same target name
+#import "same-alias.typ": render, format as util, transform as util, aliases

--- a/tests/fixtures/unit/code/snap/import-reorder.typ-40.snap
+++ b/tests/fixtures/unit/code/snap/import-reorder.typ-40.snap
@@ -1,0 +1,92 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/code/import-reorder.typ
+---
+/// typstyle: reorder-import-items
+
+// Single import with mixed styles in random order
+#import "module.typ": (
+  a.b.c,
+  alpha,
+  beta,
+  func as renamed,
+  gamma,
+  h.i.j,
+  j.k.l as util,
+  m.n,
+  p.q as custom,
+  widget as tool,
+  x.y as short,
+  xyz,
+  z.y.x,
+)
+
+// Multiple imports from same module, should ideally be merged and reordered
+#import "common.typ": format
+#import "common.typ": (
+  layout as l,
+  render,
+)
+#import "common.typ": (
+  style.color,
+  transform as t,
+)
+#import "common.typ": (
+  data.chart as graph,
+  data.table,
+)
+
+// Imports with special names and deep nesting
+#import "special.typ": (
+  _hidden,
+  _private.func as _f,
+  a.b.c.d.e.f,
+  very.deep.nested.module.function as fn,
+  x-y-z as x_y_z,
+)
+
+// Conflicting names that should be preserved
+#import "math.typ": sum
+#import "stats.typ": (
+  sum as statistical_sum,
+)
+
+// Empty and single item imports
+#import "empty.typ":
+#import "single.typ": only_item
+#import "wildcard.typ": *
+
+// Case 1: Import with comments between items - should not reorder
+#import "commented.typ": (
+  bbb,
+  aaa,
+  // This comment should prevent reordering
+)
+#import "commented.typ": (
+  ddd,
+  /* Another comment type */ ccc,
+)
+
+// Case 2: Import with duplicate item names - should not reorder
+// Same name imported twice
+#import "duplicates.typ": (
+  helper,
+  widget,
+  helper,
+  formatter,
+)
+
+// Same name imported directly and via alias
+#import "alias-duplicates.typ": (
+  config,
+  settings as config,
+  template,
+)
+
+// Two aliases with the same target name
+#import "same-alias.typ": (
+  render,
+  format as util,
+  transform as util,
+  aliases,
+)

--- a/tests/fixtures/unit/code/snap/import-reorder.typ-80.snap
+++ b/tests/fixtures/unit/code/snap/import-reorder.typ-80.snap
@@ -1,0 +1,64 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/code/import-reorder.typ
+---
+/// typstyle: reorder-import-items
+
+// Single import with mixed styles in random order
+#import "module.typ": (
+  a.b.c,
+  alpha,
+  beta,
+  func as renamed,
+  gamma,
+  h.i.j,
+  j.k.l as util,
+  m.n,
+  p.q as custom,
+  widget as tool,
+  x.y as short,
+  xyz,
+  z.y.x,
+)
+
+// Multiple imports from same module, should ideally be merged and reordered
+#import "common.typ": format
+#import "common.typ": layout as l, render
+#import "common.typ": style.color, transform as t
+#import "common.typ": data.chart as graph, data.table
+
+// Imports with special names and deep nesting
+#import "special.typ": (
+  _hidden,
+  _private.func as _f,
+  a.b.c.d.e.f,
+  very.deep.nested.module.function as fn,
+  x-y-z as x_y_z,
+)
+
+// Conflicting names that should be preserved
+#import "math.typ": sum
+#import "stats.typ": sum as statistical_sum
+
+// Empty and single item imports
+#import "empty.typ":
+#import "single.typ": only_item
+#import "wildcard.typ": *
+
+// Case 1: Import with comments between items - should not reorder
+#import "commented.typ": (
+  bbb,
+  aaa,
+  // This comment should prevent reordering
+)
+#import "commented.typ": ddd, /* Another comment type */ ccc
+
+// Case 2: Import with duplicate item names - should not reorder
+// Same name imported twice
+#import "duplicates.typ": helper, widget, helper, formatter
+
+// Same name imported directly and via alias
+#import "alias-duplicates.typ": config, settings as config, template
+
+// Two aliases with the same target name
+#import "same-alias.typ": render, format as util, transform as util, aliases

--- a/tests/src/common.rs
+++ b/tests/src/common.rs
@@ -5,6 +5,7 @@ use std::{
 
 use libtest_mimic::Failed;
 use typst_syntax::Source;
+use typstyle_core::Config;
 
 pub fn test_dir() -> &'static Path {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -12,6 +13,12 @@ pub fn test_dir() -> &'static Path {
 
 pub fn fixtures_dir() -> PathBuf {
     test_dir().join("fixtures")
+}
+
+pub fn read_source_with_config(path: &Path) -> Result<(Source, Config), Failed> {
+    let content = read_content(path)?;
+    let config = parse_directives(&content)?;
+    Ok((Source::detached(content), config))
 }
 
 pub fn read_source(path: &Path) -> Result<Source, Failed> {
@@ -34,5 +41,52 @@ fn remove_crlf(content: String) -> String {
         content.replace("\r\n", "\n")
     } else {
         content
+    }
+}
+
+/// Parses typstyle directives from the first line of a file
+fn parse_directives(content: &str) -> Result<Config, Failed> {
+    let mut config = Config::new();
+
+    // Get the first line
+    if let Some(first_line) = content.lines().next() {
+        // Check if it starts with the directive marker
+        if first_line.trim_start().starts_with("/// typstyle:") {
+            // Extract the content after the marker
+            let directive_content = first_line
+                .trim_start()
+                .strip_prefix("/// typstyle:")
+                .unwrap_or("")
+                .trim();
+
+            // Split by spaces to get individual directives
+            for directive in directive_content.split_whitespace() {
+                // Check if it's a key-value pair
+                let (key, value) = directive
+                    .split_once('=')
+                    .map(|(key, value)| (key.trim(), Some(value.trim())))
+                    .unwrap_or((directive, None));
+                match key {
+                    "reorder-import-items" => config.reorder_import_items = value != Some("false"),
+                    _ => return Err(format!("unknown directive: {key}").into()),
+                }
+            }
+        }
+    }
+
+    Ok(config)
+}
+
+#[cfg(test)]
+#[allow(unused_imports)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_single_directive() {
+        let content = "/// typstyle: reorder-import-items\n#import \"module.typ\": a, b";
+        let config = parse_directives(content).unwrap();
+
+        assert_eq!(config.reorder_import_items, true);
     }
 }


### PR DESCRIPTION
Add an option to reorder import items (default: false). Part of #212.

We sort the items of an import statement alphabetically, if it has no comment or duplicated name. In other cases, the order should not matter.

We designed a directive to set local configuration in different unit tests: `/// typstyle: some-options`.