### PR TITLE
feat(cli): support formatting multiple directories and deprecate `format-all` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1978,10 +1978,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "path-absolutize"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5"
+dependencies = [
+ "path-dedot",
+]
+
+[[package]]
 name = "path-clean"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
+
+[[package]]
+name = "path-dedot"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "pathdiff"
@@ -3722,7 +3740,9 @@ dependencies = [
  "colored",
  "insta",
  "insta-cmd",
+ "itertools 0.14.0",
  "log",
+ "path-absolutize",
  "tempfile",
  "typst-syntax",
  "typstyle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ wasm-bindgen = { version = "0.2" }
 anyhow = "1"
 clap = { version = "4.5", features = ["derive", "env"] }
 clap_complete = { version = "4.5" }
+path-absolutize = "3"
 walkdir = { version = "2" }
 
 log = "0.4"

--- a/README.md
+++ b/README.md
@@ -40,50 +40,27 @@ Beautiful and reliable typst code formatter
 Usage: typstyle [OPTIONS] [INPUT]... [COMMAND]
 
 Commands:
-  format-all  Format all files in-place in the given directory
+  format-all  (Deprecated) Format all files in-place in the given directory
   help        Print this message or the help of the given subcommand(s)
 
 Arguments:
-  [INPUT]...  Path to the input files, if not provided, read from stdin. If multiple files are provided, they will be processed in order
+  [INPUT]...  List of files or directories to format [default: stdin]
 
 Options:
   -i, --inplace  Format the file in place
-      --check    Run in 'check' mode. Exits with 0 if input is formatted correctly. Exits with 1 if formatting is required
+      --check    Run in 'check' mode. Exits with 0 if input is formatted correctly. Exits with a non-zero status code if formatting is required
   -h, --help     Print help
   -V, --version  Print version
 
 Format Configuration:
-  -c, --column <COLUMN>          The column width of the output [default: 80]
-  -t, --tab-width <TAB_WIDTH>    Spaces per level of indentation in the output [default: 2]
-      --no-reorder-import-items  Whether not to reorder import items
-      --wrap-text                Whether to wrap texts in the markup
+  -l, --line-width <LINE_WIDTH>      The column width of the output [default: 80] [aliases: column] [short aliases: c]
+  -t, --indent-width <INDENT_WIDTH>  Spaces per level of indentation in the output [default: 2] [aliases: tab-width]
+      --no-reorder-import-items      Whether not to reorder import items
+      --wrap-text                    Whether to wrap texts in the markup
 
 Debug Options:
   -a, --ast         Print the AST of the input file
   -p, --pretty-doc  Print the pretty document
-
-Log Levels:
-  -v, --verbose  Enable verbose logging
-  -q, --quiet    Print diagnostics, but nothing else
-```
-
-```txt
-Format all files in-place in the given directory
-
-Usage: typstyle format-all [OPTIONS] [DIRECTORY]
-
-Arguments:
-  [DIRECTORY]  The directory to format. If not provided, the current directory is used
-
-Options:
-      --check  Run in 'check' mode. Exits with 0 if input is formatted correctly. Exits with 1 if formatting is required
-  -h, --help   Print help
-
-Format Configuration:
-  -c, --column <COLUMN>          The column width of the output [default: 80]
-  -t, --tab-width <TAB_WIDTH>    Spaces per level of indentation in the output [default: 2]
-      --no-reorder-import-items  Whether not to reorder import items
-      --wrap-text                Whether to wrap texts in the markup
 
 Log Levels:
   -v, --verbose  Enable verbose logging

--- a/crates/typstyle-core/src/lib.rs
+++ b/crates/typstyle-core/src/lib.rs
@@ -31,19 +31,19 @@ impl Typstyle {
     }
 
     /// Format typst content.
-    pub fn format_content(self, content: impl Into<String>) -> Result<String, Error> {
+    pub fn format_content(&self, content: impl Into<String>) -> Result<String, Error> {
         // We should ensure that the source tree is spanned.
         self.format_source(&Source::detached(content.into()))
     }
 
     /// Format typst source.
-    pub fn format_source(self, source: &Source) -> Result<String, Error> {
+    pub fn format_source(&self, source: &Source) -> Result<String, Error> {
         self.format_source_inspect(source, |_| {})
     }
 
     /// Format typst source, and inspect the pretty document.
     pub fn format_source_inspect(
-        self,
+        &self,
         source: &Source,
         inspector: impl FnOnce(&ArenaDoc<'_>),
     ) -> Result<String, Error> {

--- a/crates/typstyle/Cargo.toml
+++ b/crates/typstyle/Cargo.toml
@@ -25,6 +25,8 @@ typst-syntax.workspace = true
 anyhow.workspace = true
 clap.workspace = true
 clap_complete = { workspace = true, optional = true }
+itertools.workspace = true
+path-absolutize.workspace = true
 walkdir.workspace = true
 
 log.workspace = true

--- a/crates/typstyle/src/cli.rs
+++ b/crates/typstyle/src/cli.rs
@@ -12,14 +12,15 @@ pub struct CliArguments {
     #[command(subcommand)]
     pub command: Option<Command>,
 
-    /// Path to the input files, if not provided, read from stdin. If multiple files are provided, they will be processed in order
+    /// List of files or directories to format [default: stdin]
     pub input: Vec<PathBuf>,
 
     /// Format the file in place
     #[arg(short, long, default_value_t = false, conflicts_with = "check")]
     pub inplace: bool,
 
-    /// Run in 'check' mode. Exits with 0 if input is formatted correctly. Exits with 1 if formatting is required.
+    /// Run in 'check' mode. Exits with 0 if input is formatted correctly.
+    /// Exits with a non-zero status code if formatting is required.
     #[arg(long, default_value_t = false, global = true)]
     pub check: bool,
 
@@ -48,7 +49,7 @@ impl CliArguments {
 
 #[derive(Subcommand)]
 pub enum Command {
-    /// Format all files in-place in the given directory
+    /// (Deprecated) Format all files in-place in the given directory
     FormatAll {
         /// The directory to format. If not provided, the current directory is used
         directory: Option<PathBuf>,
@@ -66,12 +67,25 @@ pub enum Command {
 #[derive(Args)]
 pub struct StyleArgs {
     /// The column width of the output
-    #[arg(short, long, default_value_t = 80, global = true)]
-    pub column: usize,
+    #[arg(
+        short = 'l',
+        long,
+        visible_short_alias = 'c',
+        visible_alias = "column",
+        default_value_t = 80,
+        global = true
+    )]
+    pub line_width: usize,
 
     /// Spaces per level of indentation in the output
-    #[arg(short, long, default_value_t = 2, global = true)]
-    pub tab_width: usize,
+    #[arg(
+        short = 't',
+        long,
+        visible_alias = "tab-width",
+        default_value_t = 2,
+        global = true
+    )]
+    pub indent_width: usize,
 
     /// Whether not to reorder import items.
     #[arg(long, default_value_t = false, global = true)]

--- a/crates/typstyle/src/fmt.rs
+++ b/crates/typstyle/src/fmt.rs
@@ -1,3 +1,7 @@
+/// This module provides functionality to format Typst files either in-place or by checking
+/// their formatting via standard input/output.
+///
+/// Adapted from: https://github.com/astral-sh/ruff/blob/main/crates/ruff_linter/src/fs.rs
 use std::{
     io::Read,
     path::{Path, PathBuf},
@@ -5,25 +9,31 @@ use std::{
 };
 
 use anyhow::{bail, Context, Result};
+use itertools::Itertools;
 use log::{debug, error, info, warn};
 use typst_syntax::Source;
 use typstyle_core::{Config, Typstyle};
 use walkdir::{DirEntry, WalkDir};
 
-use crate::cli::{CliArguments, StyleArgs};
+use crate::{
+    cli::{CliArguments, StyleArgs},
+    fs, ExitStatus,
+};
 
-pub enum FormatStatus {
-    /// The content was changed (and written back to the file if needed).
-    Changed,
-    /// The content was already well-formatted and unchanged, or erroneous.
-    Unchanged,
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum FormatMode {
+    /// Write the formatted contents back to the file.
+    Write,
+    /// Check if the file is formatted, but do not write the formatted contents back.
+    Check,
 }
 
-impl std::ops::BitOrAssign for FormatStatus {
-    fn bitor_assign(&mut self, rhs: Self) {
-        match (&self, rhs) {
-            (Self::Unchanged, FormatStatus::Unchanged) => *self = Self::Unchanged,
-            _ => *self = Self::Changed,
+impl FormatMode {
+    pub(crate) fn from_cli(cli: &CliArguments) -> Self {
+        if cli.check {
+            FormatMode::Check
+        } else {
+            FormatMode::Write
         }
     }
 }
@@ -31,8 +41,8 @@ impl std::ops::BitOrAssign for FormatStatus {
 impl StyleArgs {
     pub fn to_config(&self) -> Config {
         Config {
-            max_width: self.column,
-            tab_spaces: self.tab_width,
+            max_width: self.line_width,
+            tab_spaces: self.indent_width,
             reorder_import_items: !self.no_reorder_import_items,
             wrap_text: self.wrap_text,
             ..Default::default()
@@ -40,25 +50,14 @@ impl StyleArgs {
     }
 }
 
-/// Formats all `.typ` files in the specified directory, or the current directory if none is given.
-///
-/// This function recursively searches the provided directory for `.typ` files, formats them, and
-/// overwrites them with the formatted content if needed.
-///
-/// # Parameters
-/// - `directory`: An optional path to the directory containing `.typ` files. If `None`, the
-///   current working directory is used.
-/// - `args`: CLI arguments.
-///
-/// # Returns
-/// Returns `Ok(FormatStatus)` indicating whether any file was modified.
-pub fn format_all(directory: &Option<PathBuf>, args: &CliArguments) -> Result<FormatStatus> {
-    let mut status = FormatStatus::Unchanged;
+pub fn format_stdin(args: &CliArguments) -> Result<ExitStatus> {
+    format_one(None, args).map(|res| match res {
+        FormatResult::Formatted(_) if args.check => ExitStatus::Failure,
+        _ => ExitStatus::Success,
+    })
+}
 
-    let directory = directory
-        .clone()
-        .unwrap_or_else(|| std::env::current_dir().unwrap());
-
+pub fn format(args: &CliArguments) -> Result<ExitStatus> {
     #[derive(Default)]
     struct Summary {
         format_count: usize,
@@ -67,63 +66,50 @@ pub fn format_all(directory: &Option<PathBuf>, args: &CliArguments) -> Result<Fo
     }
     let mut summary = Summary::default();
 
-    let start_time = Instant::now();
+    let mode = FormatMode::from_cli(args);
+    let paths = resolve_typst_files(&args.input);
+    if paths.is_empty() {
+        warn!("No Typst files found under the given path(s).");
+        return Ok(ExitStatus::Success);
+    }
 
-    // Walk through all the files in the directory
-    let entries = WalkDir::new(directory)
-        .into_iter()
-        .filter_entry(|e| !is_hidden(e))
-        .filter_map(Result::ok);
-    for entry in entries {
-        if !(entry.file_type().is_file() && entry.path().extension() == Some("typ".as_ref())) {
-            continue;
-        }
-        let Ok(content) = std::fs::read_to_string(entry.path()) else {
-            continue;
-        };
-        let cfg = args.style.to_config();
-        let Ok(res) = Typstyle::new(cfg).format_content(&content) else {
-            warn!("Failed to format: {}", entry.path().display());
-            continue;
-        };
+    let start_time = Instant::now();
+    for file in paths {
+        let res = format_one(Some(&file), args).unwrap_or_else(|e| {
+            error!("{e}");
+            summary.error_count += 1;
+            FormatResult::Erroneous
+        });
 
         // Check if the content is already well-formatted (unchanged)
-        if res == content {
-            summary.unchanged_count += 1;
-            continue;
-        }
-        status = FormatStatus::Changed;
-
-        if args.check {
-            debug!("Would reformat: {}", entry.path().display());
-            summary.format_count += 1
-        } else {
-            // Attempt to overwrite the file with the formatted content
-            match write_back(entry.path(), &res) {
-                Ok(_) => summary.format_count += 1,
-                Err(e) => {
-                    error!("{e}");
-                    summary.error_count += 1;
-                }
-            }
+        match res {
+            FormatResult::Formatted(_) => summary.format_count += 1,
+            _ => summary.unchanged_count += 1,
         }
     }
     let duration = start_time.elapsed();
 
-    if args.check {
-        info!(
-            "{} would be reformatted ({} already formatted), checked in {:?}",
-            num_files(summary.format_count),
-            summary.unchanged_count,
-            duration
-        );
-    } else {
-        info!(
+    fn num_files(num: usize) -> String {
+        if num > 1 {
+            format!("{num} files")
+        } else {
+            format!("{num} file")
+        }
+    }
+
+    match mode {
+        FormatMode::Write => debug!(
             "Successfully formatted {} ({} unchanged) in {:?}",
             num_files(summary.format_count),
             summary.unchanged_count,
             duration
-        );
+        ),
+        FormatMode::Check => debug!(
+            "{} would be reformatted ({} already formatted), checked in {:?}",
+            num_files(summary.format_count),
+            summary.unchanged_count,
+            duration
+        ),
     }
     if summary.error_count > 0 {
         // Syntax errors are not counted here.
@@ -133,40 +119,10 @@ pub fn format_all(directory: &Option<PathBuf>, args: &CliArguments) -> Result<Fo
         );
     }
 
-    Ok(status)
-}
-
-/// Formats multiple `.typ` files passed as a list of paths.
-///
-/// This function processes each file individually, and if any errors occur, they are handled without stopping
-/// the entire operation
-///
-/// # Parameters
-/// - `input`: A list of paths to `.typ` files to be formatted.
-/// - `args`: CLI arguments.
-///
-/// # Returns
-/// Returns `Ok(FormatStatus)` indicating whether any file was modified.
-pub fn format_many(input: &[PathBuf], args: &CliArguments) -> Result<FormatStatus> {
-    // In case of multiple files, process them in order without failing
-    let mut status = FormatStatus::Unchanged;
-    let mut error_count = 0;
-    // Format the files one by one
-    for file in input {
-        status |= format_one(Some(file), args).unwrap_or_else(|e| {
-            error!("{e}");
-            error_count += 1;
-            FormatStatus::Unchanged
-        });
-    }
-
-    if error_count > 0 {
-        bail!(
-            "failed to format {} due to IO error",
-            num_files(error_count)
-        );
-    }
-    Ok(status)
+    Ok(match mode {
+        FormatMode::Check if summary.format_count > 0 => ExitStatus::Failure,
+        _ => ExitStatus::Success,
+    })
 }
 
 /// Formats a single `.typ` file or input from stdin.
@@ -179,54 +135,57 @@ pub fn format_many(input: &[PathBuf], args: &CliArguments) -> Result<FormatStatu
 /// - `args`: CLI arguments.
 ///
 /// # Returns
-/// Returns `Ok(FormatStatus)` indicating whether the file was modified or remained unchanged.
-pub fn format_one(input: Option<&PathBuf>, args: &CliArguments) -> Result<FormatStatus> {
-    let content = get_input(input)?;
-    let res = format_debug(content, args);
-    let status = match &res {
-        FormatResult::Changed(_) => FormatStatus::Changed,
-        _ => FormatStatus::Unchanged,
-    };
-    match res {
-        FormatResult::Changed(res) if args.inplace => {
-            // We have already validated that the input is Some.
-            write_back(input.unwrap(), &res)?;
-        }
-        FormatResult::Changed(_) if args.check => {
-            if let Some(path) = input {
-                info!("Would reformat: {}", path.display());
-            }
-        }
-        FormatResult::Changed(res) | FormatResult::Unchanged(res) => {
-            if !args.inplace && !args.check {
+/// - `Ok(FormatStatus::Changed)` if the file was reformatted.
+/// - `Ok(FormatStatus::Unchanged)` if the file was unchanged or contained errors.
+/// - `Err` if reading from or writing to the file fails.
+fn format_one(input: Option<&PathBuf>, args: &CliArguments) -> Result<FormatResult> {
+    let use_stdout = !args.inplace && !args.check;
+    let unformatted = get_input(input)?;
+
+    let res = format_debug(&unformatted, args);
+    match &res {
+        FormatResult::Formatted(res) => {
+            if args.inplace {
+                // We have already validated that the input is Some.
+                write_back(input.unwrap(), res)?;
+            } else if args.check {
+                if let Some(path) = input {
+                    info!("Would reformat: {}", fs::relativize_path(path));
+                }
+            } else {
                 print!("{}", res);
             }
         }
-        FormatResult::Erroneous(content) => {
-            if !args.inplace && !args.check {
-                print!("{}", content); // still prints the original content to enable piping
+        FormatResult::Unchanged => {
+            if use_stdout {
+                print!("{}", unformatted);
+            }
+        }
+        FormatResult::Erroneous => {
+            if use_stdout {
+                print!("{}", unformatted); // still prints the original content to enable piping
             }
             if let Some(path) = input {
                 warn!(
                     "Failed to parse {}. The source is erroneous.",
-                    path.display()
+                    fs::relativize_path(path)
                 );
             } else {
                 warn!("Failed to parse stdin. The source is erroneous.");
             }
         }
     }
-    Ok(status)
+    Ok(res)
 }
 
 enum FormatResult {
-    Changed(String),
-    Unchanged(String),
-    Erroneous(String),
+    Formatted(String),
+    Unchanged,
+    Erroneous,
 }
 
-fn format_debug(content: String, args: &CliArguments) -> FormatResult {
-    let source = Source::detached(&content);
+fn format_debug(content: &str, args: &CliArguments) -> FormatResult {
+    let source = Source::detached(content);
     let root = source.root();
     if args.debug.ast {
         println!("{:#?}", root);
@@ -239,14 +198,14 @@ fn format_debug(content: String, args: &CliArguments) -> FormatResult {
         }
     }) {
         Ok(res) => res,
-        Err(_) => return FormatResult::Erroneous(content),
+        Err(_) => return FormatResult::Erroneous,
     };
 
     // Compare `res` with `content` to perform CI checks
     if res != content {
-        FormatResult::Changed(res)
+        FormatResult::Formatted(res)
     } else {
-        FormatResult::Unchanged(res)
+        FormatResult::Unchanged
     }
 }
 
@@ -269,17 +228,34 @@ fn write_back(path: &Path, content: &str) -> Result<()> {
         .with_context(|| format!("failed to write to the file {}", path.display()))
 }
 
-fn is_hidden(entry: &DirEntry) -> bool {
-    entry
-        .file_name()
-        .to_str()
-        .is_some_and(|s| s.starts_with('.'))
-}
-
-fn num_files(num: usize) -> String {
-    if num > 1 {
-        format!("{num} files")
-    } else {
-        format!("{num} file")
+fn resolve_typst_files(input: &[PathBuf]) -> Vec<PathBuf> {
+    fn is_hidden(entry: &DirEntry) -> bool {
+        entry
+            .file_name()
+            .to_str()
+            .is_some_and(|s| s.starts_with('.'))
     }
+
+    let mut files = Vec::new();
+    let mut has_dir = false;
+    for path in input.iter().map(fs::normalize_path).unique() {
+        if path.is_dir() {
+            has_dir = true;
+            let entries = WalkDir::new(path)
+                .into_iter()
+                .filter_entry(|e| !is_hidden(e))
+                .filter_map(Result::ok);
+            for entry in entries {
+                if entry.file_type().is_file() && entry.path().extension() == Some("typ".as_ref()) {
+                    files.push(entry.into_path());
+                }
+            }
+        } else {
+            files.push(path.clone());
+        }
+    }
+    if has_dir {
+        files.sort_unstable();
+    }
+    files
 }

--- a/crates/typstyle/src/fs.rs
+++ b/crates/typstyle/src/fs.rs
@@ -1,0 +1,22 @@
+// Adapted from: https://github.com/astral-sh/ruff/blob/main/crates/ruff_linter/src/fs.rs
+
+use std::path::{Path, PathBuf};
+
+use path_absolutize::Absolutize;
+
+/// Convert any path to an absolute path (based on the current working directory).
+pub fn normalize_path<P: AsRef<Path>>(path: P) -> PathBuf {
+    let path = path.as_ref();
+    path.absolutize()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Convert an absolute path to be relative to the current working directory.
+pub fn relativize_path<P: AsRef<Path>>(path: P) -> String {
+    let path = path.as_ref();
+    path.strip_prefix(std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
+        .unwrap_or(path)
+        .display()
+        .to_string()
+}

--- a/crates/typstyle/tests/common.rs
+++ b/crates/typstyle/tests/common.rs
@@ -79,6 +79,10 @@ impl Workspace {
         fs::read_to_string(p).unwrap()
     }
 
+    pub fn is_modified(&self, path: impl AsRef<Path>) -> bool {
+        !self.is_unmodified(path)
+    }
+
     pub fn is_unmodified(&self, path: impl AsRef<Path>) -> bool {
         let p = self.project_path().join(path.as_ref());
         if let Ok(time) = p.metadata().unwrap().modified() {

--- a/crates/typstyle/tests/test_format.rs
+++ b/crates/typstyle/tests/test_format.rs
@@ -266,3 +266,111 @@ fn test_two_2_check() {
 
     assert!(space.all_unmodified());
 }
+
+#[test]
+fn test_cwd() {
+    let mut space = Workspace::new();
+    space.write_tracked("a.typ", "#let a = 0\n");
+    space.write_tracked("b.typ", "#let b  =  1\n");
+    space.write_tracked("d/c.typ", "#let c  =  2\n");
+
+    typstyle_cmd_snapshot!(space.cli().args(["."]), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    #let a = 0
+    #let b = 1
+    #let c = 2
+
+    ----- stderr -----
+    ");
+
+    assert!(space.all_unmodified());
+}
+
+#[test]
+fn test_cwd_check() {
+    let mut space = Workspace::new();
+    space.write_tracked("a.typ", "#let a = 0\n");
+    space.write_tracked("b.typ", "#let b  =  1\n");
+    space.write_tracked("d/c.typ", "#let c  =  2\n");
+
+    typstyle_cmd_snapshot!(space.cli().args(["./d/..", "--check"]), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    Would reformat: b.typ
+    Would reformat: d/c.typ
+
+    ----- stderr -----
+    ");
+
+    assert!(space.all_unmodified());
+}
+
+#[test]
+fn test_many() {
+    let mut space = Workspace::new();
+    space.write_tracked("a.typ", "#let a = 0\n");
+    space.write_tracked("b.typ", "#let b  =  1\n");
+    space.write_tracked("d/c.typ", "#let c  =  2\n");
+    space.write_tracked("d/d/e.typ", "#let d  =  3\n");
+
+    typstyle_cmd_snapshot!(space.cli().args(["a.typ", "b.typ", "d"]), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    #let a = 0
+    #let b = 1
+    #let c = 2
+    #let d = 3
+
+    ----- stderr -----
+    ");
+
+    assert!(space.is_unmodified("a.typ"));
+}
+
+#[test]
+fn test_many_inplace() {
+    let mut space = Workspace::new();
+    space.write_tracked("a.typ", "#let a = 0\n");
+    space.write_tracked("b.typ", "#let b  =  1\n");
+    space.write_tracked("d/c.typ", "#let c  =  2\n");
+    space.write_tracked("d/d/e.typ", "#let d  =  3\n");
+
+    typstyle_cmd_snapshot!(space.cli().args(["a.typ", "b.typ", "d", "-i"]), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+
+    assert!(space.is_unmodified("a.typ"));
+    assert!(space.is_modified("b.typ"));
+    assert!(space.is_modified("d/c.typ"));
+    assert!(space.is_modified("d/d/e.typ"));
+}
+
+#[test]
+fn test_many_check() {
+    let mut space = Workspace::new();
+    space.write_tracked("a.typ", "#let a = 0\n");
+    space.write_tracked("b.typ", "#let b  =  1\n");
+    space.write_tracked("d/c.typ", "#let c  =  2\n");
+    space.write_tracked("d/d/e.typ", "#let d  =  3\n");
+
+    typstyle_cmd_snapshot!(space.cli().args(["a.typ", "b.typ", "d", "--check"]), @r"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    Would reformat: b.typ
+    Would reformat: d/c.typ
+    Would reformat: d/d/e.typ
+
+    ----- stderr -----
+    ");
+
+    assert!(space.all_unmodified());
+}

--- a/crates/typstyle/tests/test_format_all.rs
+++ b/crates/typstyle/tests/test_format_all.rs
@@ -17,6 +17,7 @@ fn test_all_0() {
     Successfully formatted 2 files (0 unchanged) in [DURATION]
 
     ----- stderr -----
+    warn: format-all is deprecated and will be removed in a future version. Please directly use `typstyle <dir> -i` instead.
     ");
 
     assert_eq!(space.read_string("a.typ"), "#let a = 0\n");
@@ -40,6 +41,7 @@ fn test_all_1() {
     Successfully formatted 1 file (1 unchanged) in [DURATION]
 
     ----- stderr -----
+    warn: format-all is deprecated and will be removed in a future version. Please directly use `typstyle <dir> -i` instead.
     ");
 
     assert!(space.is_unmodified("a.typ"));
@@ -63,6 +65,7 @@ fn test_all_2() {
     Successfully formatted 0 file (2 unchanged) in [DURATION]
 
     ----- stderr -----
+    warn: format-all is deprecated and will be removed in a future version. Please directly use `typstyle <dir> -i` instead.
     ");
 
     assert!(space.is_unmodified("a.typ"));
@@ -84,10 +87,11 @@ fn test_all_0_check() {
     success: false
     exit_code: 1
     ----- stdout -----
-    Would reformat: [TEMP_PATH]/project/x/b.typ
+    Would reformat: x/b.typ
     1 file would be reformatted (0 already formatted), checked in [DURATION]
 
     ----- stderr -----
+    warn: format-all is deprecated and will be removed in a future version. Please directly use `typstyle <dir> -i` instead.
     ");
 
     assert!(space.all_unmodified());
@@ -105,10 +109,11 @@ fn test_all_1_check() {
     success: false
     exit_code: 1
     ----- stdout -----
-    Would reformat: [TEMP_PATH]/project/x/b.typ
+    Would reformat: x/b.typ
     1 file would be reformatted (1 already formatted), checked in [DURATION]
 
     ----- stderr -----
+    warn: format-all is deprecated and will be removed in a future version. Please directly use `typstyle <dir> -i` instead.
     ");
 
     assert!(space.all_unmodified());
@@ -129,6 +134,7 @@ fn test_all_2_check() {
     0 file would be reformatted (2 already formatted), checked in [DURATION]
 
     ----- stderr -----
+    warn: format-all is deprecated and will be removed in a future version. Please directly use `typstyle <dir> -i` instead.
     ");
 
     assert!(space.all_unmodified());
@@ -145,10 +151,11 @@ fn test_all_erroneous() {
     success: true
     exit_code: 0
     ----- stdout -----
-    Successfully formatted 1 file (1 unchanged) in [DURATION]
+    Successfully formatted 1 file (2 unchanged) in [DURATION]
 
     ----- stderr -----
-    warn: Failed to format: [TEMP_PATH]/project/x/y/c.typ
+    warn: format-all is deprecated and will be removed in a future version. Please directly use `typstyle <dir> -i` instead.
+    warn: Failed to parse x/y/c.typ. The source is erroneous.
     ");
 
     assert!(space.is_unmodified("a.typ"));
@@ -167,11 +174,12 @@ fn test_all_erroneous_check() {
     success: false
     exit_code: 1
     ----- stdout -----
-    Would reformat: [TEMP_PATH]/project/x/b.typ
-    1 file would be reformatted (1 already formatted), checked in [DURATION]
+    Would reformat: x/b.typ
+    1 file would be reformatted (2 already formatted), checked in [DURATION]
 
     ----- stderr -----
-    warn: Failed to format: [TEMP_PATH]/project/x/y/c.typ
+    warn: format-all is deprecated and will be removed in a future version. Please directly use `typstyle <dir> -i` instead.
+    warn: Failed to parse x/y/c.typ. The source is erroneous.
     ");
 
     assert!(space.all_unmodified());
@@ -189,6 +197,7 @@ fn test_all_column() {
     Successfully formatted 1 file (0 unchanged) in [DURATION]
 
     ----- stderr -----
+    warn: format-all is deprecated and will be removed in a future version. Please directly use `typstyle <dir> -i` instead.
     ");
 
     assert_eq!(
@@ -216,5 +225,6 @@ fn test_dir_all_check() {
     1 file would be reformatted (0 already formatted), checked in [DURATION]
 
     ----- stderr -----
+    warn: format-all is deprecated and will be removed in a future version. Please directly use `typstyle <dir> -i` instead.
     ");
 }


### PR DESCRIPTION
Now the CLI can accept a list of mixed files and directories, instead of files only.
Deprecated the `format-all` command, which can be covered by `typstyle <dir>`.

Bug fix: Directories with paths containing `.` or `..` were not formatted before.

Changes to CLI args:
- `--column`/`-c` renamed to `--line-width`/`-l`. 
- `--tab-width` renamed to `--indent-width`.
Old names are kept as aliases for compatibility.