### PR TITLE
refactor: extract wasm features into typstyle-wasm crate

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -3,6 +3,8 @@ on:
   pull_request_target:
     branches:
       - master
+    paths:
+      - "crates/typstyle-core/**"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -45,17 +45,10 @@ jobs:
 
       - name: Build wasm
         run: |
-          cd crates/typstyle-core
+          cd crates/typstyle-wasm
           wasm-pack build --features wasm
           cp ../../README.md pkg
           cp ../../LICENSE pkg
-      - name: Publish to npm
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          cd crates/typstyle-core/pkg
-          npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Build demo
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,6 +538,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2695,6 +2705,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3780,7 +3801,6 @@ dependencies = [
  "thiserror 2.0.11",
  "typst-syntax",
  "unicode-width 0.1.14",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -3796,6 +3816,19 @@ dependencies = [
  "typst-syntax",
  "typstyle-consistency",
  "typstyle-core",
+]
+
+[[package]]
+name = "typstyle-wasm"
+version = "0.13.9"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "serde-wasm-bindgen",
+ "syn",
+ "typst-syntax",
+ "typstyle-core",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ homepage = "https://enter-tainer.github.io/typstyle/"
 [workspace.dependencies]
 typstyle-core = { path = "crates/typstyle-core", version = "0.13.9" }
 typstyle = { path = "crates/typstyle", version = "0.13.9" }
+typstyle-wasm = { path = "crates/typstyle-wasm", version = "0.13.9" }
 typstyle-consistency = { path = "crates/typstyle-consistency" }
 
 # Used in core
@@ -29,9 +30,15 @@ serde = "1.0"
 smallvec = "1"
 thiserror = "2"
 unicode-width = "0.1" # use the same version as in pretty
-wasm-bindgen = { version = "0.2" }
 
-# Use in CLI
+# Used in WASM
+console_error_panic_hook = "0.1.7"
+js-sys = "0.3.77"
+serde-wasm-bindgen = "0.6.5"
+syn = { version = "2.0", default-features = false }
+wasm-bindgen = "0.2.100"
+
+# Used in CLI
 anyhow = "1"
 clap = { version = "4.5", features = ["derive", "env"] }
 clap_complete = { version = "4.5" }

--- a/crates/typstyle-core/Cargo.toml
+++ b/crates/typstyle-core/Cargo.toml
@@ -11,7 +11,6 @@ repository.workspace = true
 rust-version.workspace = true
 
 [lib]
-crate-type = ["cdylib", "lib"]
 bench = false
 
 [[bench]]
@@ -29,7 +28,6 @@ serde = { workspace = true, optional = true }
 smallvec.workspace = true
 thiserror.workspace = true
 unicode-width.workspace = true
-wasm-bindgen = { workspace = true, optional = true }
 
 [dev-dependencies]
 insta.workspace = true
@@ -37,4 +35,3 @@ criterion.workspace = true
 
 [features]
 serde = ["dep:serde"]
-wasm = ["wasm-bindgen"]

--- a/crates/typstyle-core/benches/pretty_print.rs
+++ b/crates/typstyle-core/benches/pretty_print.rs
@@ -7,7 +7,8 @@ use typstyle_core::Typstyle;
 fn bench_pretty(c: &mut Criterion, id: &str, path: &str) {
     fn pretty_print_source(source: Source) -> String {
         Typstyle::default()
-            .format_source(&source)
+            .format_source(source)
+            .render()
             .expect("expect errorless")
     }
 

--- a/crates/typstyle-core/src/attr.rs
+++ b/crates/typstyle-core/src/attr.rs
@@ -37,9 +37,10 @@ impl AttrStore {
     /// Creates a new `AttrStore` by computing formatting-related attributes
     /// for all descendants of the given syntax node.
     pub fn new(node: &SyntaxNode) -> AttrStore {
-        let mut store = AttrStore {
-            attr_map: Default::default(),
-        };
+        if node.erroneous() {
+            return Default::default(); // No attributes for erroneous nodes
+        }
+        let mut store = AttrStore::default();
         store.compute_no_format(node);
         store.compute_multiline(node);
         store.compute_math_align_point(node);

--- a/crates/typstyle-core/src/lib.rs
+++ b/crates/typstyle-core/src/lib.rs
@@ -84,23 +84,3 @@ impl<'a> Formatter<'a> {
         Ok(doc)
     }
 }
-
-/// Format typst content by Typstyle configured with given max_width.
-///
-/// It returns the original string if the source is erroneous.
-pub fn format_with_width(content: &str, width: usize) -> String {
-    let config = Config::new().with_width(width);
-    let t = Typstyle::new(config);
-    t.format_text(content)
-        .render()
-        .unwrap_or_else(|_| content.to_string())
-}
-
-#[cfg(all(target_arch = "wasm32", feature = "wasm"))]
-use wasm_bindgen::prelude::*;
-
-#[cfg(all(target_arch = "wasm32", feature = "wasm"))]
-#[wasm_bindgen]
-pub fn pretty_print_wasm(content: &str, width: usize) -> String {
-    format_with_width(content, width)
-}

--- a/crates/typstyle-core/src/pretty/mod.rs
+++ b/crates/typstyle-core/src/pretty/mod.rs
@@ -41,6 +41,10 @@ impl<'a> PrettyPrinter<'a> {
         }
     }
 
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
+
     fn get_fold_style(&self, ctx: Context, node: impl AstNode<'a>) -> FoldStyle {
         self.get_fold_style_untyped(ctx, node.to_untyped())
     }

--- a/crates/typstyle-wasm/Cargo.toml
+++ b/crates/typstyle-wasm/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "typstyle-wasm"
+publish = false
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+authors.workspace = true
+description = "WebAssembly bindings for Typstyle"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+bench = false
+
+[features]
+default = ["console_error_panic_hook"]
+
+[dependencies]
+typstyle-core = { workspace = true, features = ["serde"] }
+typst-syntax.workspace = true
+
+console_error_panic_hook = { workspace = true, optional = true }
+js-sys.workspace = true
+serde-wasm-bindgen.workspace = true
+wasm-bindgen.workspace = true
+
+[build-dependencies]
+syn.workspace = true

--- a/crates/typstyle-wasm/build.rs
+++ b/crates/typstyle-wasm/build.rs
@@ -1,0 +1,137 @@
+use std::{env, fs, path::Path};
+
+use syn::{Attribute, FieldsNamed, Item, ItemStruct, Lit, Meta, Type};
+
+fn main() {
+    // Define the path to the Config struct in the typstyle-core crate.
+    // Adjust this relative path if your directory structure is different.
+    let core_config_path = Path::new("../typstyle-core/src/config.rs");
+
+    // Tell Cargo to rerun this build script if the core config file changes.
+    println!("cargo:rerun-if-changed={}", core_config_path.display());
+
+    let core_config_content = fs::read_to_string(core_config_path)
+        .unwrap_or_else(|e| panic!("Failed to read {}: {}", core_config_path.display(), e));
+
+    let ast = syn::parse_file(&core_config_content)
+        .unwrap_or_else(|e| panic!("Failed to parse {}: {}", core_config_path.display(), e));
+
+    let config_struct_option = find_config_struct(&ast);
+
+    let ts_interface_fields = if let Some(config_struct) = config_struct_option {
+        generate_ts_fields_for_config_struct(config_struct)
+    } else {
+        eprintln!(
+            "cargo:warning=Config struct not found in {}. Proceeding with an empty TypeScript interface.",
+            core_config_path.display()
+        );
+        String::new() // Default to empty if Config struct is not found
+    };
+
+    let ts_interface = format!("export interface Config {{\n{}}}", ts_interface_fields);
+
+    let out_dir = env::var_os("OUT_DIR")
+        .expect("OUT_DIR environment variable not set. This script should be run by Cargo.");
+    let dest_path = Path::new(&out_dir).join("generated_config_interface.ts");
+
+    fs::write(&dest_path, ts_interface).unwrap_or_else(|e| {
+        panic!(
+            "Failed to write generated TypeScript interface to {}: {}",
+            dest_path.display(),
+            e
+        )
+    });
+
+    // Tell Cargo to rerun this build script if the build script itself changes.
+    println!("cargo:rerun-if-changed=build.rs");
+}
+
+/// Finds a struct definition by name (e.g., "Config") within a parsed Rust file AST.
+fn find_config_struct(ast: &syn::File) -> Option<&ItemStruct> {
+    for item in &ast.items {
+        if let Item::Struct(item_struct @ ItemStruct { ident, .. }) = item {
+            if ident == "Config" {
+                // Ensure this matches the target struct name
+                return Some(item_struct);
+            }
+        }
+    }
+    None
+}
+
+/// Generates TypeScript interface field definitions from a Rust struct's fields.
+/// Includes JSDoc comments extracted from Rust doc comments.
+///
+/// Assume `Config` is at the top level.
+fn generate_ts_fields_for_config_struct(config_struct: &ItemStruct) -> String {
+    let mut ts_fields_string = String::new();
+
+    // Optional: Extract and add doc comments for the interface itself
+    // let interface_doc = extract_doc_comments(&config_struct.attrs);
+    // ts_fields_string.push_str(&interface_doc);
+
+    if let syn::Fields::Named(FieldsNamed { named, .. }) = &config_struct.fields {
+        for field in named {
+            let field_doc_comments = extract_doc_comments(&field.attrs);
+            if let (Some(field_ident), Some(ts_type)) =
+                (&field.ident, rust_type_to_ts_type(&field.ty))
+            {
+                ts_fields_string.push_str(&field_doc_comments);
+                ts_fields_string.push_str(&format!("    {}: {},\n", field_ident, ts_type));
+            } else {
+                eprintln!(
+                    "cargo:warning=Could not map type for field {:?} in Config struct. It will be omitted from the TypeScript interface.",
+                    field.ident
+                );
+            }
+        }
+    }
+    ts_fields_string
+}
+
+/// Converts a Rust type identifier to its corresponding TypeScript type string.
+fn rust_type_to_ts_type(ty: &Type) -> Option<String> {
+    if let Type::Path(type_path) = ty {
+        if type_path.qself.is_none() {
+            let last_segment = type_path.path.segments.last()?;
+            let ident_str = last_segment.ident.to_string();
+            // Map common Rust types to TypeScript types.
+            return match ident_str.as_str() {
+                "usize" | "u8" | "u16" | "u32" | "u64" | "isize" | "i8" | "i16" | "i32" | "i64"
+                | "f32" | "f64" => Some("number".to_string()),
+                "bool" => Some("boolean".to_string()),
+                "String" => Some("string".to_string()),
+                // Add more mappings if your Config struct uses other types
+                _ => None,
+            };
+        }
+    }
+    None
+}
+
+/// Extracts Rust doc comments (#[doc = "..."]) from attributes and formats them as JSDoc.
+fn extract_doc_comments(attrs: &[Attribute]) -> String {
+    let mut doc_lines = Vec::new();
+    for attr in attrs {
+        if attr.path().is_ident("doc") {
+            if let Meta::NameValue(nv) = &attr.meta {
+                if let syn::Expr::Lit(expr_lit) = &nv.value {
+                    if let Lit::Str(lit_str) = &expr_lit.lit {
+                        doc_lines.push(lit_str.value().trim().to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    if doc_lines.is_empty() {
+        String::new()
+    } else {
+        let mut comment = "    /**\n".to_string();
+        for line in doc_lines {
+            comment.push_str(&format!("     * {}\n", line));
+        }
+        comment.push_str("     */\n");
+        comment
+    }
+}

--- a/crates/typstyle-wasm/src/lib.rs
+++ b/crates/typstyle-wasm/src/lib.rs
@@ -1,0 +1,56 @@
+use js_sys::Error;
+use typstyle_core::{Config, Typstyle};
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(typescript_custom_section)]
+const TYPES: &'static str =
+    include_str!(concat!(env!("OUT_DIR"), "/generated_config_interface.ts"));
+
+#[wasm_bindgen(start)]
+pub fn run() {
+    // When the `console_error_panic_hook` feature is enabled, we can call the
+    // `set_panic_hook` function at least once during initialization, and then
+    // we will get better error messages if our code ever panics.
+    //
+    // For more details see
+    // https://github.com/rustwasm/console_error_panic_hook#readme
+    #[cfg(feature = "console_error_panic_hook")]
+    console_error_panic_hook::set_once();
+}
+
+/// Parses the content and returns its AST.
+#[wasm_bindgen]
+pub fn parse(text: &str) -> Result<String, Error> {
+    let root = typst_syntax::parse(text);
+    Ok(format!("{root:#?}"))
+}
+
+/// Formats the content using the provided configuration.
+#[wasm_bindgen]
+pub fn format(
+    text: &str,
+    #[wasm_bindgen(unchecked_param_type = "Config")] config: JsValue,
+) -> Result<String, Error> {
+    let config = parse_config(config)?;
+    let t = Typstyle::new(config);
+    t.format_text(text).render().map_err(into_error)
+}
+
+/// Get the pretty IR for the content.
+#[wasm_bindgen]
+pub fn format_ir(
+    text: &str,
+    #[wasm_bindgen(unchecked_param_type = "Config")] config: JsValue,
+) -> Result<String, Error> {
+    let config = parse_config(config)?;
+    let t = Typstyle::new(config);
+    t.format_text(text).render_ir().map_err(into_error)
+}
+
+fn parse_config(config: JsValue) -> Result<Config, Error> {
+    serde_wasm_bindgen::from_value(config).map_err(into_error)
+}
+
+fn into_error<E: std::fmt::Display>(err: E) -> Error {
+    Error::new(&err.to_string())
+}

--- a/tests/src/repo-e2e.rs
+++ b/tests/src/repo-e2e.rs
@@ -186,12 +186,9 @@ fn make_formatter(config: Config) -> impl Fn(Source) -> anyhow::Result<String> {
         if source.root().erroneous() {
             bail!("the file has syntax errors: {:?}", source.root().errors());
         }
-        let first_pass = Typstyle::new(config.clone())
-            .format_source(&source)
-            .context("first pass")?;
-        let second_pass = Typstyle::new(config.clone())
-            .format_content(&first_pass)
-            .context("second pass")?;
+        let t = Typstyle::new(config.clone());
+        let first_pass = t.format_source(source).render().context("first pass")?;
+        let second_pass = t.format_text(&first_pass).render().context("second pass")?;
         if first_pass != second_pass {
             bail!(
                 "the formatting does not converge:\n{}",

--- a/tests/src/unit.rs
+++ b/tests/src/unit.rs
@@ -113,7 +113,7 @@ fn check_snapshot(path: &Path, width: usize) -> Result<(), Failed> {
             insta::assert_snapshot!(snap_name, "");
         } else {
             cfg.max_width = width;
-            let mut formatted = Typstyle::new(cfg).format_source(&source).unwrap();
+            let mut formatted = Typstyle::new(cfg).format_source(source).render().unwrap();
             if formatted.starts_with('\n') {
                 formatted.insert_str(0, "// DUMMY\n");
             }
@@ -135,7 +135,8 @@ fn check_convergence(path: &Path, width: usize) -> Result<(), Failed> {
     }
 
     cfg.max_width = width;
-    let mut first_pass = Typstyle::new(cfg.clone()).format_source(&source)?;
+    let t = Typstyle::new(cfg);
+    let mut first_pass = t.format_source(source).render()?;
     for i in 0..=opt.relax_convergence {
         let new_source = Source::detached(&first_pass);
         if new_source.root().erroneous() {
@@ -145,7 +146,7 @@ fn check_convergence(path: &Path, width: usize) -> Result<(), Failed> {
                 new_source.root().errors()
             )
         }
-        let second_pass = Typstyle::new(cfg.clone()).format_source(&new_source)?;
+        let second_pass = t.format_source(new_source).render()?;
         if first_pass == second_pass {
             return Ok(());
         }
@@ -176,6 +177,7 @@ fn check_output_consistency(path: &Path, width: usize) -> Result<(), Failed> {
     }
 
     cfg.max_width = width;
+    let t = Typstyle::new(cfg);
 
     let mut err_sink = ErrorSink::new(format!("consistency {}", path.display()));
 
@@ -188,7 +190,7 @@ fn check_output_consistency(path: &Path, width: usize) -> Result<(), Failed> {
         name: format!("{}char", width),
         sources: harness.format(
             &base_world,
-            |source| Ok(Typstyle::new(cfg.clone()).format_source(&source).unwrap()),
+            |source| Ok(t.format_source(source).render()?),
             &mut err_sink,
         )?,
     };

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,7 @@
     "vite-plugin-wasm": "^3.3.0"
   },
   "dependencies": {
-    "typstyle-core": "file:../crates/typstyle-core/pkg",
+    "typstyle-core": "file:../crates/typstyle-wasm/pkg",
     "vanjs-core": "^1.5.2"
   }
 }

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -415,7 +415,7 @@ typescript@^5.6.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.2.tgz#d1de67b6bef77c41823f822df8f0b3bcff60a5a0"
   integrity sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==
 
-"typstyle-core@file:../crates/typstyle-core/pkg":
+"typstyle-core@file:../crates/typstyle-wasm/pkg":
   version "0.12.10"
 
 uuid@^10.0.0:


### PR DESCRIPTION
### Internal

- Changed APIs of the `Typstyle` struct.
- Extracted wasm binding functions to `typstyle-wasm` crate. The `build.rs` for generating config interface is generated by copilot.
- Removed publishing to npm in CI, as it is only intended for the bundler target. We may consider bring it back later.
