### PR TITLE
fix: bad escape hatch in corner cases

### DIFF
--- a/crates/typstyle-core/src/pretty/code_misc.rs
+++ b/crates/typstyle-core/src/pretty/code_misc.rs
@@ -12,6 +12,9 @@ impl<'a> PrettyPrinter<'a> {
         ctx: Context,
         array_item: ArrayItem<'a>,
     ) -> ArenaDoc<'a> {
+        if let Some(res) = self.check_disabled(array_item.to_untyped()) {
+            return res;
+        }
         match array_item {
             ArrayItem::Pos(p) => self.convert_expr(ctx, p),
             ArrayItem::Spread(s) => self.convert_spread(ctx, s),
@@ -23,6 +26,9 @@ impl<'a> PrettyPrinter<'a> {
         ctx: Context,
         dict_item: DictItem<'a>,
     ) -> ArenaDoc<'a> {
+        if let Some(res) = self.check_disabled(dict_item.to_untyped()) {
+            return res;
+        }
         match dict_item {
             DictItem::Named(n) => self.convert_named(ctx, n),
             DictItem::Keyed(k) => self.convert_keyed(ctx, k),
@@ -31,6 +37,9 @@ impl<'a> PrettyPrinter<'a> {
     }
 
     pub(super) fn convert_param(&'a self, ctx: Context, param: Param<'a>) -> ArenaDoc<'a> {
+        if let Some(res) = self.check_disabled(param.to_untyped()) {
+            return res;
+        }
         match param {
             Param::Pos(p) => self.convert_pattern(ctx, p),
             Param::Named(n) => self.convert_named(ctx, n),
@@ -55,6 +64,9 @@ impl<'a> PrettyPrinter<'a> {
         ctx: Context,
         destructuring_item: DestructuringItem<'a>,
     ) -> ArenaDoc<'a> {
+        if let Some(res) = self.check_disabled(destructuring_item.to_untyped()) {
+            return res;
+        }
         match destructuring_item {
             DestructuringItem::Spread(s) => self.convert_spread(ctx, s),
             DestructuringItem::Named(n) => self.convert_named(ctx, n),

--- a/tests/fixtures/unit/off/complex.typ
+++ b/tests/fixtures/unit/off/complex.typ
@@ -1,0 +1,65 @@
+
+#let complex_structure = (
+  // Arrays with multiple ugly sections
+  arrays: (
+    /* @typstyle off */ 4-   3,5    +   8,6*2/3,
+    7, 8, /* @typstyle off */ .. (16   -9,  ),11*1,12/1
+  ),
+
+  // Dictionary with inline off directives
+  dict: (
+    name: "Alice", /* @typstyle off */city:"Paris"+""+"", age:25,
+     /* @typstyle off */ id:123*1,status:"active"+""
+  ),
+
+  // Destructuring patterns with off
+  patterns: {
+    let (first, /* @typstyle off */ ..   rest,last) = (1,   2, 3   , )
+  },
+
+  // Code blocks with mid-line off directives
+  code: {
+    let x = 1; /* @typstyle off */ let y=2;let z=3;
+
+    // Function definition with off mid-parameter list
+    let my_func(
+     param2, /* @typstyle off */ param3: 1*4 +     2,param4:none,
+    ) = {
+      // Text styling with off between attributes
+      text(
+        size: 12pt, /* @typstyle off */ weight:"bold",fill:red,
+      )[Styled text]
+    }
+
+    // Show rule with off in unexpected places
+    show heading: it => [
+      #set text(blue); /* @typstyle off */ #set text(size:14pt,weight:"bold")
+      #it.body; /* @typstyle off */ #h(  5pt )#text(red)[*x*]
+    ]
+
+    my_func
+  },
+
+  // Complex content with lists and alignment
+  content: [
+    // List with multiple ugly sections
+    - Normal item 1
+    - Normal item 2
+    /* @typstyle off */ - #{"Ugly"   +"item" +  "3"}
+    /* @typstyle off */ #{"Another" +  "ugly"+   "item"   +"4"}
+    - Normal item 5
+
+    // List with off after dashes
+    - Normal item 1
+    - Normal item 2; /* @typstyle off */ - #{[Ugly]  ; [item]  ; [3]}
+    - Normal item 4; /* @typstyle off */ #{[Another]   ;[ugly]  ; [item];   [5]}
+    - Normal item 6
+
+    // Complex nesting with off at various depths
+    #align(
+      center, /* @typstyle off */ box(width:100%,height:50pt, /* @typstyle off */ fill:blue,stroke:red)[
+        Nested content with /* @typstyle off */ #stack(dir:ttb,spacing:5pt, [A], [B])
+      ]
+    )
+  ],
+)

--- a/tests/fixtures/unit/off/snap/complex.typ-0.snap
+++ b/tests/fixtures/unit/off/snap/complex.typ-0.snap
@@ -1,0 +1,113 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/off/complex.typ
+---
+// DUMMY
+
+#let complex_structure = (
+  // Arrays with multiple ugly sections
+  arrays: (
+    /* @typstyle off */
+    4-   3,
+    5
+      + 8,
+    6
+      * 2
+      / 3,
+    7,
+    8,
+    /* @typstyle off */
+    .. (16   -9,  ),
+    11
+      * 1,
+    12
+      / 1,
+  ),
+  // Dictionary with inline off directives
+  dict: (
+    name: "Alice",
+    /* @typstyle off */
+    city:"Paris"+""+"",
+    age: 25,
+    /* @typstyle off */
+    id:123*1,
+    status: "active"
+      + "",
+  ),
+  // Destructuring patterns with off
+  patterns: {
+    let (
+      first,
+      /* @typstyle off */
+      ..   rest,
+      last,
+    ) = (
+      1,
+      2,
+      3,
+    )
+  },
+  // Code blocks with mid-line off directives
+  code: {
+    let x = 1
+    /* @typstyle off */
+    let y=2
+    let z = 3
+
+    // Function definition with off mid-parameter list
+    let my_func(
+      param2,
+      /* @typstyle off */
+      param3: 1*4 +     2,
+      param4: none,
+    ) = {
+      // Text styling with off between attributes
+      text(
+        size: 12pt,
+        /* @typstyle off */
+        weight: "bold",
+        fill: red,
+      )[Styled text]
+    }
+
+    // Show rule with off in unexpected places
+    show heading: it => [
+      #set text(
+        blue,
+      ); /* @typstyle off */ #set text(size:14pt,weight:"bold")
+      #it.body; /* @typstyle off */ #h(  5pt )#text(
+        red,
+      )[*x*]
+    ]
+
+    my_func
+  },
+  // Complex content with lists and alignment
+  content: [
+    // List with multiple ugly sections
+    - Normal item 1
+    - Normal item 2
+      /* @typstyle off */ - #{"Ugly"   +"item" +  "3"}
+      /* @typstyle off */ #{"Another" +  "ugly"+   "item"   +"4"}
+    - Normal item 5
+
+    // List with off after dashes
+    - Normal item 1
+    - Normal item 2; /* @typstyle off */ - #{
+        [Ugly]
+        [item]
+        [3]
+      }
+    - Normal item 4; /* @typstyle off */ #{[Another]   ;[ugly]  ; [item];   [5]}
+    - Normal item 6
+
+    // Complex nesting with off at various depths
+    #align(
+      center,
+      /* @typstyle off */
+      box(width:100%,height:50pt, /* @typstyle off */ fill:blue,stroke:red)[
+        Nested content with /* @typstyle off */ #stack(dir:ttb,spacing:5pt, [A], [B])
+      ],
+    )
+  ],
+)

--- a/tests/fixtures/unit/off/snap/complex.typ-120.snap
+++ b/tests/fixtures/unit/off/snap/complex.typ-120.snap
@@ -1,0 +1,84 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/off/complex.typ
+---
+// DUMMY
+
+#let complex_structure = (
+  // Arrays with multiple ugly sections
+  arrays: (
+    /* @typstyle off */ 4-   3,
+    5 + 8,
+    6 * 2 / 3,
+    7,
+    8,
+    /* @typstyle off */ .. (16   -9,  ),
+    11 * 1,
+    12 / 1,
+  ),
+  // Dictionary with inline off directives
+  dict: (
+    name: "Alice",
+    /* @typstyle off */ city:"Paris"+""+"",
+    age: 25,
+    /* @typstyle off */ id:123*1,
+    status: "active" + "",
+  ),
+  // Destructuring patterns with off
+  patterns: {
+    let (first, /* @typstyle off */ ..   rest, last) = (1, 2, 3)
+  },
+  // Code blocks with mid-line off directives
+  code: {
+    let x = 1
+    /* @typstyle off */
+    let y=2
+    let z = 3
+
+    // Function definition with off mid-parameter list
+    let my_func(
+      param2,
+      /* @typstyle off */ param3: 1*4 +     2,
+      param4: none,
+    ) = {
+      // Text styling with off between attributes
+      text(size: 12pt, /* @typstyle off */ weight: "bold", fill: red)[Styled text]
+    }
+
+    // Show rule with off in unexpected places
+    show heading: it => [
+      #set text(blue); /* @typstyle off */ #set text(size:14pt,weight:"bold")
+      #it.body; /* @typstyle off */ #h(  5pt )#text(red)[*x*]
+    ]
+
+    my_func
+  },
+  // Complex content with lists and alignment
+  content: [
+    // List with multiple ugly sections
+    - Normal item 1
+    - Normal item 2
+      /* @typstyle off */ - #{"Ugly"   +"item" +  "3"}
+      /* @typstyle off */ #{"Another" +  "ugly"+   "item"   +"4"}
+    - Normal item 5
+
+    // List with off after dashes
+    - Normal item 1
+    - Normal item 2; /* @typstyle off */ - #{
+        [Ugly]
+        [item]
+        [3]
+      }
+    - Normal item 4; /* @typstyle off */ #{[Another]   ;[ugly]  ; [item];   [5]}
+    - Normal item 6
+
+    // Complex nesting with off at various depths
+    #align(
+      center,
+      /* @typstyle off */
+      box(width:100%,height:50pt, /* @typstyle off */ fill:blue,stroke:red)[
+        Nested content with /* @typstyle off */ #stack(dir:ttb,spacing:5pt, [A], [B])
+      ],
+    )
+  ],
+)

--- a/tests/fixtures/unit/off/snap/complex.typ-40.snap
+++ b/tests/fixtures/unit/off/snap/complex.typ-40.snap
@@ -1,0 +1,99 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/off/complex.typ
+---
+// DUMMY
+
+#let complex_structure = (
+  // Arrays with multiple ugly sections
+  arrays: (
+    /* @typstyle off */ 4-   3,
+    5 + 8,
+    6 * 2 / 3,
+    7,
+    8,
+    /* @typstyle off */ .. (16   -9,  ),
+    11 * 1,
+    12 / 1,
+  ),
+  // Dictionary with inline off directives
+  dict: (
+    name: "Alice",
+    /* @typstyle off */
+    city:"Paris"+""+"",
+    age: 25,
+    /* @typstyle off */ id:123*1,
+    status: "active" + "",
+  ),
+  // Destructuring patterns with off
+  patterns: {
+    let (
+      first,
+      /* @typstyle off */ ..   rest,
+      last,
+    ) = (1, 2, 3)
+  },
+  // Code blocks with mid-line off directives
+  code: {
+    let x = 1
+    /* @typstyle off */
+    let y=2
+    let z = 3
+
+    // Function definition with off mid-parameter list
+    let my_func(
+      param2,
+      /* @typstyle off */
+      param3: 1*4 +     2,
+      param4: none,
+    ) = {
+      // Text styling with off between attributes
+      text(
+        size: 12pt,
+        /* @typstyle off */
+        weight: "bold",
+        fill: red,
+      )[Styled text]
+    }
+
+    // Show rule with off in unexpected places
+    show heading: it => [
+      #set text(
+        blue,
+      ); /* @typstyle off */ #set text(size:14pt,weight:"bold")
+      #it.body; /* @typstyle off */ #h(  5pt )#text(
+        red,
+      )[*x*]
+    ]
+
+    my_func
+  },
+  // Complex content with lists and alignment
+  content: [
+    // List with multiple ugly sections
+    - Normal item 1
+    - Normal item 2
+      /* @typstyle off */ - #{"Ugly"   +"item" +  "3"}
+      /* @typstyle off */ #{"Another" +  "ugly"+   "item"   +"4"}
+    - Normal item 5
+
+    // List with off after dashes
+    - Normal item 1
+    - Normal item 2; /* @typstyle off */ - #{
+        [Ugly]
+        [item]
+        [3]
+      }
+    - Normal item 4; /* @typstyle off */ #{[Another]   ;[ugly]  ; [item];   [5]}
+    - Normal item 6
+
+    // Complex nesting with off at various depths
+    #align(
+      center,
+      /* @typstyle off */
+      box(width:100%,height:50pt, /* @typstyle off */ fill:blue,stroke:red)[
+        Nested content with /* @typstyle off */ #stack(dir:ttb,spacing:5pt, [A], [B])
+      ],
+    )
+  ],
+)

--- a/tests/fixtures/unit/off/snap/complex.typ-80.snap
+++ b/tests/fixtures/unit/off/snap/complex.typ-80.snap
@@ -1,0 +1,88 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/off/complex.typ
+---
+// DUMMY
+
+#let complex_structure = (
+  // Arrays with multiple ugly sections
+  arrays: (
+    /* @typstyle off */ 4-   3,
+    5 + 8,
+    6 * 2 / 3,
+    7,
+    8,
+    /* @typstyle off */ .. (16   -9,  ),
+    11 * 1,
+    12 / 1,
+  ),
+  // Dictionary with inline off directives
+  dict: (
+    name: "Alice",
+    /* @typstyle off */ city:"Paris"+""+"",
+    age: 25,
+    /* @typstyle off */ id:123*1,
+    status: "active" + "",
+  ),
+  // Destructuring patterns with off
+  patterns: {
+    let (first, /* @typstyle off */ ..   rest, last) = (1, 2, 3)
+  },
+  // Code blocks with mid-line off directives
+  code: {
+    let x = 1
+    /* @typstyle off */
+    let y=2
+    let z = 3
+
+    // Function definition with off mid-parameter list
+    let my_func(
+      param2,
+      /* @typstyle off */ param3: 1*4 +     2,
+      param4: none,
+    ) = {
+      // Text styling with off between attributes
+      text(
+        size: 12pt,
+        /* @typstyle off */ weight: "bold",
+        fill: red,
+      )[Styled text]
+    }
+
+    // Show rule with off in unexpected places
+    show heading: it => [
+      #set text(blue); /* @typstyle off */ #set text(size:14pt,weight:"bold")
+      #it.body; /* @typstyle off */ #h(  5pt )#text(red)[*x*]
+    ]
+
+    my_func
+  },
+  // Complex content with lists and alignment
+  content: [
+    // List with multiple ugly sections
+    - Normal item 1
+    - Normal item 2
+      /* @typstyle off */ - #{"Ugly"   +"item" +  "3"}
+      /* @typstyle off */ #{"Another" +  "ugly"+   "item"   +"4"}
+    - Normal item 5
+
+    // List with off after dashes
+    - Normal item 1
+    - Normal item 2; /* @typstyle off */ - #{
+        [Ugly]
+        [item]
+        [3]
+      }
+    - Normal item 4; /* @typstyle off */ #{[Another]   ;[ugly]  ; [item];   [5]}
+    - Normal item 6
+
+    // Complex nesting with off at various depths
+    #align(
+      center,
+      /* @typstyle off */
+      box(width:100%,height:50pt, /* @typstyle off */ fill:blue,stroke:red)[
+        Nested content with /* @typstyle off */ #stack(dir:ttb,spacing:5pt, [A], [B])
+      ],
+    )
+  ],
+)

--- a/tests/fixtures/unit/off/snap/through.typ-0.snap
+++ b/tests/fixtures/unit/off/snap/through.typ-0.snap
@@ -1,9 +1,79 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/off/through.typ
-snapshot_kind: text
 ---
+/* @typstyle off */
+// line comment
+#(
+  114
+)
+
+/* @typstyle off */ /* block */ #(
+  999
+)
+
 /* @typstyle off */
 #1
 #let aaa = 123
 #let bbb = 123
+
+/* @typstyle off */
+
+
+#(
+  1
+    + 4
+)
+
+#(
+  1
+    + /* @typstyle off */(3    /    9)    * 6
+)
+
+#[
+  /* @typstyle off */
+
+  #(
+    1
+      + 2
+      + 3
+  )
+]
+
+#{
+  /* @typstyle off */
+
+  (1+2+3)
+}
+
+#{
+  // @typstyle off
+  let   _ =   1
+  let _ = 2
+  let _ = 3
+}
+
+#{
+  let _ = 0
+  // @typstyle off
+  let   _ =   1
+  let _ = 2
+  let _ = 3
+}
+#[
+  // @typstyle off
+  #let   _  =   1
+  #let _ = 2
+]
+
+$
+  // @typstyle off
+  sin(   x  )
+  cos(x)
+$
+$
+  sin(x)
+  // @typstyle off
+  cos(   x  )
+  tan(x)
+$

--- a/tests/fixtures/unit/off/snap/through.typ-120.snap
+++ b/tests/fixtures/unit/off/snap/through.typ-120.snap
@@ -1,9 +1,65 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/off/through.typ
-snapshot_kind: text
 ---
+/* @typstyle off */
+// line comment
+#114
+
+/* @typstyle off */ /* block */ #999
+
 /* @typstyle off */
 #1
 #let aaa = 123
 #let bbb = 123
+
+/* @typstyle off */
+
+
+#(1 + 4)
+
+#(1 + /* @typstyle off */(3    /    9)    * 6)
+
+#[
+  /* @typstyle off */
+
+  #(1 + 2 + 3)
+]
+
+#{
+  /* @typstyle off */
+
+  (1+2+3)
+}
+
+#{
+  // @typstyle off
+  let   _ =   1
+  let _ = 2
+  let _ = 3
+}
+
+#{
+  let _ = 0
+  // @typstyle off
+  let   _ =   1
+  let _ = 2
+  let _ = 3
+}
+#[
+  // @typstyle off
+  #let   _  =   1
+  #let _ = 2
+]
+
+$
+  // @typstyle off
+  sin(   x  )
+  cos(x)
+$
+$
+  sin(x)
+  // @typstyle off
+  cos(   x  )
+  tan(x)
+$

--- a/tests/fixtures/unit/off/snap/through.typ-40.snap
+++ b/tests/fixtures/unit/off/snap/through.typ-40.snap
@@ -1,9 +1,68 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/off/through.typ
-snapshot_kind: text
 ---
+/* @typstyle off */
+// line comment
+#114
+
+/* @typstyle off */ /* block */ #999
+
 /* @typstyle off */
 #1
 #let aaa = 123
 #let bbb = 123
+
+/* @typstyle off */
+
+
+#(1 + 4)
+
+#(
+  1
+    + /* @typstyle off */(3    /    9)    * 6
+)
+
+#[
+  /* @typstyle off */
+
+  #(1 + 2 + 3)
+]
+
+#{
+  /* @typstyle off */
+
+  (1+2+3)
+}
+
+#{
+  // @typstyle off
+  let   _ =   1
+  let _ = 2
+  let _ = 3
+}
+
+#{
+  let _ = 0
+  // @typstyle off
+  let   _ =   1
+  let _ = 2
+  let _ = 3
+}
+#[
+  // @typstyle off
+  #let   _  =   1
+  #let _ = 2
+]
+
+$
+  // @typstyle off
+  sin(   x  )
+  cos(x)
+$
+$
+  sin(x)
+  // @typstyle off
+  cos(   x  )
+  tan(x)
+$

--- a/tests/fixtures/unit/off/snap/through.typ-80.snap
+++ b/tests/fixtures/unit/off/snap/through.typ-80.snap
@@ -1,9 +1,65 @@
 ---
 source: tests/src/unit.rs
 input_file: tests/fixtures/unit/off/through.typ
-snapshot_kind: text
 ---
+/* @typstyle off */
+// line comment
+#114
+
+/* @typstyle off */ /* block */ #999
+
 /* @typstyle off */
 #1
 #let aaa = 123
 #let bbb = 123
+
+/* @typstyle off */
+
+
+#(1 + 4)
+
+#(1 + /* @typstyle off */(3    /    9)    * 6)
+
+#[
+  /* @typstyle off */
+
+  #(1 + 2 + 3)
+]
+
+#{
+  /* @typstyle off */
+
+  (1+2+3)
+}
+
+#{
+  // @typstyle off
+  let   _ =   1
+  let _ = 2
+  let _ = 3
+}
+
+#{
+  let _ = 0
+  // @typstyle off
+  let   _ =   1
+  let _ = 2
+  let _ = 3
+}
+#[
+  // @typstyle off
+  #let   _  =   1
+  #let _ = 2
+]
+
+$
+  // @typstyle off
+  sin(   x  )
+  cos(x)
+$
+$
+  sin(x)
+  // @typstyle off
+  cos(   x  )
+  tan(x)
+$

--- a/tests/fixtures/unit/off/through.typ
+++ b/tests/fixtures/unit/off/through.typ
@@ -1,4 +1,62 @@
 /* @typstyle off */
+// line comment
+#(   114  )
+
+/* @typstyle off */ /* block */ #(   999  )
+
+/* @typstyle off */
 #1
 #let   aaa  =  123
 #let   bbb  =  123
+
+/* @typstyle off */
+
+
+#(1   +  4)
+
+#( 1 + /* @typstyle off */ (3    /    9)    * 6)
+
+#[
+  /* @typstyle off */
+
+  #(1+2+3)
+]
+
+#{
+/* @typstyle off */
+
+  (1+2+3)
+
+}
+
+#{
+  // @typstyle off
+  let   _ =   1
+    let   _   =   2
+let  _   =   3
+}
+
+#{
+  let _ = 0
+  // @typstyle off
+  let   _ =   1
+  let  _   =   2
+  let _     = 3
+}
+#[
+  // @typstyle off
+  #let   _  =   1
+  #let   _    =   2
+]
+
+$
+  // @typstyle off
+  sin(   x  )
+  cos(  x  )
+$
+$
+  sin(x)
+  // @typstyle off
+  cos(   x  )
+  tan(  x  )
+$


### PR DESCRIPTION
- Previously, escape hatch does not work for:
  - ArrayItem
  - DictItem
  - Param
  - DestructuringItem
  Now it is fixed.

- `@typstyle off` no longer penetrates comments.

- Previously, if `@typstyle off` appears before Code or Math, it applies to the whole syntax node. Now it only applies to its first non-trivial child.