### PR TITLE
fix: apply escape hatch to table header/footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Bug fix: Previously, `@typstyle off` is not correctly recognized for `{table,grid}.{header,footer}`. Now it is fixed.
+
 ### Playground
 
 - Feature: Added some loadable sample documents.

--- a/crates/typstyle-core/src/pretty/table.rs
+++ b/crates/typstyle-core/src/pretty/table.rs
@@ -46,12 +46,16 @@ impl<'a> PrettyPrinter<'a> {
             if let Some(arg) = node.cast::<Arg>() {
                 match arg {
                     Arg::Pos(Expr::FuncCall(func_call)) if is_header_footer(func_call) => {
-                        collector.push_row(
+                        // This func_call does not pass the escape-hatch check in `convert_expr`.
+                        let doc = if let Some(res) = self.check_disabled(func_call.to_untyped()) {
+                            res
+                        } else {
                             self.convert_expr(ctx, func_call.callee())
                                 + self.convert_args(ctx, func_call.args(), |nodes| {
                                     self.convert_table(ctx, nodes, columns)
-                                }),
-                        );
+                                })
+                        };
+                        collector.push_row(doc);
                     }
                     Arg::Pos(expr) => {
                         collector.push_cell(self.convert_expr(ctx, expr));

--- a/tests/fixtures/unit/table/off.typ
+++ b/tests/fixtures/unit/table/off.typ
@@ -1,0 +1,20 @@
+// @typstyle off
+#grid(  )
+
+#table(
+  // @typstyle off
+  table.header(  )[#(  )],
+  // @typstyle off
+  table.cell(  )[#(  )],
+  // @typstyle off
+  table.footer(  )[#(  )],
+)
+
+#grid(
+  // @typstyle off
+  grid.header(  )[#(  )],
+  // @typstyle off
+  grid.cell(  )[#(  )],
+  // @typstyle off
+  grid.footer(  )[#(  )],
+)

--- a/tests/fixtures/unit/table/snap/off.typ-0.snap
+++ b/tests/fixtures/unit/table/snap/off.typ-0.snap
@@ -1,0 +1,24 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/table/off.typ
+---
+// @typstyle off
+#grid(  )
+
+#table(
+  // @typstyle off
+  table.header(  )[#(  )],
+  // @typstyle off
+  table.cell(  )[#(  )],
+  // @typstyle off
+  table.footer(  )[#(  )],
+)
+
+#grid(
+  // @typstyle off
+  grid.header(  )[#(  )],
+  // @typstyle off
+  grid.cell(  )[#(  )],
+  // @typstyle off
+  grid.footer(  )[#(  )],
+)

--- a/tests/fixtures/unit/table/snap/off.typ-120.snap
+++ b/tests/fixtures/unit/table/snap/off.typ-120.snap
@@ -1,0 +1,24 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/table/off.typ
+---
+// @typstyle off
+#grid(  )
+
+#table(
+  // @typstyle off
+  table.header(  )[#(  )],
+  // @typstyle off
+  table.cell(  )[#(  )],
+  // @typstyle off
+  table.footer(  )[#(  )],
+)
+
+#grid(
+  // @typstyle off
+  grid.header(  )[#(  )],
+  // @typstyle off
+  grid.cell(  )[#(  )],
+  // @typstyle off
+  grid.footer(  )[#(  )],
+)

--- a/tests/fixtures/unit/table/snap/off.typ-40.snap
+++ b/tests/fixtures/unit/table/snap/off.typ-40.snap
@@ -1,0 +1,24 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/table/off.typ
+---
+// @typstyle off
+#grid(  )
+
+#table(
+  // @typstyle off
+  table.header(  )[#(  )],
+  // @typstyle off
+  table.cell(  )[#(  )],
+  // @typstyle off
+  table.footer(  )[#(  )],
+)
+
+#grid(
+  // @typstyle off
+  grid.header(  )[#(  )],
+  // @typstyle off
+  grid.cell(  )[#(  )],
+  // @typstyle off
+  grid.footer(  )[#(  )],
+)

--- a/tests/fixtures/unit/table/snap/off.typ-80.snap
+++ b/tests/fixtures/unit/table/snap/off.typ-80.snap
@@ -1,0 +1,24 @@
+---
+source: tests/src/unit.rs
+input_file: tests/fixtures/unit/table/off.typ
+---
+// @typstyle off
+#grid(  )
+
+#table(
+  // @typstyle off
+  table.header(  )[#(  )],
+  // @typstyle off
+  table.cell(  )[#(  )],
+  // @typstyle off
+  table.footer(  )[#(  )],
+)
+
+#grid(
+  // @typstyle off
+  grid.header(  )[#(  )],
+  // @typstyle off
+  grid.cell(  )[#(  )],
+  // @typstyle off
+  grid.footer(  )[#(  )],
+)


### PR DESCRIPTION
## Summary

Fixes #431.

## Changes

`{table,grid}.{header,footer}` are handled specially. We did not check whether their formatting is disabled. Now this is fixed.

## Checklist

Before submitting, please ensure you've done the following:

- [x] **Updated CHANGELOG.md**: Added your changes with examples to the changelog
- [x] **Updated documentation**: Updated relevant docs, examples, or README
- [x] **Added tests**: Added tests for new features or bug fixes

## Testing

<!-- How did you test these changes? -->

## Additional Notes

<!-- Any additional context or notes -->
