### PR TITLE
fix: remove mention of `--collapse-spaces` in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Format Configuration:
   -l, --line-width <LINE_WIDTH>      Maximum width of each line [default: 80] [aliases: column] [short aliases: c]
   -t, --indent-width <INDENT_WIDTH>  Number of spaces per indentation level [default: 2] [aliases: tab-width]
       --no-reorder-import-items      Disable alphabetical reordering of import items
-      --wrap-text                    Wrap text in markup to fit within the line width. Implies `--collapse-spaces`
+      --wrap-text                    Wrap text in markup to fit within the line width, and collapse spaces in markup
 
 Debug Options:
   -a, --ast         Print the AST of the input file

--- a/crates/typstyle/src/cli.rs
+++ b/crates/typstyle/src/cli.rs
@@ -91,7 +91,7 @@ pub struct StyleArgs {
     #[arg(long, default_value_t = false, global = true)]
     pub no_reorder_import_items: bool,
 
-    /// Wrap text in markup to fit within the line width. Implies `--collapse-spaces`.
+    /// Wrap text in markup to fit within the line width, and collapse spaces in markup
     #[arg(long, default_value_t = false, global = true)]
     pub wrap_text: bool,
 }


### PR DESCRIPTION
## Summary

Closes #427

## Changes

## Checklist

Before submitting, please ensure you've done the following:

- [x] **Updated CHANGELOG.md**: Added your changes with examples to the changelog
- [x] **Updated documentation**: Updated relevant docs, examples, or README
- [x] **Added tests**: Added tests for new features or bug fixes

## Testing

<!-- How did you test these changes? -->

## Additional Notes

<!-- Any additional context or notes -->
