### PR TITLE
test: optionally save diff PNGs to given directory

### DIFF
--- a/crates/typstyle-consistency/src/harness.rs
+++ b/crates/typstyle-consistency/src/harness.rs
@@ -187,22 +187,19 @@ impl FormatterHarness {
             ..Default::default()
         }));
 
-        let base_result = compile_world(
-            format!("{} - {} - original", self.name, entry_path.display()),
-            &base_world,
-        )?;
+        let name = if self.name.is_empty() {
+            entry_path.display().to_string()
+        } else {
+            format!("{} - {}", self.name, entry_path.display())
+        };
+        let base_result = compile_world(format!("{} - original", name), &base_world)?;
 
         for sources in formatted {
             let world = FormattedWorld {
                 base: &base_world,
                 formatted: sources.sources.clone(),
             };
-            let name = format!(
-                "{} - {} - {}",
-                self.name,
-                entry_path.display(),
-                sources.name
-            );
+            let name = format!("{} - {}", name, sources.name);
             let fmt_result = compile_world(name.clone(), &world)?;
 
             compare_docs(&base_result, &fmt_result, require_compile, &mut sub_sink)?;

--- a/tests/src/unit.rs
+++ b/tests/src/unit.rs
@@ -179,12 +179,12 @@ fn check_output_consistency(path: &Path, width: usize) -> Result<(), Failed> {
     let mut err_sink = ErrorSink::new(format!("consistency {}", path.display()));
 
     let mut harness = FormatterHarness::new("".to_string(), PathBuf::new())?;
-    let main_vpath = Path::new("__main__");
+    let main_vpath = path.strip_prefix(fixtures_dir())?;
     harness.add_source_file(main_vpath, source.text())?;
 
     let base_world = harness.snapshot();
     let fmt_sources = FormattedSources {
-        name: "formatted".to_string(),
+        name: format!("{}char", width),
         sources: harness.format(
             &base_world,
             |source| Ok(Typstyle::new(cfg.clone()).format_source(&source).unwrap()),
@@ -197,6 +197,8 @@ fn check_output_consistency(path: &Path, width: usize) -> Result<(), Failed> {
     if err_sink.is_ok() {
         Ok(())
     } else {
-        Err(err_sink.into())
+        // ensure output is colored
+        eprintln!("{}", err_sink);
+        Err(Failed::without_message())
     }
 }


### PR DESCRIPTION
if env `TYPSTYLE_SAVE_DIFF` is set, save pngs to that directory when the outputs are inconsistent.