### PR TITLE
feat(cli): add timing option to show elapsed time for formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Format Configuration:
 Debug Options:
   -a, --ast         Print the AST of the input file
   -p, --pretty-doc  Print the pretty document
+      --timing      Show elapsed time taken by the formatter
 
 Log Levels:
   -v, --verbose  Enable verbose logging

--- a/crates/typstyle/src/cli.rs
+++ b/crates/typstyle/src/cli.rs
@@ -100,6 +100,10 @@ pub struct DebugArgs {
     /// Print the pretty document
     #[arg(short, long, default_value_t = false)]
     pub pretty_doc: bool,
+
+    /// Show elapsed time taken by the formatter
+    #[arg(long, default_value_t = false)]
+    pub timing: bool,
 }
 
 #[derive(Args)]


### PR DESCRIPTION
A useful feature for developers and users to observe its performance.
The parsing time is not included.

Example:

```
$ typstyle a.typ --check --timing
Formatting completed in 109.4µs
Would reformat: a.typ
```

