### PR TITLE
feat: sort import items by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Beautiful and reliable typst code formatter
 Usage: typstyle [OPTIONS] [INPUT]... [COMMAND]
 
 Commands:
-  format-all   Format all files in-place in the given directory
-  help         Print this message or the help of the given subcommand(s)
+  format-all  Format all files in-place in the given directory
+  help        Print this message or the help of the given subcommand(s)
 
 Arguments:
   [INPUT]...  Path to the input files, if not provided, read from stdin. If multiple files are provided, they will be processed in order
@@ -53,7 +53,10 @@ Options:
   -V, --version  Print version
 
 Format Configuration:
-  -c, --column <COLUMN>  The column width of the output [default: 80]
+  -c, --column <COLUMN>          The column width of the output [default: 80]
+  -t, --tab-width <TAB_WIDTH>    Spaces per level of indentation in the output [default: 2]
+      --no-reorder-import-items  Whether not to reorder import items
+      --wrap-text                Whether to wrap texts in the markup
 
 Debug Options:
   -a, --ast         Print the AST of the input file
@@ -77,7 +80,10 @@ Options:
   -h, --help   Print help
 
 Format Configuration:
-  -c, --column <COLUMN>  The column width of the output [default: 80]
+  -c, --column <COLUMN>          The column width of the output [default: 80]
+  -t, --tab-width <TAB_WIDTH>    Spaces per level of indentation in the output [default: 2]
+      --no-reorder-import-items  Whether not to reorder import items
+      --wrap-text                Whether to wrap texts in the markup
 
 Log Levels:
   -v, --verbose  Enable verbose logging

--- a/crates/typstyle-core/src/config.rs
+++ b/crates/typstyle-core/src/config.rs
@@ -21,7 +21,7 @@ impl Default for Config {
             tab_spaces: 2,
             max_width: 80,
             blank_lines_upper_bound: 2,
-            reorder_import_items: false,
+            reorder_import_items: true,
             wrap_text: false,
         }
     }

--- a/crates/typstyle/src/cli.rs
+++ b/crates/typstyle/src/cli.rs
@@ -73,9 +73,9 @@ pub struct StyleArgs {
     #[arg(short, long, default_value_t = 2, global = true)]
     pub tab_width: usize,
 
-    /// Whether to reorder import items.
+    /// Whether not to reorder import items.
     #[arg(long, default_value_t = false, global = true)]
-    pub reorder_import_items: bool,
+    pub no_reorder_import_items: bool,
 
     /// Whether to wrap texts in the markup.
     #[arg(long, default_value_t = false, global = true)]

--- a/crates/typstyle/src/fmt.rs
+++ b/crates/typstyle/src/fmt.rs
@@ -33,7 +33,7 @@ impl StyleArgs {
         Config {
             max_width: self.column,
             tab_spaces: self.tab_width,
-            reorder_import_items: self.reorder_import_items,
+            reorder_import_items: !self.no_reorder_import_items,
             wrap_text: self.wrap_text,
             ..Default::default()
         }

--- a/crates/typstyle/tests/test_style_args.rs
+++ b/crates/typstyle/tests/test_style_args.rs
@@ -36,15 +36,15 @@ fn test_reorder_import_items() {
     success: true
     exit_code: 0
     ----- stdout -----
-    #import "module.typ": xyz, func as renamed, h.i.j, a.b.c
+    #import "module.typ": a.b.c, func as renamed, h.i.j, xyz
 
     ----- stderr -----
     "#);
-    typstyle_cmd_snapshot!(space.cli().args(["--reorder-import-items"]).pass_stdin(stdin), @r#"
+    typstyle_cmd_snapshot!(space.cli().args(["--no-reorder-import-items"]).pass_stdin(stdin), @r#"
     success: true
     exit_code: 0
     ----- stdout -----
-    #import "module.typ": a.b.c, func as renamed, h.i.j, xyz
+    #import "module.typ": xyz, func as renamed, h.i.j, a.b.c
 
     ----- stderr -----
     "#);

--- a/tests/fixtures/packages/snap/codly.typ-0.snap
+++ b/tests/fixtures/packages/snap/codly.typ-0.snap
@@ -13,8 +13,8 @@ input_file: tests/fixtures/packages/codly.typ
 
 #import "args.typ": (
   __codly-args,
-  __codly-save,
   __codly-load,
+  __codly-save,
 )
 
 #let __codly-inset(

--- a/tests/fixtures/packages/snap/codly.typ-120.snap
+++ b/tests/fixtures/packages/snap/codly.typ-120.snap
@@ -11,7 +11,7 @@ input_file: tests/fixtures/packages/codly.typ
  * This file is used as test case only and remains unchanged from the original.
  */
 
-#import "args.typ": __codly-args, __codly-save, __codly-load
+#import "args.typ": __codly-args, __codly-load, __codly-save
 
 #let __codly-inset(inset) = {
   if type(inset) == dictionary {

--- a/tests/fixtures/packages/snap/codly.typ-40.snap
+++ b/tests/fixtures/packages/snap/codly.typ-40.snap
@@ -13,8 +13,8 @@ input_file: tests/fixtures/packages/codly.typ
 
 #import "args.typ": (
   __codly-args,
-  __codly-save,
   __codly-load,
+  __codly-save,
 )
 
 #let __codly-inset(inset) = {

--- a/tests/fixtures/packages/snap/codly.typ-80.snap
+++ b/tests/fixtures/packages/snap/codly.typ-80.snap
@@ -11,7 +11,7 @@ input_file: tests/fixtures/packages/codly.typ
  * This file is used as test case only and remains unchanged from the original.
  */
 
-#import "args.typ": __codly-args, __codly-save, __codly-load
+#import "args.typ": __codly-args, __codly-load, __codly-save
 
 #let __codly-inset(inset) = {
   if type(inset) == dictionary {

--- a/tests/fixtures/unit/code/snap/import.typ-0.snap
+++ b/tests/fixtures/unit/code/snap/import.typ-0.snap
@@ -1,9 +1,8 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/code/import.typ
-snapshot_kind: text
 ---
 #import "@preview/fletcher:0.4.0" as fletcher: (
-  node,
   edge,
+  node,
 )

--- a/tests/fixtures/unit/code/snap/import.typ-120.snap
+++ b/tests/fixtures/unit/code/snap/import.typ-120.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/code/import.typ
-snapshot_kind: text
 ---
-#import "@preview/fletcher:0.4.0" as fletcher: node, edge
+#import "@preview/fletcher:0.4.0" as fletcher: edge, node

--- a/tests/fixtures/unit/code/snap/import.typ-40.snap
+++ b/tests/fixtures/unit/code/snap/import.typ-40.snap
@@ -1,9 +1,8 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/code/import.typ
-snapshot_kind: text
 ---
 #import "@preview/fletcher:0.4.0" as fletcher: (
-  node,
   edge,
+  node,
 )

--- a/tests/fixtures/unit/code/snap/import.typ-80.snap
+++ b/tests/fixtures/unit/code/snap/import.typ-80.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/code/import.typ
-snapshot_kind: text
 ---
-#import "@preview/fletcher:0.4.0" as fletcher: node, edge
+#import "@preview/fletcher:0.4.0" as fletcher: edge, node

--- a/tests/fixtures/unit/comment/snap/in-import.typ-0.snap
+++ b/tests/fixtures/unit/comment/snap/in-import.typ-0.snap
@@ -10,20 +10,20 @@ input_file: tests/fixtures/unit/comment/in-import.typ
   eee as fff,
 )
 #import "@preview/fletcher:0.5.2" as fletcher: (
-  node,
   edge,
+  node,
 )
 #import "@preview/fletcher:0.5.2" as fletcher: (
-  node,
   edge,
+  node,
 )
 #import "@preview/fletcher:0.5.2" as fletcher: (
-  node,
   edge,
+  node,
 )
 #import "@preview/fletcher:0.5.2" as fletcher: (
-  node,
   edge,
+  node,
 )
 
 #import /* 0 */ "test.typ"/* 1 */

--- a/tests/fixtures/unit/comment/snap/in-import.typ-120.snap
+++ b/tests/fixtures/unit/comment/snap/in-import.typ-120.snap
@@ -6,10 +6,10 @@ input_file: tests/fixtures/unit/comment/in-import.typ
 #import "test.typ":
 #import "test.typ": *
 #import "test.typ": a.b.c.d, eee as fff
-#import "@preview/fletcher:0.5.2" as fletcher: node, edge
-#import "@preview/fletcher:0.5.2" as fletcher: node, edge
-#import "@preview/fletcher:0.5.2" as fletcher: node, edge
-#import "@preview/fletcher:0.5.2" as fletcher: node, edge
+#import "@preview/fletcher:0.5.2" as fletcher: edge, node
+#import "@preview/fletcher:0.5.2" as fletcher: edge, node
+#import "@preview/fletcher:0.5.2" as fletcher: edge, node
+#import "@preview/fletcher:0.5.2" as fletcher: edge, node
 
 #import /* 0 */ "test.typ"/* 1 */
 #import /* 0 */ "test.typ" /* 1 */:/* 2 */

--- a/tests/fixtures/unit/comment/snap/in-import.typ-40.snap
+++ b/tests/fixtures/unit/comment/snap/in-import.typ-40.snap
@@ -7,20 +7,20 @@ input_file: tests/fixtures/unit/comment/in-import.typ
 #import "test.typ": *
 #import "test.typ": a.b.c.d, eee as fff
 #import "@preview/fletcher:0.5.2" as fletcher: (
-  node,
   edge,
+  node,
 )
 #import "@preview/fletcher:0.5.2" as fletcher: (
-  node,
   edge,
+  node,
 )
 #import "@preview/fletcher:0.5.2" as fletcher: (
-  node,
   edge,
+  node,
 )
 #import "@preview/fletcher:0.5.2" as fletcher: (
-  node,
   edge,
+  node,
 )
 
 #import /* 0 */ "test.typ"/* 1 */

--- a/tests/fixtures/unit/comment/snap/in-import.typ-80.snap
+++ b/tests/fixtures/unit/comment/snap/in-import.typ-80.snap
@@ -6,10 +6,10 @@ input_file: tests/fixtures/unit/comment/in-import.typ
 #import "test.typ":
 #import "test.typ": *
 #import "test.typ": a.b.c.d, eee as fff
-#import "@preview/fletcher:0.5.2" as fletcher: node, edge
-#import "@preview/fletcher:0.5.2" as fletcher: node, edge
-#import "@preview/fletcher:0.5.2" as fletcher: node, edge
-#import "@preview/fletcher:0.5.2" as fletcher: node, edge
+#import "@preview/fletcher:0.5.2" as fletcher: edge, node
+#import "@preview/fletcher:0.5.2" as fletcher: edge, node
+#import "@preview/fletcher:0.5.2" as fletcher: edge, node
+#import "@preview/fletcher:0.5.2" as fletcher: edge, node
 
 #import /* 0 */ "test.typ"/* 1 */
 #import /* 0 */ "test.typ" /* 1 */:/* 2 */

--- a/tests/fixtures/unit/func/snap/func-call-with-newline.typ-0.snap
+++ b/tests/fixtures/unit/func/snap/func-call-with-newline.typ-0.snap
@@ -4,8 +4,8 @@ input_file: tests/fixtures/unit/func/func-call-with-newline.typ
 ---
 #import "@preview/fletcher:0.5.0" as fletcher: (
   diagram,
-  node,
   edge,
+  node,
 )
 #set page(
   width: auto,

--- a/tests/fixtures/unit/func/snap/func-call-with-newline.typ-120.snap
+++ b/tests/fixtures/unit/func/snap/func-call-with-newline.typ-120.snap
@@ -2,7 +2,7 @@
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/func/func-call-with-newline.typ
 ---
-#import "@preview/fletcher:0.5.0" as fletcher: diagram, node, edge
+#import "@preview/fletcher:0.5.0" as fletcher: diagram, edge, node
 #set page(width: auto, height: auto, margin: 5mm, fill: white)
 
 #diagram(

--- a/tests/fixtures/unit/func/snap/func-call-with-newline.typ-40.snap
+++ b/tests/fixtures/unit/func/snap/func-call-with-newline.typ-40.snap
@@ -4,8 +4,8 @@ input_file: tests/fixtures/unit/func/func-call-with-newline.typ
 ---
 #import "@preview/fletcher:0.5.0" as fletcher: (
   diagram,
-  node,
   edge,
+  node,
 )
 #set page(
   width: auto,

--- a/tests/fixtures/unit/func/snap/func-call-with-newline.typ-80.snap
+++ b/tests/fixtures/unit/func/snap/func-call-with-newline.typ-80.snap
@@ -2,7 +2,7 @@
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/func/func-call-with-newline.typ
 ---
-#import "@preview/fletcher:0.5.0" as fletcher: diagram, node, edge
+#import "@preview/fletcher:0.5.0" as fletcher: diagram, edge, node
 #set page(width: auto, height: auto, margin: 5mm, fill: white)
 
 #diagram(


### PR DESCRIPTION
In cli args, you now need to provide `--no-reorder-import-items` if you want to disable this feature.