### PR TITLE
feat: do not collapse consecutive spaces in markup by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ Options:
   -V, --version  Print version
 
 Format Configuration:
-  -l, --line-width <LINE_WIDTH>      The column width of the output [default: 80] [aliases: column] [short aliases: c]
-  -t, --indent-width <INDENT_WIDTH>  Spaces per level of indentation in the output [default: 2] [aliases: tab-width]
-      --no-reorder-import-items      Whether not to reorder import items
-      --wrap-text                    Whether to wrap texts in the markup
+  -l, --line-width <LINE_WIDTH>      Maximum width of each line [default: 80] [aliases: column] [short aliases: c]
+  -t, --indent-width <INDENT_WIDTH>  Number of spaces per indentation level [default: 2] [aliases: tab-width]
+      --no-reorder-import-items      Disable alphabetical reordering of import items
+      --wrap-text                    Wrap text in markup to fit within the line width. Implies `--collapse-spaces`
 
 Debug Options:
   -a, --ast         Print the AST of the input file

--- a/crates/typstyle-core/src/config.rs
+++ b/crates/typstyle-core/src/config.rs
@@ -2,16 +2,18 @@
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Config {
-    /// Number of spaces per tab
+    /// Number of spaces to use for each indentation level.
     pub tab_spaces: usize,
     /// Maximum width of each line.
     pub max_width: usize,
-    /// Maximum number of blank lines which can be put between items.
+    /// Maximum number of consecutive blank lines allowed between code items.
     pub blank_lines_upper_bound: usize,
-    /// Whether to reorder import items.
-    /// When enabled, import items will be sorted alphabetically.
+    /// When `true`, consecutive whitespace in markup is collapsed into a single space.
+    pub collapse_markup_spaces: bool,
+    /// When `true`, import items are sorted alphabetically.
     pub reorder_import_items: bool,
-    /// Whether to wrap texts in the markup.
+    /// When `true`, text in markup will be wrapped to fit within `max_width`.
+    /// Implies `collapse_markup_spaces`.
     pub wrap_text: bool,
 }
 
@@ -22,6 +24,7 @@ impl Default for Config {
             max_width: 80,
             blank_lines_upper_bound: 2,
             reorder_import_items: true,
+            collapse_markup_spaces: false,
             wrap_text: false,
         }
     }

--- a/crates/typstyle-core/src/pretty/math.rs
+++ b/crates/typstyle-core/src/pretty/math.rs
@@ -94,7 +94,7 @@ impl<'a> PrettyPrinter<'a> {
                 let expr_doc = self.convert_expr(ctx, expr);
                 doc += expr_doc;
             } else if let Some(space) = node.cast::<Space>() {
-                doc += self.convert_space(space);
+                doc += self.convert_space(ctx, space);
             } else if node.kind() == SyntaxKind::Hash {
                 doc += self.arena.text("#");
                 peek_hash = true;
@@ -137,7 +137,7 @@ impl<'a> PrettyPrinter<'a> {
             if last.kind() == SyntaxKind::Space {
                 has_close_space = true;
                 inner_nodes = rest;
-                self.convert_space_untyped(last)
+                self.convert_space_untyped(ctx, last)
             } else {
                 self.arena.nil()
             }
@@ -154,7 +154,7 @@ impl<'a> PrettyPrinter<'a> {
                 FlowItem::tight(self.convert_math(ctx, math))
             } else if node.kind() == SyntaxKind::Space {
                 // We can not arbitrarily break line here, as it may become ugly.
-                FlowItem::tight(self.convert_space_untyped(node))
+                FlowItem::tight(self.convert_space_untyped(ctx, node))
             } else {
                 FlowItem::none()
             }
@@ -209,7 +209,7 @@ impl<'a> PrettyPrinter<'a> {
             if let Some(expr) = node.cast::<Expr>() {
                 FlowItem::spaced(self.convert_expr(ctx, expr))
             } else if let Some(space) = node.cast::<Space>() {
-                FlowItem::tight(self.convert_space(space))
+                FlowItem::tight(self.convert_space(ctx, space))
             } else {
                 FlowItem::tight(self.convert_trivia_untyped(node))
             }

--- a/crates/typstyle-core/src/pretty/mod.rs
+++ b/crates/typstyle-core/src/pretty/mod.rs
@@ -100,7 +100,7 @@ impl<'a> PrettyPrinter<'a> {
     fn convert_expr_impl(&'a self, ctx: Context, expr: Expr<'a>) -> ArenaDoc<'a> {
         match expr {
             Expr::Text(t) => self.convert_text(t),
-            Expr::Space(s) => self.convert_space(s),
+            Expr::Space(s) => self.convert_space(ctx, s),
             Expr::Linebreak(b) => self.convert_trivia(b),
             Expr::Parbreak(b) => self.convert_parbreak(b),
             Expr::Escape(e) => self.convert_trivia(e),

--- a/crates/typstyle-core/src/pretty/text.rs
+++ b/crates/typstyle-core/src/pretty/text.rs
@@ -1,6 +1,6 @@
 use typst_syntax::{ast::*, SyntaxNode};
 
-use super::{prelude::*, PrettyPrinter};
+use super::{prelude::*, Context, PrettyPrinter};
 use crate::ext::StrExt;
 
 impl<'a> PrettyPrinter<'a> {
@@ -13,13 +13,19 @@ impl<'a> PrettyPrinter<'a> {
         wrap_text(&self.arena, text.get())
     }
 
-    pub(super) fn convert_space(&'a self, space: Space) -> ArenaDoc<'a> {
-        self.convert_space_untyped(space.to_untyped())
+    pub(super) fn convert_space(&'a self, ctx: Context, space: Space<'a>) -> ArenaDoc<'a> {
+        self.convert_space_untyped(ctx, space.to_untyped())
     }
 
-    pub(super) fn convert_space_untyped(&'a self, node: &SyntaxNode) -> ArenaDoc<'a> {
+    pub(super) fn convert_space_untyped(
+        &'a self,
+        ctx: Context,
+        node: &'a SyntaxNode,
+    ) -> ArenaDoc<'a> {
         if node.text().has_linebreak() {
             self.arena.hardline()
+        } else if ctx.mode.is_markup() && !self.config.collapse_markup_spaces {
+            self.arena.text(node.text().as_str())
         } else {
             self.arena.space()
         }

--- a/crates/typstyle/src/cli.rs
+++ b/crates/typstyle/src/cli.rs
@@ -66,7 +66,7 @@ pub enum Command {
 
 #[derive(Args)]
 pub struct StyleArgs {
-    /// The column width of the output
+    /// Maximum width of each line.
     #[arg(
         short = 'l',
         long,
@@ -77,7 +77,7 @@ pub struct StyleArgs {
     )]
     pub line_width: usize,
 
-    /// Spaces per level of indentation in the output
+    /// Number of spaces per indentation level.
     #[arg(
         short = 't',
         long,
@@ -87,11 +87,11 @@ pub struct StyleArgs {
     )]
     pub indent_width: usize,
 
-    /// Whether not to reorder import items.
+    /// Disable alphabetical reordering of import items.
     #[arg(long, default_value_t = false, global = true)]
     pub no_reorder_import_items: bool,
 
-    /// Whether to wrap texts in the markup.
+    /// Wrap text in markup to fit within the line width. Implies `--collapse-spaces`.
     #[arg(long, default_value_t = false, global = true)]
     pub wrap_text: bool,
 }

--- a/crates/typstyle/tests/test_style_args.rs
+++ b/crates/typstyle/tests/test_style_args.rs
@@ -54,7 +54,7 @@ fn test_reorder_import_items() {
 fn test_wrap_text() {
     let space = Workspace::new();
 
-    let stdin = "lorem ipsum dolor sit amet, consectetur adipiscing elit.";
+    let stdin = "lorem  ipsum   dolor sit amet, consectetur   adipiscing elit.";
 
     typstyle_cmd_snapshot!(space.cli().args(["-c=20", "--wrap-text"]).pass_stdin(stdin), @r"
     success: true

--- a/tests/fixtures/articles/snap/undergraduate-math.typ-0.snap
+++ b/tests/fixtures/articles/snap/undergraduate-math.typ-0.snap
@@ -585,7 +585,7 @@ Comment on an expression as here (there is also `overbrace(..)`).
 
 = Dots
 Use low dots in a list ${0, 1, 2, ...}$, entered as `{0, 1, 2, ...}`.
-Use centered dots in a sum or product $1 + dots.h.c + 100$, entered as `1 + dots.h.c + 100`.
+Use centered dots in a sum or product $1 + dots.h.c + 100$, entered as  `1 + dots.h.c + 100`.
 You can also get vertical dots `dots.v`, diagonal dots `dots.down` and anti-diagonal dots `dots.up`.
 
 = Roman names

--- a/tests/fixtures/articles/snap/undergraduate-math.typ-120.snap
+++ b/tests/fixtures/articles/snap/undergraduate-math.typ-120.snap
@@ -238,7 +238,7 @@ Comment on an expression as here (there is also `overbrace(..)`).
 
 = Dots
 Use low dots in a list ${0, 1, 2, ...}$, entered as `{0, 1, 2, ...}`.
-Use centered dots in a sum or product $1 + dots.h.c + 100$, entered as `1 + dots.h.c + 100`.
+Use centered dots in a sum or product $1 + dots.h.c + 100$, entered as  `1 + dots.h.c + 100`.
 You can also get vertical dots `dots.v`, diagonal dots `dots.down` and anti-diagonal dots `dots.up`.
 
 = Roman names

--- a/tests/fixtures/articles/snap/undergraduate-math.typ-40.snap
+++ b/tests/fixtures/articles/snap/undergraduate-math.typ-40.snap
@@ -471,7 +471,7 @@ Comment on an expression as here (there is also `overbrace(..)`).
 
 = Dots
 Use low dots in a list ${0, 1, 2, ...}$, entered as `{0, 1, 2, ...}`.
-Use centered dots in a sum or product $1 + dots.h.c + 100$, entered as `1 + dots.h.c + 100`.
+Use centered dots in a sum or product $1 + dots.h.c + 100$, entered as  `1 + dots.h.c + 100`.
 You can also get vertical dots `dots.v`, diagonal dots `dots.down` and anti-diagonal dots `dots.up`.
 
 = Roman names

--- a/tests/fixtures/articles/snap/undergraduate-math.typ-80.snap
+++ b/tests/fixtures/articles/snap/undergraduate-math.typ-80.snap
@@ -265,7 +265,7 @@ Comment on an expression as here (there is also `overbrace(..)`).
 
 = Dots
 Use low dots in a list ${0, 1, 2, ...}$, entered as `{0, 1, 2, ...}`.
-Use centered dots in a sum or product $1 + dots.h.c + 100$, entered as `1 + dots.h.c + 100`.
+Use centered dots in a sum or product $1 + dots.h.c + 100$, entered as  `1 + dots.h.c + 100`.
 You can also get vertical dots `dots.v`, diagonal dots `dots.down` and anti-diagonal dots `dots.up`.
 
 = Roman names

--- a/tests/fixtures/unit/code/args/snap/compact-complex.typ-0.snap
+++ b/tests/fixtures/unit/code/args/snap/compact-complex.typ-0.snap
@@ -149,7 +149,7 @@ input_file: tests/fixtures/unit/code/args/compact-complex.typ
 
 // With repeated whitespace and line breaks
 #f(
-  [First with spaces],
+  [First    with    spaces],
   [Second with
 
     multiple

--- a/tests/fixtures/unit/code/args/snap/compact-complex.typ-120.snap
+++ b/tests/fixtures/unit/code/args/snap/compact-complex.typ-120.snap
@@ -86,7 +86,7 @@ input_file: tests/fixtures/unit/code/args/compact-complex.typ
 
 // With repeated whitespace and line breaks
 #f(
-  [First with spaces],
+  [First    with    spaces],
   [Second with
 
     multiple

--- a/tests/fixtures/unit/code/args/snap/compact-complex.typ-40.snap
+++ b/tests/fixtures/unit/code/args/snap/compact-complex.typ-40.snap
@@ -107,7 +107,7 @@ input_file: tests/fixtures/unit/code/args/compact-complex.typ
 
 // With repeated whitespace and line breaks
 #f(
-  [First with spaces],
+  [First    with    spaces],
   [Second with
 
     multiple

--- a/tests/fixtures/unit/code/args/snap/compact-complex.typ-80.snap
+++ b/tests/fixtures/unit/code/args/snap/compact-complex.typ-80.snap
@@ -86,7 +86,7 @@ input_file: tests/fixtures/unit/code/args/compact-complex.typ
 
 // With repeated whitespace and line breaks
 #f(
-  [First with spaces],
+  [First    with    spaces],
   [Second with
 
     multiple

--- a/tests/fixtures/unit/comment/snap/block-align.typ-0.snap
+++ b/tests/fixtures/unit/comment/snap/block-align.typ-0.snap
@@ -2,50 +2,50 @@
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/comment/block-align.typ
 ---
-something0 /*
+something0  /*
+             1234567890
+              1234567890
+            */
+
+something1  /*
             1234567890
              1234567890
-           */
+                */
 
-something1 /*
-           1234567890
-            1234567890
-               */
-
-something2 /*
-            * 1234567890
-            */
-
-something3 /*
-            * 1234567890
-            */
-
-something4 /*
-            * 1234567890
-            */ ffhgfg
-
-#[
-  something0 /*
-              1234567890
-               1234567890
+something2  /*
+             * 1234567890
              */
 
-  something1 /*
-             1234567890
+something3  /*
+             * 1234567890
+             */
+
+something4  /*
+             * 1234567890
+             */   ffhgfg
+
+#[
+  something0  /*
+               1234567890
+                1234567890
+              */
+
+  something1  /*
               1234567890
-                 */
+               1234567890
+                  */
 
-  something2 /*
-              * 1234567890
-              */
+  something2  /*
+               * 1234567890
+               */
 
-  something3 /*
-              * 1234567890
-              */
+  something3  /*
+               * 1234567890
+               */
 
-  something4 /*
-              * 1234567890
-              */ ffhgfg
+  something4  /*
+               * 1234567890
+               */   ffhgfg
 ]
 
 #{

--- a/tests/fixtures/unit/comment/snap/block-align.typ-120.snap
+++ b/tests/fixtures/unit/comment/snap/block-align.typ-120.snap
@@ -2,50 +2,50 @@
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/comment/block-align.typ
 ---
-something0 /*
+something0  /*
+             1234567890
+              1234567890
+            */
+
+something1  /*
             1234567890
              1234567890
-           */
+                */
 
-something1 /*
-           1234567890
-            1234567890
-               */
-
-something2 /*
-            * 1234567890
-            */
-
-something3 /*
-            * 1234567890
-            */
-
-something4 /*
-            * 1234567890
-            */ ffhgfg
-
-#[
-  something0 /*
-              1234567890
-               1234567890
+something2  /*
+             * 1234567890
              */
 
-  something1 /*
-             1234567890
+something3  /*
+             * 1234567890
+             */
+
+something4  /*
+             * 1234567890
+             */   ffhgfg
+
+#[
+  something0  /*
+               1234567890
+                1234567890
+              */
+
+  something1  /*
               1234567890
-                 */
+               1234567890
+                  */
 
-  something2 /*
-              * 1234567890
-              */
+  something2  /*
+               * 1234567890
+               */
 
-  something3 /*
-              * 1234567890
-              */
+  something3  /*
+               * 1234567890
+               */
 
-  something4 /*
-              * 1234567890
-              */ ffhgfg
+  something4  /*
+               * 1234567890
+               */   ffhgfg
 ]
 
 #{

--- a/tests/fixtures/unit/comment/snap/block-align.typ-40.snap
+++ b/tests/fixtures/unit/comment/snap/block-align.typ-40.snap
@@ -2,50 +2,50 @@
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/comment/block-align.typ
 ---
-something0 /*
+something0  /*
+             1234567890
+              1234567890
+            */
+
+something1  /*
             1234567890
              1234567890
-           */
+                */
 
-something1 /*
-           1234567890
-            1234567890
-               */
-
-something2 /*
-            * 1234567890
-            */
-
-something3 /*
-            * 1234567890
-            */
-
-something4 /*
-            * 1234567890
-            */ ffhgfg
-
-#[
-  something0 /*
-              1234567890
-               1234567890
+something2  /*
+             * 1234567890
              */
 
-  something1 /*
-             1234567890
+something3  /*
+             * 1234567890
+             */
+
+something4  /*
+             * 1234567890
+             */   ffhgfg
+
+#[
+  something0  /*
+               1234567890
+                1234567890
+              */
+
+  something1  /*
               1234567890
-                 */
+               1234567890
+                  */
 
-  something2 /*
-              * 1234567890
-              */
+  something2  /*
+               * 1234567890
+               */
 
-  something3 /*
-              * 1234567890
-              */
+  something3  /*
+               * 1234567890
+               */
 
-  something4 /*
-              * 1234567890
-              */ ffhgfg
+  something4  /*
+               * 1234567890
+               */   ffhgfg
 ]
 
 #{

--- a/tests/fixtures/unit/comment/snap/block-align.typ-80.snap
+++ b/tests/fixtures/unit/comment/snap/block-align.typ-80.snap
@@ -2,50 +2,50 @@
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/comment/block-align.typ
 ---
-something0 /*
+something0  /*
+             1234567890
+              1234567890
+            */
+
+something1  /*
             1234567890
              1234567890
-           */
+                */
 
-something1 /*
-           1234567890
-            1234567890
-               */
-
-something2 /*
-            * 1234567890
-            */
-
-something3 /*
-            * 1234567890
-            */
-
-something4 /*
-            * 1234567890
-            */ ffhgfg
-
-#[
-  something0 /*
-              1234567890
-               1234567890
+something2  /*
+             * 1234567890
              */
 
-  something1 /*
-             1234567890
+something3  /*
+             * 1234567890
+             */
+
+something4  /*
+             * 1234567890
+             */   ffhgfg
+
+#[
+  something0  /*
+               1234567890
+                1234567890
+              */
+
+  something1  /*
               1234567890
-                 */
+               1234567890
+                  */
 
-  something2 /*
-              * 1234567890
-              */
+  something2  /*
+               * 1234567890
+               */
 
-  something3 /*
-              * 1234567890
-              */
+  something3  /*
+               * 1234567890
+               */
 
-  something4 /*
-              * 1234567890
-              */ ffhgfg
+  something4  /*
+               * 1234567890
+               */   ffhgfg
 ]
 
 #{

--- a/tests/fixtures/unit/comment/snap/in-import.typ-0.snap
+++ b/tests/fixtures/unit/comment/snap/in-import.typ-0.snap
@@ -29,7 +29,7 @@ input_file: tests/fixtures/unit/comment/in-import.typ
 #import /* 0 */ "test.typ"/* 1 */
 #import /* 0 */ "test.typ" /* 1 */:/* 2 */
 #import /* 0 */ "test.typ" /* 1 */: /* 2 */
-#import /* 0 */ "test.typ" /* 1 */: /* 2 */
+#import /* 0 */ "test.typ" /* 1 */:  /* 2 */
 #import /* 0 */ "test.typ" /* 1 */: /* 2 */ /* 3 */ *
 #import /* 0 */ "test.typ" /* 1 */: /* 2 */ (
   a./* 3 */b/* 4 */.c./* 5 */d,

--- a/tests/fixtures/unit/comment/snap/in-import.typ-120.snap
+++ b/tests/fixtures/unit/comment/snap/in-import.typ-120.snap
@@ -14,7 +14,7 @@ input_file: tests/fixtures/unit/comment/in-import.typ
 #import /* 0 */ "test.typ"/* 1 */
 #import /* 0 */ "test.typ" /* 1 */:/* 2 */
 #import /* 0 */ "test.typ" /* 1 */: /* 2 */
-#import /* 0 */ "test.typ" /* 1 */: /* 2 */
+#import /* 0 */ "test.typ" /* 1 */:  /* 2 */
 #import /* 0 */ "test.typ" /* 1 */: /* 2 */ /* 3 */ *
 #import /* 0 */ "test.typ" /* 1 */: /* 2 */ a./* 3 */b/* 4 */.c./* 5 */d, /* 6 */ eee /* 7 */ as /* 8 */ /* 9 */ fff
 #import /* 0 */ "@preview/fletcher:0.4.0" /* 1 */ as /* 2 */ fletcher /* 3 */: /* 4 */ node /* 5 */, /* 6 */ edge

--- a/tests/fixtures/unit/comment/snap/in-import.typ-40.snap
+++ b/tests/fixtures/unit/comment/snap/in-import.typ-40.snap
@@ -26,7 +26,7 @@ input_file: tests/fixtures/unit/comment/in-import.typ
 #import /* 0 */ "test.typ"/* 1 */
 #import /* 0 */ "test.typ" /* 1 */:/* 2 */
 #import /* 0 */ "test.typ" /* 1 */: /* 2 */
-#import /* 0 */ "test.typ" /* 1 */: /* 2 */
+#import /* 0 */ "test.typ" /* 1 */:  /* 2 */
 #import /* 0 */ "test.typ" /* 1 */: /* 2 */ /* 3 */ *
 #import /* 0 */ "test.typ" /* 1 */: /* 2 */ (
   a./* 3 */b/* 4 */.c./* 5 */d,

--- a/tests/fixtures/unit/comment/snap/in-import.typ-80.snap
+++ b/tests/fixtures/unit/comment/snap/in-import.typ-80.snap
@@ -14,7 +14,7 @@ input_file: tests/fixtures/unit/comment/in-import.typ
 #import /* 0 */ "test.typ"/* 1 */
 #import /* 0 */ "test.typ" /* 1 */:/* 2 */
 #import /* 0 */ "test.typ" /* 1 */: /* 2 */
-#import /* 0 */ "test.typ" /* 1 */: /* 2 */
+#import /* 0 */ "test.typ" /* 1 */:  /* 2 */
 #import /* 0 */ "test.typ" /* 1 */: /* 2 */ /* 3 */ *
 #import /* 0 */ "test.typ" /* 1 */: /* 2 */ (
   a./* 3 */b/* 4 */.c./* 5 */d,

--- a/tests/fixtures/unit/comment/snap/in-include.typ-0.snap
+++ b/tests/fixtures/unit/comment/snap/in-include.typ-0.snap
@@ -1,8 +1,7 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/comment/in-include.typ
-snapshot_kind: text
 ---
-#include /* * strong * */ /* block */ "cond.typ" // line
+#include /* * strong * */ /* block */ "cond.typ"   // line
 #include /* block
-          */ "cond.typ" // line
+          */ "cond.typ"   // line

--- a/tests/fixtures/unit/comment/snap/in-include.typ-120.snap
+++ b/tests/fixtures/unit/comment/snap/in-include.typ-120.snap
@@ -1,8 +1,7 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/comment/in-include.typ
-snapshot_kind: text
 ---
-#include /* * strong * */ /* block */ "cond.typ" // line
+#include /* * strong * */ /* block */ "cond.typ"   // line
 #include /* block
-          */ "cond.typ" // line
+          */ "cond.typ"   // line

--- a/tests/fixtures/unit/comment/snap/in-include.typ-40.snap
+++ b/tests/fixtures/unit/comment/snap/in-include.typ-40.snap
@@ -1,8 +1,7 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/comment/in-include.typ
-snapshot_kind: text
 ---
-#include /* * strong * */ /* block */ "cond.typ" // line
+#include /* * strong * */ /* block */ "cond.typ"   // line
 #include /* block
-          */ "cond.typ" // line
+          */ "cond.typ"   // line

--- a/tests/fixtures/unit/comment/snap/in-include.typ-80.snap
+++ b/tests/fixtures/unit/comment/snap/in-include.typ-80.snap
@@ -1,8 +1,7 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/comment/in-include.typ
-snapshot_kind: text
 ---
-#include /* * strong * */ /* block */ "cond.typ" // line
+#include /* * strong * */ /* block */ "cond.typ"   // line
 #include /* block
-          */ "cond.typ" // line
+          */ "cond.typ"   // line

--- a/tests/fixtures/unit/comment/snap/in-markup.typ-0.snap
+++ b/tests/fixtures/unit/comment/snap/in-markup.typ-0.snap
@@ -1,13 +1,12 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/comment/in-markup.typ
-snapshot_kind: text
 ---
-== /* 1 */ heading2 // 11
+== /* 1 */ heading2   // 11
 
-=== /* 2 */ heading3 // 22
+=== /* 2 */ heading3    // 22
 
-+ /*  */ 3 // 354
++ /*  */ 3   // 354
 
 - 5645
   // 454

--- a/tests/fixtures/unit/comment/snap/in-markup.typ-120.snap
+++ b/tests/fixtures/unit/comment/snap/in-markup.typ-120.snap
@@ -1,13 +1,12 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/comment/in-markup.typ
-snapshot_kind: text
 ---
-== /* 1 */ heading2 // 11
+== /* 1 */ heading2   // 11
 
-=== /* 2 */ heading3 // 22
+=== /* 2 */ heading3    // 22
 
-+ /*  */ 3 // 354
++ /*  */ 3   // 354
 
 - 5645
   // 454

--- a/tests/fixtures/unit/comment/snap/in-markup.typ-40.snap
+++ b/tests/fixtures/unit/comment/snap/in-markup.typ-40.snap
@@ -1,13 +1,12 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/comment/in-markup.typ
-snapshot_kind: text
 ---
-== /* 1 */ heading2 // 11
+== /* 1 */ heading2   // 11
 
-=== /* 2 */ heading3 // 22
+=== /* 2 */ heading3    // 22
 
-+ /*  */ 3 // 354
++ /*  */ 3   // 354
 
 - 5645
   // 454

--- a/tests/fixtures/unit/comment/snap/in-markup.typ-80.snap
+++ b/tests/fixtures/unit/comment/snap/in-markup.typ-80.snap
@@ -1,13 +1,12 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/comment/in-markup.typ
-snapshot_kind: text
 ---
-== /* 1 */ heading2 // 11
+== /* 1 */ heading2   // 11
 
-=== /* 2 */ heading3 // 22
+=== /* 2 */ heading3    // 22
 
-+ /*  */ 3 // 354
++ /*  */ 3   // 354
 
 - 5645
   // 454

--- a/tests/fixtures/unit/markup/linebreak.typ
+++ b/tests/fixtures/unit/markup/linebreak.typ
@@ -1,26 +1,24 @@
-/// typstyle: wrap_text
-
 #[]a
-#[ ] b
-#[   ] bb
+ #[ ] b
+   #[   ] bb
 c#[
 ]
-d #[
+  d #[
 
 ]
-e
+ e
 #[
 
 
 ]
-f
+  f
 
 #[
   1
 
 ]
 
-g
+ g
 #[
 
   2

--- a/tests/fixtures/unit/markup/reflow/snap/linebreak.typ-120.snap
+++ b/tests/fixtures/unit/markup/reflow/snap/linebreak.typ-120.snap
@@ -4,7 +4,8 @@ input_file: tests/fixtures/unit/markup/reflow/linebreak.typ
 ---
 /// typstyle: wrap_text
 
-#[]a #[ ] b c#[ ]
+#[]a #[ ] b #[ ] bb c#[
+]
 d #[
 
 ]

--- a/tests/fixtures/unit/markup/reflow/snap/linebreak.typ-40.snap
+++ b/tests/fixtures/unit/markup/reflow/snap/linebreak.typ-40.snap
@@ -4,7 +4,8 @@ input_file: tests/fixtures/unit/markup/reflow/linebreak.typ
 ---
 /// typstyle: wrap_text
 
-#[]a #[ ] b c#[ ]
+#[]a #[ ] b #[ ] bb c#[
+]
 d #[
 
 ]

--- a/tests/fixtures/unit/markup/reflow/snap/linebreak.typ-80.snap
+++ b/tests/fixtures/unit/markup/reflow/snap/linebreak.typ-80.snap
@@ -4,7 +4,8 @@ input_file: tests/fixtures/unit/markup/reflow/linebreak.typ
 ---
 /// typstyle: wrap_text
 
-#[]a #[ ] b c#[ ]
+#[]a #[ ] b #[ ] bb c#[
+]
 d #[
 
 ]

--- a/tests/fixtures/unit/markup/snap/content-multiline.typ-0.snap
+++ b/tests/fixtures/unit/markup/snap/content-multiline.typ-0.snap
@@ -4,8 +4,10 @@ input_file: tests/fixtures/unit/markup/content-multiline.typ
 ---
 #[]
 #[ ]
-#[ ]
-#[ ]
+#[
+]
+#[
+]
 #[
 
 ]

--- a/tests/fixtures/unit/markup/snap/content-multiline.typ-120.snap
+++ b/tests/fixtures/unit/markup/snap/content-multiline.typ-120.snap
@@ -4,8 +4,10 @@ input_file: tests/fixtures/unit/markup/content-multiline.typ
 ---
 #[]
 #[ ]
-#[ ]
-#[ ]
+#[
+]
+#[
+]
 #[
 
 ]

--- a/tests/fixtures/unit/markup/snap/content-multiline.typ-40.snap
+++ b/tests/fixtures/unit/markup/snap/content-multiline.typ-40.snap
@@ -4,8 +4,10 @@ input_file: tests/fixtures/unit/markup/content-multiline.typ
 ---
 #[]
 #[ ]
-#[ ]
-#[ ]
+#[
+]
+#[
+]
 #[
 
 ]

--- a/tests/fixtures/unit/markup/snap/content-multiline.typ-80.snap
+++ b/tests/fixtures/unit/markup/snap/content-multiline.typ-80.snap
@@ -4,8 +4,10 @@ input_file: tests/fixtures/unit/markup/content-multiline.typ
 ---
 #[]
 #[ ]
-#[ ]
-#[ ]
+#[
+]
+#[
+]
 #[
 
 ]

--- a/tests/fixtures/unit/markup/snap/linebreak.typ-0.snap
+++ b/tests/fixtures/unit/markup/snap/linebreak.typ-0.snap
@@ -1,18 +1,13 @@
 ---
 source: tests/src/unit.rs
-input_file: tests/fixtures/unit/markup/reflow/linebreak.typ
+input_file: tests/fixtures/unit/markup/linebreak.typ
 ---
-/// typstyle: wrap_text
-
 #[]a
-#[ ]
-b
-#[ ]
-bb
+#[ ] b
+#[   ] bb
 c#[
 ]
-d
-#[
+d #[
 
 ]
 e

--- a/tests/fixtures/unit/markup/snap/linebreak.typ-120.snap
+++ b/tests/fixtures/unit/markup/snap/linebreak.typ-120.snap
@@ -1,18 +1,13 @@
 ---
 source: tests/src/unit.rs
-input_file: tests/fixtures/unit/markup/reflow/linebreak.typ
+input_file: tests/fixtures/unit/markup/linebreak.typ
 ---
-/// typstyle: wrap_text
-
 #[]a
-#[ ]
-b
-#[ ]
-bb
+#[ ] b
+#[   ] bb
 c#[
 ]
-d
-#[
+d #[
 
 ]
 e

--- a/tests/fixtures/unit/markup/snap/linebreak.typ-40.snap
+++ b/tests/fixtures/unit/markup/snap/linebreak.typ-40.snap
@@ -1,18 +1,13 @@
 ---
 source: tests/src/unit.rs
-input_file: tests/fixtures/unit/markup/reflow/linebreak.typ
+input_file: tests/fixtures/unit/markup/linebreak.typ
 ---
-/// typstyle: wrap_text
-
 #[]a
-#[ ]
-b
-#[ ]
-bb
+#[ ] b
+#[   ] bb
 c#[
 ]
-d
-#[
+d #[
 
 ]
 e

--- a/tests/fixtures/unit/markup/snap/linebreak.typ-80.snap
+++ b/tests/fixtures/unit/markup/snap/linebreak.typ-80.snap
@@ -1,18 +1,13 @@
 ---
 source: tests/src/unit.rs
-input_file: tests/fixtures/unit/markup/reflow/linebreak.typ
+input_file: tests/fixtures/unit/markup/linebreak.typ
 ---
-/// typstyle: wrap_text
-
 #[]a
-#[ ]
-b
-#[ ]
-bb
+#[ ] b
+#[   ] bb
 c#[
 ]
-d
-#[
+d #[
 
 ]
 e

--- a/tests/fixtures/unit/markup/snap/shebang.typ-0.snap
+++ b/tests/fixtures/unit/markup/snap/shebang.typ-0.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/markup/shebang.typ
-snapshot_kind: text
 ---
 #!typst compile
-We use a shebang
+We  use  a  shebang

--- a/tests/fixtures/unit/markup/snap/shebang.typ-120.snap
+++ b/tests/fixtures/unit/markup/snap/shebang.typ-120.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/markup/shebang.typ
-snapshot_kind: text
 ---
 #!typst compile
-We use a shebang
+We  use  a  shebang

--- a/tests/fixtures/unit/markup/snap/shebang.typ-40.snap
+++ b/tests/fixtures/unit/markup/snap/shebang.typ-40.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/markup/shebang.typ
-snapshot_kind: text
 ---
 #!typst compile
-We use a shebang
+We  use  a  shebang

--- a/tests/fixtures/unit/markup/snap/shebang.typ-80.snap
+++ b/tests/fixtures/unit/markup/snap/shebang.typ-80.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/markup/shebang.typ
-snapshot_kind: text
 ---
 #!typst compile
-We use a shebang
+We  use  a  shebang

--- a/tests/fixtures/unit/markup/snap/spaces.typ-0.snap
+++ b/tests/fixtures/unit/markup/snap/spaces.typ-0.snap
@@ -1,0 +1,81 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/markup/spaces.typ
+---
+// Basic multiple spaces and formatting
+Text with  two spaces between words.
+
+Text with   three   spaces   between   words.     // line comment
+
+*Bold*  with  two  spaces and _italic_   with   three   spaces.
+
+`Code`    with    four    spaces and #smallcaps[Small Caps]  mixed.
+
+#strike[Strikethrough]   and   #super[superscript]  and  #sub[subscript]   combined.
+
+// Mixed content with spaces
+Link  to  #link("url")[example]    and    #text(red)[colored]   text   together.
+
+Math with  spaces: $x + y = z$  and  inline math  $a b c$   surrounding.
+
+// Spaces at boundaries and special characters
+Leading and trailing     /*  block comment   */    spaces
+
+Text  with  "quotes"   and   'apostrophes'    and    symbols:   &   <   >   {}   []
+
+Emoji  😀  with  spaces  🎉  and  Unicode:  α  β  γ   characters.
+
+// Nested markup and line breaks
+This is #emph[emphasized  text  with  spaces] and #box[boxed   content] together.
+
+Nested #strong[*bold*  inside  strong] with spaces  \
+and  line  breaks  \
+across   multiple   lines.
+
+// Lists, quotes, and structural elements
+- Item  with  spaces and nested    item    together
++ Numbered   list   with   1. Deep    nested    content
+
+#quote[
+  Quoted  text  with  spaces
+  and   multiple   lines
+]
+
+= Heading  with  spaces and == Subheading   combined
+
+// Complex structures and code
+#align(center)[
+  Centered  text  with  spaces
+] and #stack[
+  Stacked  content
+  with   preserved   spaces
+]
+
+#table(
+  columns: 2,
+  [Cell  with  spaces],
+  [Another   cell   with   spaces],
+
+  [More    content],
+  [Even     more     spaced     content],
+)
+
+Here's `inline  code  with  spaces` and code blocks:
+
+```
+Code block
+with  preserved  spaces
+```
+
+#show ref: repr
+// References and function calls
+See @reference  for  @ref1  @ref2   multiple   citations.
+
+Call #math.vec("arg1", "arg2")  and  nested #text(text[content  with  spaces])  functions.
+
+// Mixed whitespace and internationalization
+Text	with	tabs	and  spaces  mixed    together.
+
+Français  avec  des  中文  文本  与  العربية  مع  international   spaces.
+
+Text with non-breaking and  en-spaces  and  em-spaces  together.

--- a/tests/fixtures/unit/markup/snap/spaces.typ-120.snap
+++ b/tests/fixtures/unit/markup/snap/spaces.typ-120.snap
@@ -1,0 +1,78 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/markup/spaces.typ
+---
+// Basic multiple spaces and formatting
+Text with  two spaces between words.
+
+Text with   three   spaces   between   words.     // line comment
+
+*Bold*  with  two  spaces and _italic_   with   three   spaces.
+
+`Code`    with    four    spaces and #smallcaps[Small Caps]  mixed.
+
+#strike[Strikethrough]   and   #super[superscript]  and  #sub[subscript]   combined.
+
+// Mixed content with spaces
+Link  to  #link("url")[example]    and    #text(red)[colored]   text   together.
+
+Math with  spaces: $x + y = z$  and  inline math  $a b c$   surrounding.
+
+// Spaces at boundaries and special characters
+Leading and trailing     /*  block comment   */    spaces
+
+Text  with  "quotes"   and   'apostrophes'    and    symbols:   &   <   >   {}   []
+
+Emoji  😀  with  spaces  🎉  and  Unicode:  α  β  γ   characters.
+
+// Nested markup and line breaks
+This is #emph[emphasized  text  with  spaces] and #box[boxed   content] together.
+
+Nested #strong[*bold*  inside  strong] with spaces  \
+and  line  breaks  \
+across   multiple   lines.
+
+// Lists, quotes, and structural elements
+- Item  with  spaces and nested    item    together
++ Numbered   list   with   1. Deep    nested    content
+
+#quote[
+  Quoted  text  with  spaces
+  and   multiple   lines
+]
+
+= Heading  with  spaces and == Subheading   combined
+
+// Complex structures and code
+#align(center)[
+  Centered  text  with  spaces
+] and #stack[
+  Stacked  content
+  with   preserved   spaces
+]
+
+#table(
+  columns: 2,
+  [Cell  with  spaces], [Another   cell   with   spaces],
+  [More    content], [Even     more     spaced     content],
+)
+
+Here's `inline  code  with  spaces` and code blocks:
+
+```
+Code block
+with  preserved  spaces
+```
+
+#show ref: repr
+// References and function calls
+See @reference  for  @ref1  @ref2   multiple   citations.
+
+Call #math.vec("arg1", "arg2")  and  nested #text(text[content  with  spaces])  functions.
+
+// Mixed whitespace and internationalization
+Text	with	tabs	and  spaces  mixed    together.
+
+Français  avec  des  中文  文本  与  العربية  مع  international   spaces.
+
+Text with non-breaking and  en-spaces  and  em-spaces  together.

--- a/tests/fixtures/unit/markup/snap/spaces.typ-40.snap
+++ b/tests/fixtures/unit/markup/snap/spaces.typ-40.snap
@@ -1,0 +1,81 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/markup/spaces.typ
+---
+// Basic multiple spaces and formatting
+Text with  two spaces between words.
+
+Text with   three   spaces   between   words.     // line comment
+
+*Bold*  with  two  spaces and _italic_   with   three   spaces.
+
+`Code`    with    four    spaces and #smallcaps[Small Caps]  mixed.
+
+#strike[Strikethrough]   and   #super[superscript]  and  #sub[subscript]   combined.
+
+// Mixed content with spaces
+Link  to  #link("url")[example]    and    #text(red)[colored]   text   together.
+
+Math with  spaces: $x + y = z$  and  inline math  $a b c$   surrounding.
+
+// Spaces at boundaries and special characters
+Leading and trailing     /*  block comment   */    spaces
+
+Text  with  "quotes"   and   'apostrophes'    and    symbols:   &   <   >   {}   []
+
+Emoji  😀  with  spaces  🎉  and  Unicode:  α  β  γ   characters.
+
+// Nested markup and line breaks
+This is #emph[emphasized  text  with  spaces] and #box[boxed   content] together.
+
+Nested #strong[*bold*  inside  strong] with spaces  \
+and  line  breaks  \
+across   multiple   lines.
+
+// Lists, quotes, and structural elements
+- Item  with  spaces and nested    item    together
++ Numbered   list   with   1. Deep    nested    content
+
+#quote[
+  Quoted  text  with  spaces
+  and   multiple   lines
+]
+
+= Heading  with  spaces and == Subheading   combined
+
+// Complex structures and code
+#align(center)[
+  Centered  text  with  spaces
+] and #stack[
+  Stacked  content
+  with   preserved   spaces
+]
+
+#table(
+  columns: 2,
+  [Cell  with  spaces],
+  [Another   cell   with   spaces],
+
+  [More    content],
+  [Even     more     spaced     content],
+)
+
+Here's `inline  code  with  spaces` and code blocks:
+
+```
+Code block
+with  preserved  spaces
+```
+
+#show ref: repr
+// References and function calls
+See @reference  for  @ref1  @ref2   multiple   citations.
+
+Call #math.vec("arg1", "arg2")  and  nested #text(text[content  with  spaces])  functions.
+
+// Mixed whitespace and internationalization
+Text	with	tabs	and  spaces  mixed    together.
+
+Français  avec  des  中文  文本  与  العربية  مع  international   spaces.
+
+Text with non-breaking and  en-spaces  and  em-spaces  together.

--- a/tests/fixtures/unit/markup/snap/spaces.typ-80.snap
+++ b/tests/fixtures/unit/markup/snap/spaces.typ-80.snap
@@ -1,0 +1,78 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/markup/spaces.typ
+---
+// Basic multiple spaces and formatting
+Text with  two spaces between words.
+
+Text with   three   spaces   between   words.     // line comment
+
+*Bold*  with  two  spaces and _italic_   with   three   spaces.
+
+`Code`    with    four    spaces and #smallcaps[Small Caps]  mixed.
+
+#strike[Strikethrough]   and   #super[superscript]  and  #sub[subscript]   combined.
+
+// Mixed content with spaces
+Link  to  #link("url")[example]    and    #text(red)[colored]   text   together.
+
+Math with  spaces: $x + y = z$  and  inline math  $a b c$   surrounding.
+
+// Spaces at boundaries and special characters
+Leading and trailing     /*  block comment   */    spaces
+
+Text  with  "quotes"   and   'apostrophes'    and    symbols:   &   <   >   {}   []
+
+Emoji  😀  with  spaces  🎉  and  Unicode:  α  β  γ   characters.
+
+// Nested markup and line breaks
+This is #emph[emphasized  text  with  spaces] and #box[boxed   content] together.
+
+Nested #strong[*bold*  inside  strong] with spaces  \
+and  line  breaks  \
+across   multiple   lines.
+
+// Lists, quotes, and structural elements
+- Item  with  spaces and nested    item    together
++ Numbered   list   with   1. Deep    nested    content
+
+#quote[
+  Quoted  text  with  spaces
+  and   multiple   lines
+]
+
+= Heading  with  spaces and == Subheading   combined
+
+// Complex structures and code
+#align(center)[
+  Centered  text  with  spaces
+] and #stack[
+  Stacked  content
+  with   preserved   spaces
+]
+
+#table(
+  columns: 2,
+  [Cell  with  spaces], [Another   cell   with   spaces],
+  [More    content], [Even     more     spaced     content],
+)
+
+Here's `inline  code  with  spaces` and code blocks:
+
+```
+Code block
+with  preserved  spaces
+```
+
+#show ref: repr
+// References and function calls
+See @reference  for  @ref1  @ref2   multiple   citations.
+
+Call #math.vec("arg1", "arg2")  and  nested #text(text[content  with  spaces])  functions.
+
+// Mixed whitespace and internationalization
+Text	with	tabs	and  spaces  mixed    together.
+
+Français  avec  des  中文  文本  与  العربية  مع  international   spaces.
+
+Text with non-breaking and  en-spaces  and  em-spaces  together.

--- a/tests/fixtures/unit/markup/snap/strong-space.typ-0.snap
+++ b/tests/fixtures/unit/markup/snap/strong-space.typ-0.snap
@@ -3,16 +3,16 @@ source: tests/src/unit.rs
 input_file: tests/fixtures/unit/markup/strong-space.typ
 ---
 // Basic spacing variations
-Empty: * *
+Empty: *    *
 No spaces:*bold*
 Left space: *bold*
 Right space:*bold *
 Both spaces: * bold *
 
 // Multiple spacing variations
-Too many spaces: * bold *
-Tab spacing: * bold *
-Mixed spacing: * bold* *bold * * bold *
+Too many spaces:  * bold *
+Tab spacing:	* bold *
+Mixed spacing: * bold*   *bold * * bold *
 
 // Line breaks with strong elements
 Line
@@ -28,7 +28,7 @@ emphasis_ across lines*
 
 // Strong elements in structural elements
 - List item with*no space*around strong
-- Another item with * excessive spacing *
+- Another item with * excessive    spacing *
 
 // Different contexts
 "Quotation with *strong * element"
@@ -42,7 +42,7 @@ English and *中文* mixed with*不同*spacing patterns
 *中文与English* mixed *在同一个*strong element
 
 // Adjacent strong elements with varying spacing
-*one**two* *three* *four* *five*
+*one**two* *three*   *four*     *five*
 
 // Comment with strong
 // This is a *comment* with * strong * elements
@@ -51,4 +51,4 @@ English and *中文* mixed with*不同*spacing patterns
 中文测试：*无空格* text，前空格 *有空格*，后空格 *有空格* text，*内部 空格*，
 行
 *跨越
-换行* 以及 *嵌套 _强调_* *相邻* *元素*
+换行* 以及 *嵌套 _强调_* *相邻*  *元素*

--- a/tests/fixtures/unit/markup/snap/strong-space.typ-120.snap
+++ b/tests/fixtures/unit/markup/snap/strong-space.typ-120.snap
@@ -3,16 +3,16 @@ source: tests/src/unit.rs
 input_file: tests/fixtures/unit/markup/strong-space.typ
 ---
 // Basic spacing variations
-Empty: * *
+Empty: *    *
 No spaces:*bold*
 Left space: *bold*
 Right space:*bold *
 Both spaces: * bold *
 
 // Multiple spacing variations
-Too many spaces: * bold *
-Tab spacing: * bold *
-Mixed spacing: * bold* *bold * * bold *
+Too many spaces:  * bold *
+Tab spacing:	* bold *
+Mixed spacing: * bold*   *bold * * bold *
 
 // Line breaks with strong elements
 Line
@@ -28,7 +28,7 @@ emphasis_ across lines*
 
 // Strong elements in structural elements
 - List item with*no space*around strong
-- Another item with * excessive spacing *
+- Another item with * excessive    spacing *
 
 // Different contexts
 "Quotation with *strong * element"
@@ -42,7 +42,7 @@ English and *中文* mixed with*不同*spacing patterns
 *中文与English* mixed *在同一个*strong element
 
 // Adjacent strong elements with varying spacing
-*one**two* *three* *four* *five*
+*one**two* *three*   *four*     *five*
 
 // Comment with strong
 // This is a *comment* with * strong * elements
@@ -51,4 +51,4 @@ English and *中文* mixed with*不同*spacing patterns
 中文测试：*无空格* text，前空格 *有空格*，后空格 *有空格* text，*内部 空格*，
 行
 *跨越
-换行* 以及 *嵌套 _强调_* *相邻* *元素*
+换行* 以及 *嵌套 _强调_* *相邻*  *元素*

--- a/tests/fixtures/unit/markup/snap/strong-space.typ-40.snap
+++ b/tests/fixtures/unit/markup/snap/strong-space.typ-40.snap
@@ -3,16 +3,16 @@ source: tests/src/unit.rs
 input_file: tests/fixtures/unit/markup/strong-space.typ
 ---
 // Basic spacing variations
-Empty: * *
+Empty: *    *
 No spaces:*bold*
 Left space: *bold*
 Right space:*bold *
 Both spaces: * bold *
 
 // Multiple spacing variations
-Too many spaces: * bold *
-Tab spacing: * bold *
-Mixed spacing: * bold* *bold * * bold *
+Too many spaces:  * bold *
+Tab spacing:	* bold *
+Mixed spacing: * bold*   *bold * * bold *
 
 // Line breaks with strong elements
 Line
@@ -28,7 +28,7 @@ emphasis_ across lines*
 
 // Strong elements in structural elements
 - List item with*no space*around strong
-- Another item with * excessive spacing *
+- Another item with * excessive    spacing *
 
 // Different contexts
 "Quotation with *strong * element"
@@ -42,7 +42,7 @@ English and *中文* mixed with*不同*spacing patterns
 *中文与English* mixed *在同一个*strong element
 
 // Adjacent strong elements with varying spacing
-*one**two* *three* *four* *five*
+*one**two* *three*   *four*     *five*
 
 // Comment with strong
 // This is a *comment* with * strong * elements
@@ -51,4 +51,4 @@ English and *中文* mixed with*不同*spacing patterns
 中文测试：*无空格* text，前空格 *有空格*，后空格 *有空格* text，*内部 空格*，
 行
 *跨越
-换行* 以及 *嵌套 _强调_* *相邻* *元素*
+换行* 以及 *嵌套 _强调_* *相邻*  *元素*

--- a/tests/fixtures/unit/markup/snap/strong-space.typ-80.snap
+++ b/tests/fixtures/unit/markup/snap/strong-space.typ-80.snap
@@ -3,16 +3,16 @@ source: tests/src/unit.rs
 input_file: tests/fixtures/unit/markup/strong-space.typ
 ---
 // Basic spacing variations
-Empty: * *
+Empty: *    *
 No spaces:*bold*
 Left space: *bold*
 Right space:*bold *
 Both spaces: * bold *
 
 // Multiple spacing variations
-Too many spaces: * bold *
-Tab spacing: * bold *
-Mixed spacing: * bold* *bold * * bold *
+Too many spaces:  * bold *
+Tab spacing:	* bold *
+Mixed spacing: * bold*   *bold * * bold *
 
 // Line breaks with strong elements
 Line
@@ -28,7 +28,7 @@ emphasis_ across lines*
 
 // Strong elements in structural elements
 - List item with*no space*around strong
-- Another item with * excessive spacing *
+- Another item with * excessive    spacing *
 
 // Different contexts
 "Quotation with *strong * element"
@@ -42,7 +42,7 @@ English and *中文* mixed with*不同*spacing patterns
 *中文与English* mixed *在同一个*strong element
 
 // Adjacent strong elements with varying spacing
-*one**two* *three* *four* *five*
+*one**two* *three*   *four*     *five*
 
 // Comment with strong
 // This is a *comment* with * strong * elements
@@ -51,4 +51,4 @@ English and *中文* mixed with*不同*spacing patterns
 中文测试：*无空格* text，前空格 *有空格*，后空格 *有空格* text，*内部 空格*，
 行
 *跨越
-换行* 以及 *嵌套 _强调_* *相邻* *元素*
+换行* 以及 *嵌套 _强调_* *相邻*  *元素*

--- a/tests/fixtures/unit/markup/spaces.typ
+++ b/tests/fixtures/unit/markup/spaces.typ
@@ -1,0 +1,74 @@
+// Basic multiple spaces and formatting
+Text with  two spaces between words.
+
+    Text with   three   spaces   between   words.     // line comment
+
+*Bold*  with  two  spaces and _italic_   with   three   spaces.
+
+`Code`    with    four    spaces and #smallcaps[Small Caps]  mixed.
+
+#strike[Strikethrough]   and   #super[superscript]  and  #sub[subscript]   combined.
+
+// Mixed content with spaces
+Link  to  #link("url")[example]    and    #text(red)[colored]   text   together.
+
+Math with  spaces: $x  +  y  =  z$  and  inline math  $a   b   c$   surrounding.
+
+// Spaces at boundaries and special characters
+   Leading and trailing     /*  block comment   */    spaces
+
+Text  with  "quotes"   and   'apostrophes'    and    symbols:   &   <   >   {}   []
+
+Emoji  😀  with  spaces  🎉  and  Unicode:  α  β  γ   characters.
+
+// Nested markup and line breaks
+This is #emph[emphasized  text  with  spaces] and #box[boxed   content] together.
+
+Nested #strong[*bold*  inside  strong] with spaces  \
+  and  line  breaks  \
+   across   multiple   lines.
+
+// Lists, quotes, and structural elements
+- Item  with  spaces and nested    item    together
++ Numbered   list   with   1. Deep    nested    content
+
+#quote[
+  Quoted  text  with  spaces
+     and   multiple   lines
+]
+
+= Heading  with  spaces and == Subheading   combined
+
+// Complex structures and code
+#align(center)[
+  Centered  text  with  spaces
+] and #stack[
+     Stacked  content
+  with   preserved   spaces
+]
+
+#table(
+  columns: 2,
+  [Cell  with  spaces], [Another   cell   with   spaces],
+  [More    content], [Even     more     spaced     content]
+)
+
+Here's `inline  code  with  spaces` and code blocks:
+
+```
+Code block
+with  preserved  spaces
+```
+
+#show ref: repr
+// References and function calls
+See @reference  for  @ref1  @ref2   multiple   citations.
+
+Call #math.vec("arg1",  "arg2")  and  nested #text(text[content  with  spaces])  functions.
+
+// Mixed whitespace and internationalization
+Text	with	tabs	and  spaces  mixed    together.
+
+Français  avec  des  中文  文本  与  العربية  مع  international   spaces.
+
+Text with non-breaking and  en-spaces  and  em-spaces  together.

--- a/tests/fixtures/unit/mixed/snap/complex.typ-0.snap
+++ b/tests/fixtures/unit/mixed/snap/complex.typ-0.snap
@@ -9,9 +9,9 @@ input_file: tests/fixtures/unit/mixed/complex.typ
   param4: "string",
 ) = { }
 
-= Poorly Formatted * Heading* with _ emphasis _
+= Poorly    Formatted    * Heading* with   _ emphasis _
 
-This paragraph has excessive spacing and random
+This paragraph has    excessive      spacing and random
 #text(
   font: "Comic Sans MS",
   weight: "bold",
@@ -34,13 +34,13 @@ breaks. It also has*bold text*without proper spacing and_emphasized_content stuc
 )[Third *nested* content #align(center)[with aligned
     content]]
 
-- First list item with bad spacing
+- First   list item with      bad spacing
   #stack(
     dir: ltr,
     spacing: 1em,
   )[stacked
     content] in the middle of a list
-  - Nested item with
+  - Nested item  with
   code: `let x =
   5`
 - Second item with equation: $x^2 +
@@ -55,8 +55,8 @@ breaks. It also has*bold text*without proper spacing and_emphasized_content stuc
 #box(
   width: 80%,
 )[
-  Content in a box that's poorly indented
-  with random spacing
+  Content in a box that's  poorly indented
+  with random    spacing
   #place(
     dx: 20pt,
     dy: -5pt,
@@ -64,7 +64,7 @@ breaks. It also has*bold text*without proper spacing and_emphasized_content stuc
   ]
 ]
 
-== Code Block with Poor Spacing
+== Code Block with    Poor Spacing
 
 $
   sum_(i=0)^n i =
@@ -120,9 +120,9 @@ $
     2fr,
   ),
   [ * Header 1 *],
-  [*Header 2*],
+  [*Header    2*],
 
-  [Cell 1],
+  [Cell   1],
   [
     Cell with
     #text(
@@ -134,7 +134,7 @@ $
 
 #lorem(40) +
 #[This content is *oddly* _mixed_ with various
-  syntactic elements] +
+  syntactic  elements] +
 #v(1cm) +
 #pad(
   x: 2em,

--- a/tests/fixtures/unit/mixed/snap/complex.typ-120.snap
+++ b/tests/fixtures/unit/mixed/snap/complex.typ-120.snap
@@ -9,9 +9,9 @@ input_file: tests/fixtures/unit/mixed/complex.typ
   param4: "string",
 ) = { }
 
-= Poorly Formatted * Heading* with _ emphasis _
+= Poorly    Formatted    * Heading* with   _ emphasis _
 
-This paragraph has excessive spacing and random
+This paragraph has    excessive      spacing and random
 #text(font: "Comic Sans MS", weight: "bold", size: 12pt)[inserted function] line
 breaks. It also has*bold text*without proper spacing and_emphasized_content stuck together.
 
@@ -30,10 +30,10 @@ breaks. It also has*bold text*without proper spacing and_emphasized_content stuc
 )[Third *nested* content #align(center)[with aligned
     content]]
 
-- First list item with bad spacing
+- First   list item with      bad spacing
   #stack(dir: ltr, spacing: 1em)[stacked
     content] in the middle of a list
-  - Nested item with
+  - Nested item  with
   code: `let x =
   5`
 - Second item with equation: $x^2 +
@@ -41,13 +41,13 @@ breaks. It also has*bold text*without proper spacing and_emphasized_content stuc
   #underline(stroke: 2pt + blue)[ underlined text ]
 
 #box(width: 80%)[
-  Content in a box that's poorly indented
-  with random spacing
+  Content in a box that's  poorly indented
+  with random    spacing
   #place(dx: 20pt, dy: -5pt)[*placed* content
   ]
 ]
 
-== Code Block with Poor Spacing
+== Code Block with    Poor Spacing
 
 $
   sum_(i=0)^n i =
@@ -79,8 +79,8 @@ $
 
 #table(
   columns: (1fr, 2fr),
-  [ * Header 1 *], [*Header 2*],
-  [Cell 1],
+  [ * Header 1 *], [*Header    2*],
+  [Cell   1],
   [
     Cell with
     #text(style: "italic", fill: green)[styled]
@@ -89,7 +89,7 @@ $
 
 #lorem(40) +
 #[This content is *oddly* _mixed_ with various
-  syntactic elements] +
+  syntactic  elements] +
 #v(1cm) +
 #pad(x: 2em, top: 5pt, bottom: 8pt)[Padded content with
   #box(width: 50pt, height: auto)"image.jpg"]

--- a/tests/fixtures/unit/mixed/snap/complex.typ-40.snap
+++ b/tests/fixtures/unit/mixed/snap/complex.typ-40.snap
@@ -9,9 +9,9 @@ input_file: tests/fixtures/unit/mixed/complex.typ
   param4: "string",
 ) = { }
 
-= Poorly Formatted * Heading* with _ emphasis _
+= Poorly    Formatted    * Heading* with   _ emphasis _
 
-This paragraph has excessive spacing and random
+This paragraph has    excessive      spacing and random
 #text(
   font: "Comic Sans MS",
   weight: "bold",
@@ -34,10 +34,10 @@ breaks. It also has*bold text*without proper spacing and_emphasized_content stuc
 )[Third *nested* content #align(center)[with aligned
     content]]
 
-- First list item with bad spacing
+- First   list item with      bad spacing
   #stack(dir: ltr, spacing: 1em)[stacked
     content] in the middle of a list
-  - Nested item with
+  - Nested item  with
   code: `let x =
   5`
 - Second item with equation: $x^2 +
@@ -47,8 +47,8 @@ breaks. It also has*bold text*without proper spacing and_emphasized_content stuc
   ]
 
 #box(width: 80%)[
-  Content in a box that's poorly indented
-  with random spacing
+  Content in a box that's  poorly indented
+  with random    spacing
   #place(
     dx: 20pt,
     dy: -5pt,
@@ -56,7 +56,7 @@ breaks. It also has*bold text*without proper spacing and_emphasized_content stuc
   ]
 ]
 
-== Code Block with Poor Spacing
+== Code Block with    Poor Spacing
 
 $
   sum_(i=0)^n i =
@@ -97,8 +97,8 @@ $
 
 #table(
   columns: (1fr, 2fr),
-  [ * Header 1 *], [*Header 2*],
-  [Cell 1],
+  [ * Header 1 *], [*Header    2*],
+  [Cell   1],
   [
     Cell with
     #text(
@@ -110,7 +110,7 @@ $
 
 #lorem(40) +
 #[This content is *oddly* _mixed_ with various
-  syntactic elements] +
+  syntactic  elements] +
 #v(1cm) +
 #pad(
   x: 2em,

--- a/tests/fixtures/unit/mixed/snap/complex.typ-80.snap
+++ b/tests/fixtures/unit/mixed/snap/complex.typ-80.snap
@@ -9,9 +9,9 @@ input_file: tests/fixtures/unit/mixed/complex.typ
   param4: "string",
 ) = { }
 
-= Poorly Formatted * Heading* with _ emphasis _
+= Poorly    Formatted    * Heading* with   _ emphasis _
 
-This paragraph has excessive spacing and random
+This paragraph has    excessive      spacing and random
 #text(font: "Comic Sans MS", weight: "bold", size: 12pt)[inserted function] line
 breaks. It also has*bold text*without proper spacing and_emphasized_content stuck together.
 
@@ -30,10 +30,10 @@ breaks. It also has*bold text*without proper spacing and_emphasized_content stuc
 )[Third *nested* content #align(center)[with aligned
     content]]
 
-- First list item with bad spacing
+- First   list item with      bad spacing
   #stack(dir: ltr, spacing: 1em)[stacked
     content] in the middle of a list
-  - Nested item with
+  - Nested item  with
   code: `let x =
   5`
 - Second item with equation: $x^2 +
@@ -41,13 +41,13 @@ breaks. It also has*bold text*without proper spacing and_emphasized_content stuc
   #underline(stroke: 2pt + blue)[ underlined text ]
 
 #box(width: 80%)[
-  Content in a box that's poorly indented
-  with random spacing
+  Content in a box that's  poorly indented
+  with random    spacing
   #place(dx: 20pt, dy: -5pt)[*placed* content
   ]
 ]
 
-== Code Block with Poor Spacing
+== Code Block with    Poor Spacing
 
 $
   sum_(i=0)^n i =
@@ -79,8 +79,8 @@ $
 
 #table(
   columns: (1fr, 2fr),
-  [ * Header 1 *], [*Header 2*],
-  [Cell 1],
+  [ * Header 1 *], [*Header    2*],
+  [Cell   1],
   [
     Cell with
     #text(style: "italic", fill: green)[styled]
@@ -89,7 +89,7 @@ $
 
 #lorem(40) +
 #[This content is *oddly* _mixed_ with various
-  syntactic elements] +
+  syntactic  elements] +
 #v(1cm) +
 #pad(x: 2em, top: 5pt, bottom: 8pt)[Padded content with
   #box(width: 50pt, height: auto)"image.jpg"]

--- a/tests/src/common.rs
+++ b/tests/src/common.rs
@@ -86,7 +86,10 @@ fn parse_directives(content: &str) -> Result<Options, Failed> {
                 options.relax_convergence = value.and_then(|v| v.parse().ok()).unwrap_or(1)
             }
             "reorder_import_items" => config.reorder_import_items = value != Some("false"),
-            "wrap_text" => config.wrap_text = value != Some("false"),
+            "wrap_text" => {
+                config.wrap_text = value != Some("false");
+                config.collapse_markup_spaces |= config.wrap_text;
+            }
             _ => return Err(format!("unknown directive: {key}").into()),
         }
         Ok(())


### PR DESCRIPTION
resolves #296.

now markup spaces between items will not collapse to a single one, unless enabling that feature.