### PR TITLE
fix: build gh-pages with wasm crate

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,12 +5,14 @@ on:
       - master
     tags:
       - "*"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "docs/**"
+      - "crates/typstyle-wasm/**"
+      - ".github/workflows/gh-pages.yml"
   workflow_dispatch:
-
-permissions:
-  pages: write
-  id-token: write
-  contents: read
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -20,33 +22,31 @@ concurrency:
 
 jobs:
   build-gh-pages:
+    name: Build Docs & Playground and Prepare Artifact
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
         with: { submodules: recursive }
-      - uses: rui314/setup-mold@v1
-      - uses: dtolnay/rust-toolchain@stable
-        with: { targets: wasm32-unknown-unknown }
-      - uses: jetli/wasm-pack-action@v0.4.0
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
         with:
-          version: "v0.12.1"
+          target: wasm32-unknown-unknown
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@wasm-pack
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
       - name: Install the latest version of rye
         uses: eifinger/setup-rye@v4
         with:
           enable-cache: true
-          cache-prefix: 'typstyle-rye'
+          cache-prefix: "typstyle-rye"
 
       - name: Build wasm
         run: |
           cd crates/typstyle-wasm
-          wasm-pack build --features wasm
+          wasm-pack build
           cp ../../README.md pkg
           cp ../../LICENSE pkg
 
@@ -60,13 +60,28 @@ jobs:
           rye sync
           rye run docs-build
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-      - name: Upload artifact
+      - name: Upload artifact for deployment
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload `/github-pages` sub directory
+          # This path will be the root of what 'actions/deploy-pages' deploys
           path: "site"
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build-gh-pages
+    # Deploy on push to master, or manual workflow dispatch
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/crates/typstyle-wasm/build.rs
+++ b/crates/typstyle-wasm/build.rs
@@ -28,7 +28,7 @@ fn main() {
         String::new() // Default to empty if Config struct is not found
     };
 
-    let ts_interface = format!("export interface Config {{\n{}}}", ts_interface_fields);
+    let ts_interface = format!("export interface Config {{\n{ts_interface_fields}}}");
 
     let out_dir = env::var_os("OUT_DIR")
         .expect("OUT_DIR environment variable not set. This script should be run by Cargo.");
@@ -77,7 +77,7 @@ fn generate_ts_fields_for_config_struct(config_struct: &ItemStruct) -> String {
                 (&field.ident, rust_type_to_ts_type(&field.ty))
             {
                 ts_fields_string.push_str(&field_doc_comments);
-                ts_fields_string.push_str(&format!("    {}: {},\n", field_ident, ts_type));
+                ts_fields_string.push_str(&format!("    {field_ident}: {ts_type},\n"));
             } else {
                 eprintln!(
                     "cargo:warning=Could not map type for field {:?} in Config struct. It will be omitted from the TypeScript interface.",
@@ -129,7 +129,7 @@ fn extract_doc_comments(attrs: &[Attribute]) -> String {
     } else {
         let mut comment = "    /**\n".to_string();
         for line in doc_lines {
-            comment.push_str(&format!("     * {}\n", line));
+            comment.push_str(&format!("     * {line}\n"));
         }
         comment.push_str("     */\n");
         comment

--- a/crates/typstyle-wasm/src/lib.rs
+++ b/crates/typstyle-wasm/src/lib.rs
@@ -54,3 +54,12 @@ fn parse_config(config: JsValue) -> Result<Config, Error> {
 fn into_error<E: std::fmt::Display>(err: E) -> Error {
     Error::new(&err.to_string())
 }
+
+#[wasm_bindgen]
+pub fn pretty_print_wasm(content: &str, width: usize) -> String {
+    let config = Config::new().with_width(width);
+    let t = Typstyle::new(config);
+    t.format_text(content)
+        .render()
+        .unwrap_or_else(|_| content.to_string())
+}


### PR DESCRIPTION
bring `pretty_print_wasm` back for temporary compatibility.

also move "ci: building docs on PR" here from other drafting PRs