### PR TITLE
revert: do not indent strong/emph body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Bug fix: Previously, `@typstyle off` is not correctly recognized for `{table,grid}.{header,footer}`. Now it is fixed.
+- Revert: The body of strong/emph is no longer indented.
 
 ### Playground
 

--- a/crates/typstyle-core/src/pretty/markup.rs
+++ b/crates/typstyle-core/src/pretty/markup.rs
@@ -247,7 +247,7 @@ impl<'a> PrettyPrinter<'a> {
         let open = get_delim(repr.start_bound);
         let close = get_delim(repr.end_bound);
         // Do not indent (compact), if the opening will not break.
-        let needs_indent = matches!(scope, MarkupScope::ContentBlock | MarkupScope::Strong)
+        let needs_indent = matches!(scope, MarkupScope::ContentBlock)
             && !(matches!(*open, Doc::Nil | Doc::Text(_))
                 && contains_exactly_one_primary_expr(markup));
         let body_with_before = open + body;

--- a/tests/fixtures/ai/basic/snap/presentation.typ-0.snap
+++ b/tests/fixtures/ai/basic/snap/presentation.typ-0.snap
@@ -43,10 +43,10 @@ input_file: tests/fixtures/ai/basic/presentation.typ
   )
 
   _Presenter
-    Name
-    •
-    Conference
-    2024_
+  Name
+  •
+  Conference
+  2024_
 ]
 
 #pagebreak()

--- a/tests/fixtures/ai/basic/snap/technical.typ-0.snap
+++ b/tests/fixtures/ai/basic/snap/technical.typ-0.snap
@@ -92,19 +92,19 @@ Authorization: Bearer YOUR_API_KEY
 
 == Rate Limiting
 - *Standard
-    users:*
+  users:*
   100
   requests
   per
   minute
 - *Premium
-    users:*
+  users:*
   1000
   requests
   per
   minute
 - *Enterprise
-    users:*
+  users:*
   10000
   requests
   per
@@ -457,7 +457,7 @@ languages:
   ),
 )[
   *Need
-    Help?*
+  Help?*
   Contact
   our
   developer

--- a/tests/fixtures/ai/feat/snap/mixed-content.typ-0.snap
+++ b/tests/fixtures/ai/feat/snap/mixed-content.typ-0.snap
@@ -515,8 +515,8 @@ These results have important implications for future research directions and pra
   center,
 )[
   _This document contains #{
-      // Count total words approximately
-      let content-words = 850 // Approximate word count
-      content-words
-    } words and was automatically formatted using Typstyle._
+    // Count total words approximately
+    let content-words = 850 // Approximate word count
+    content-words
+  } words and was automatically formatted using Typstyle._
 ]

--- a/tests/fixtures/ai/feat/snap/mixed-content.typ-120.snap
+++ b/tests/fixtures/ai/feat/snap/mixed-content.typ-120.snap
@@ -242,8 +242,8 @@ These results have important implications for future research directions and pra
 
 #align(center)[
   _This document contains #{
-      // Count total words approximately
-      let content-words = 850 // Approximate word count
-      content-words
-    } words and was automatically formatted using Typstyle._
+    // Count total words approximately
+    let content-words = 850 // Approximate word count
+    content-words
+  } words and was automatically formatted using Typstyle._
 ]

--- a/tests/fixtures/ai/feat/snap/mixed-content.typ-40.snap
+++ b/tests/fixtures/ai/feat/snap/mixed-content.typ-40.snap
@@ -350,8 +350,8 @@ These results have important implications for future research directions and pra
 
 #align(center)[
   _This document contains #{
-      // Count total words approximately
-      let content-words = 850 // Approximate word count
-      content-words
-    } words and was automatically formatted using Typstyle._
+    // Count total words approximately
+    let content-words = 850 // Approximate word count
+    content-words
+  } words and was automatically formatted using Typstyle._
 ]

--- a/tests/fixtures/ai/feat/snap/mixed-content.typ-80.snap
+++ b/tests/fixtures/ai/feat/snap/mixed-content.typ-80.snap
@@ -252,8 +252,8 @@ These results have important implications for future research directions and pra
 
 #align(center)[
   _This document contains #{
-      // Count total words approximately
-      let content-words = 850 // Approximate word count
-      content-words
-    } words and was automatically formatted using Typstyle._
+    // Count total words approximately
+    let content-words = 850 // Approximate word count
+    content-words
+  } words and was automatically formatted using Typstyle._
 ]

--- a/tests/fixtures/articles/snap/serve.typ-0.snap
+++ b/tests/fixtures/articles/snap/serve.typ-0.snap
@@ -25,7 +25,7 @@ typst-book serve
 // connection is used to trigger the client-side refresh.
 
 ***Note:*** *The `serve` command is for testing a book's HTML output, and is not
-  intended to be a complete HTTP server for a website.*
+intended to be a complete HTTP server for a website.*
 
 == Specify a directory
 

--- a/tests/fixtures/articles/snap/serve.typ-120.snap
+++ b/tests/fixtures/articles/snap/serve.typ-120.snap
@@ -21,7 +21,7 @@ typst-book serve
 // connection is used to trigger the client-side refresh.
 
 ***Note:*** *The `serve` command is for testing a book's HTML output, and is not
-  intended to be a complete HTTP server for a website.*
+intended to be a complete HTTP server for a website.*
 
 == Specify a directory
 

--- a/tests/fixtures/articles/snap/serve.typ-40.snap
+++ b/tests/fixtures/articles/snap/serve.typ-40.snap
@@ -25,7 +25,7 @@ typst-book serve
 // connection is used to trigger the client-side refresh.
 
 ***Note:*** *The `serve` command is for testing a book's HTML output, and is not
-  intended to be a complete HTTP server for a website.*
+intended to be a complete HTTP server for a website.*
 
 == Specify a directory
 

--- a/tests/fixtures/articles/snap/serve.typ-80.snap
+++ b/tests/fixtures/articles/snap/serve.typ-80.snap
@@ -21,7 +21,7 @@ typst-book serve
 // connection is used to trigger the client-side refresh.
 
 ***Note:*** *The `serve` command is for testing a book's HTML output, and is not
-  intended to be a complete HTTP server for a website.*
+intended to be a complete HTTP server for a website.*
 
 == Specify a directory
 

--- a/tests/fixtures/unit/document/snap/top-comment.typ-0.snap
+++ b/tests/fixtures/unit/document/snap/top-comment.typ-0.snap
@@ -7,4 +7,4 @@ input_file: tests/fixtures/unit/document/top-comment.typ
 
 Something else
 1*
-  2* 3
+2* 3

--- a/tests/fixtures/unit/document/snap/top-comment.typ-120.snap
+++ b/tests/fixtures/unit/document/snap/top-comment.typ-120.snap
@@ -7,4 +7,4 @@ input_file: tests/fixtures/unit/document/top-comment.typ
 
 Something else
 1*
-  2* 3
+2* 3

--- a/tests/fixtures/unit/document/snap/top-comment.typ-40.snap
+++ b/tests/fixtures/unit/document/snap/top-comment.typ-40.snap
@@ -7,4 +7,4 @@ input_file: tests/fixtures/unit/document/top-comment.typ
 
 Something else
 1*
-  2* 3
+2* 3

--- a/tests/fixtures/unit/document/snap/top-comment.typ-80.snap
+++ b/tests/fixtures/unit/document/snap/top-comment.typ-80.snap
@@ -7,4 +7,4 @@ input_file: tests/fixtures/unit/document/top-comment.typ
 
 Something else
 1*
-  2* 3
+2* 3

--- a/tests/fixtures/unit/markup/reflow/snap/commented.typ-0.snap
+++ b/tests/fixtures/unit/markup/reflow/snap/commented.typ-0.snap
@@ -40,7 +40,7 @@ with
 mixed
 with
 *strong
-  text*
+text*
 and
 $"math" "equations"$
 to
@@ -79,7 +79,7 @@ case
 mixing
 everything:
 *bold
-  text*
+text*
 // comment after strong
 `code block`
 /* block comment */

--- a/tests/fixtures/unit/markup/reflow/snap/commented.typ-40.snap
+++ b/tests/fixtures/unit/markup/reflow/snap/commented.typ-40.snap
@@ -25,7 +25,7 @@ term / definition // comment after slash
 heading = title // comment after equals
 
 A complex case mixing everything: *bold
-  text* // comment after strong
+text* // comment after strong
 `code block` /* block comment */ with
 $"math"$ // final comment
 and #text(red)[colored text] // with formatting

--- a/tests/fixtures/unit/markup/reflow/snap/general.typ-0.snap
+++ b/tests/fixtures/unit/markup/reflow/snap/general.typ-0.snap
@@ -102,7 +102,7 @@ This
 line
 contains
 *strong
-  text*
+text*
 mixed
 with
 `raw code`
@@ -145,7 +145,7 @@ $F = m a$
 inline
 with
 _emphasized
-  words_
+words_
 and
 `code snippets`.
 
@@ -173,7 +173,7 @@ like
 mixed
 with
 *important
-  notes*
+notes*
 and
 $sum_(i=1)^n x_i$.
 
@@ -184,7 +184,7 @@ $sum_(i=1)^n x_i$.
   item
   with
   *bold
-    text*
+  text*
   and
   $alpha$
   equation
@@ -306,9 +306,9 @@ $sum_(i=1)^n x_i$.
       auto,
     ),
     [*Header
-      1*],
+    1*],
     [*Header
-      2*],
+    2*],
 
     [Content],
     [More
@@ -445,7 +445,7 @@ item:
   It
   contains
   *strong
-    text*,
+  text*,
   `inline code`,
   and
   $"math" = "elements"$

--- a/tests/fixtures/unit/markup/reflow/snap/general.typ-80.snap
+++ b/tests/fixtures/unit/markup/reflow/snap/general.typ-80.snap
@@ -31,7 +31,7 @@ Testing _multiple_ `inline` $"elements"$ in a single line with various _spacing_
 patterns.
 
 Some text with equations $E = m c^2$ and $F = m a$ inline with _emphasized
-  words_ and `code snippets`.
+words_ and `code snippets`.
 
 Here's a paragraph with line breaks and multiple spaces to test reflow behavior
 with $"complex" = (a + b)^2$ equations.

--- a/tests/fixtures/unit/markup/reflow/snap/marker.typ-0.snap
+++ b/tests/fixtures/unit/markup/reflow/snap/marker.typ-0.snap
@@ -136,7 +136,7 @@ Discussion
 of
 point 3.
 *with
-  emphasis*.
+emphasis*.
 Reference
 to
 section 4.

--- a/tests/fixtures/unit/markup/reflow/snap/marker.typ-120.snap
+++ b/tests/fixtures/unit/markup/reflow/snap/marker.typ-120.snap
@@ -29,7 +29,7 @@ break (overflow).
 
 // Punctuation after potential markers
 Sentence about version 1. (with parentheses). Text mentioning chapter 2. "with quotes". Discussion of point 3. *with
-  emphasis*. Reference to section 4. `with code`. Price is \$5. New sentence starts here.
+emphasis*. Reference to section 4. `with code`. Price is \$5. New sentence starts here.
 
 // === enum markers ===
 01. Item with leading zero.

--- a/tests/fixtures/unit/markup/reflow/snap/spaces.typ-0.snap
+++ b/tests/fixtures/unit/markup/reflow/snap/spaces.typ-0.snap
@@ -7,7 +7,7 @@ input_file: tests/fixtures/unit/markup/reflow/spaces.typ
 Nested
 #strong[
   *
-    bold
+  bold
   *
   *inside
   *

--- a/tests/fixtures/unit/markup/reflow/snap/unicode.typ-0.snap
+++ b/tests/fixtures/unit/markup/reflow/snap/unicode.typ-0.snap
@@ -74,7 +74,7 @@ English,
 https://site.com/页面
 链接和
 *formatted
-  text*
+text*
 `code`
 $e = m c^2$
 等多种元素。テスト。

--- a/tests/fixtures/unit/markup/snap/content-compact-reflow.typ-0.snap
+++ b/tests/fixtures/unit/markup/snap/content-compact-reflow.typ-0.snap
@@ -37,11 +37,11 @@ input_file: tests/fixtures/unit/markup/content-compact-reflow.typ
 #[*strong
 *]
 #[_
-  emph_]
+emph_]
 #[*
-  _
-    strong-emph
-  _
+_
+strong-emph
+_
 *]
 
 #[#{}]

--- a/tests/fixtures/unit/markup/snap/content-compact-reflow.typ-120.snap
+++ b/tests/fixtures/unit/markup/snap/content-compact-reflow.typ-120.snap
@@ -22,11 +22,11 @@ input_file: tests/fixtures/unit/markup/content-compact-reflow.typ
 #[*strong
 *]
 #[_
-  emph_]
+emph_]
 #[*
-  _
-    strong-emph
-  _
+_
+strong-emph
+_
 *]
 
 #[#{}]

--- a/tests/fixtures/unit/markup/snap/content-compact-reflow.typ-40.snap
+++ b/tests/fixtures/unit/markup/snap/content-compact-reflow.typ-40.snap
@@ -22,11 +22,11 @@ input_file: tests/fixtures/unit/markup/content-compact-reflow.typ
 #[*strong
 *]
 #[_
-  emph_]
+emph_]
 #[*
-  _
-    strong-emph
-  _
+_
+strong-emph
+_
 *]
 
 #[#{}]

--- a/tests/fixtures/unit/markup/snap/content-compact-reflow.typ-80.snap
+++ b/tests/fixtures/unit/markup/snap/content-compact-reflow.typ-80.snap
@@ -22,11 +22,11 @@ input_file: tests/fixtures/unit/markup/content-compact-reflow.typ
 #[*strong
 *]
 #[_
-  emph_]
+emph_]
 #[*
-  _
-    strong-emph
-  _
+_
+strong-emph
+_
 *]
 
 #[#{}]

--- a/tests/fixtures/unit/markup/snap/content-compact.typ-0.snap
+++ b/tests/fixtures/unit/markup/snap/content-compact.typ-0.snap
@@ -35,9 +35,9 @@ input_file: tests/fixtures/unit/markup/content-compact.typ
 #[*strong
 *]
 #[_
-  emph_]
+emph_]
 #[* _
-  strong-emph
+strong-emph
 _ *]
 
 #[#{}]

--- a/tests/fixtures/unit/markup/snap/content-compact.typ-120.snap
+++ b/tests/fixtures/unit/markup/snap/content-compact.typ-120.snap
@@ -23,9 +23,9 @@ input_file: tests/fixtures/unit/markup/content-compact.typ
 #[*strong
 *]
 #[_
-  emph_]
+emph_]
 #[* _
-  strong-emph
+strong-emph
 _ *]
 
 #[#{}]

--- a/tests/fixtures/unit/markup/snap/content-compact.typ-40.snap
+++ b/tests/fixtures/unit/markup/snap/content-compact.typ-40.snap
@@ -23,9 +23,9 @@ input_file: tests/fixtures/unit/markup/content-compact.typ
 #[*strong
 *]
 #[_
-  emph_]
+emph_]
 #[* _
-  strong-emph
+strong-emph
 _ *]
 
 #[#{}]

--- a/tests/fixtures/unit/markup/snap/content-compact.typ-80.snap
+++ b/tests/fixtures/unit/markup/snap/content-compact.typ-80.snap
@@ -23,9 +23,9 @@ input_file: tests/fixtures/unit/markup/content-compact.typ
 #[*strong
 *]
 #[_
-  emph_]
+emph_]
 #[* _
-  strong-emph
+strong-emph
 _ *]
 
 #[#{}]

--- a/tests/fixtures/unit/markup/snap/spaces2-collapse.typ-0.snap
+++ b/tests/fixtures/unit/markup/snap/spaces2-collapse.typ-0.snap
@@ -22,10 +22,10 @@ Spaces can turn to line breaks in the following cases:
 
 * in strong syntax *
 * in
-  multiline
-  strong syntax *
+multiline
+strong syntax *
 _
-  in emph syntax
+in emph syntax
 _
 
 

--- a/tests/fixtures/unit/markup/snap/spaces2-collapse.typ-120.snap
+++ b/tests/fixtures/unit/markup/snap/spaces2-collapse.typ-120.snap
@@ -22,10 +22,10 @@ Spaces can turn to line breaks in the following cases:
 
 * in strong syntax *
 * in
-  multiline
-  strong syntax *
+multiline
+strong syntax *
 _
-  in emph syntax
+in emph syntax
 _
 
 

--- a/tests/fixtures/unit/markup/snap/spaces2-collapse.typ-40.snap
+++ b/tests/fixtures/unit/markup/snap/spaces2-collapse.typ-40.snap
@@ -22,10 +22,10 @@ Spaces can turn to line breaks in the following cases:
 
 * in strong syntax *
 * in
-  multiline
-  strong syntax *
+multiline
+strong syntax *
 _
-  in emph syntax
+in emph syntax
 _
 
 

--- a/tests/fixtures/unit/markup/snap/spaces2-collapse.typ-80.snap
+++ b/tests/fixtures/unit/markup/snap/spaces2-collapse.typ-80.snap
@@ -22,10 +22,10 @@ Spaces can turn to line breaks in the following cases:
 
 * in strong syntax *
 * in
-  multiline
-  strong syntax *
+multiline
+strong syntax *
 _
-  in emph syntax
+in emph syntax
 _
 
 

--- a/tests/fixtures/unit/markup/snap/spaces2-reflow.typ-0.snap
+++ b/tests/fixtures/unit/markup/snap/spaces2-reflow.typ-0.snap
@@ -53,20 +53,20 @@ cases:
 ]
 
 *
-  in
-  strong
-  syntax
+in
+strong
+syntax
 *
 *
-  in
-  multiline
-  strong
-  syntax
+in
+multiline
+strong
+syntax
 *
 _
-  in
-  emph
-  syntax
+in
+emph
+syntax
 _
 
 

--- a/tests/fixtures/unit/markup/snap/spaces2-reflow.typ-120.snap
+++ b/tests/fixtures/unit/markup/snap/spaces2-reflow.typ-120.snap
@@ -23,7 +23,7 @@ Spaces can turn to line breaks in the following cases:
 * in strong syntax *
 * in multiline strong syntax *
 _
-  in emph syntax
+in emph syntax
 _
 
 

--- a/tests/fixtures/unit/markup/snap/spaces2-reflow.typ-40.snap
+++ b/tests/fixtures/unit/markup/snap/spaces2-reflow.typ-40.snap
@@ -25,7 +25,7 @@ following cases:
 * in strong syntax *
 * in multiline strong syntax *
 _
-  in emph syntax
+in emph syntax
 _
 
 

--- a/tests/fixtures/unit/markup/snap/spaces2-reflow.typ-80.snap
+++ b/tests/fixtures/unit/markup/snap/spaces2-reflow.typ-80.snap
@@ -23,7 +23,7 @@ Spaces can turn to line breaks in the following cases:
 * in strong syntax *
 * in multiline strong syntax *
 _
-  in emph syntax
+in emph syntax
 _
 
 

--- a/tests/fixtures/unit/markup/snap/spaces2.typ-0.snap
+++ b/tests/fixtures/unit/markup/snap/spaces2.typ-0.snap
@@ -20,10 +20,10 @@ Spaces can turn to line breaks in the following cases:
 
 * in strong syntax *
 * in
-  multiline
-  strong syntax *
+multiline
+strong syntax *
 _
-  in emph syntax
+in emph syntax
 _
 
 

--- a/tests/fixtures/unit/markup/snap/spaces2.typ-120.snap
+++ b/tests/fixtures/unit/markup/snap/spaces2.typ-120.snap
@@ -20,10 +20,10 @@ Spaces can turn to line breaks in the following cases:
 
 * in strong syntax *
 * in
-  multiline
-  strong syntax *
+multiline
+strong syntax *
 _
-  in emph syntax
+in emph syntax
 _
 
 

--- a/tests/fixtures/unit/markup/snap/spaces2.typ-40.snap
+++ b/tests/fixtures/unit/markup/snap/spaces2.typ-40.snap
@@ -20,10 +20,10 @@ Spaces can turn to line breaks in the following cases:
 
 * in strong syntax *
 * in
-  multiline
-  strong syntax *
+multiline
+strong syntax *
 _
-  in emph syntax
+in emph syntax
 _
 
 

--- a/tests/fixtures/unit/markup/snap/spaces2.typ-80.snap
+++ b/tests/fixtures/unit/markup/snap/spaces2.typ-80.snap
@@ -20,10 +20,10 @@ Spaces can turn to line breaks in the following cases:
 
 * in strong syntax *
 * in
-  multiline
-  strong syntax *
+multiline
+strong syntax *
 _
-  in emph syntax
+in emph syntax
 _
 
 

--- a/tests/fixtures/unit/markup/snap/strong-multiline.typ-0.snap
+++ b/tests/fixtures/unit/markup/snap/strong-multiline.typ-0.snap
@@ -5,19 +5,19 @@ input_file: tests/fixtures/unit/markup/strong-multiline.typ
 // DUMMY
 
 *11111
-  111*
+111*
 
 * 11111
-  111 *
+111 *
 
 *22222
-  222
+222
 *
 
 *
-  333
+333
 *
 
 * #text(fill: red)[555]
-  aaaaa
+aaaaa
 *

--- a/tests/fixtures/unit/markup/snap/strong-multiline.typ-120.snap
+++ b/tests/fixtures/unit/markup/snap/strong-multiline.typ-120.snap
@@ -5,19 +5,19 @@ input_file: tests/fixtures/unit/markup/strong-multiline.typ
 // DUMMY
 
 *11111
-  111*
+111*
 
 * 11111
-  111 *
+111 *
 
 *22222
-  222
+222
 *
 
 *
-  333
+333
 *
 
 * #text(fill: red)[555]
-  aaaaa
+aaaaa
 *

--- a/tests/fixtures/unit/markup/snap/strong-multiline.typ-40.snap
+++ b/tests/fixtures/unit/markup/snap/strong-multiline.typ-40.snap
@@ -5,19 +5,19 @@ input_file: tests/fixtures/unit/markup/strong-multiline.typ
 // DUMMY
 
 *11111
-  111*
+111*
 
 * 11111
-  111 *
+111 *
 
 *22222
-  222
+222
 *
 
 *
-  333
+333
 *
 
 * #text(fill: red)[555]
-  aaaaa
+aaaaa
 *

--- a/tests/fixtures/unit/markup/snap/strong-multiline.typ-80.snap
+++ b/tests/fixtures/unit/markup/snap/strong-multiline.typ-80.snap
@@ -5,19 +5,19 @@ input_file: tests/fixtures/unit/markup/strong-multiline.typ
 // DUMMY
 
 *11111
-  111*
+111*
 
 * 11111
-  111 *
+111 *
 
 *22222
-  222
+222
 *
 
 *
-  333
+333
 *
 
 * #text(fill: red)[555]
-  aaaaa
+aaaaa
 *

--- a/tests/fixtures/unit/markup/snap/strong-space.typ-0.snap
+++ b/tests/fixtures/unit/markup/snap/strong-space.typ-0.snap
@@ -17,13 +17,13 @@ Mixed spacing: * bold*   *bold * *  bold  *
 // Line breaks with strong elements
 Line
 *breaks
-  inside* strong and text *across
-  multiple
-  lines* with content
+inside* strong and text *across
+multiple
+lines* with content
 
 // Complex nesting with inconsistent spacing
 Nested: *bold with _emphasis_ inside* vs * bold with _nested
-    emphasis_ across lines*
+emphasis_ across lines*
 
 // Strong elements in structural elements
 - List item with*no space*around strong
@@ -32,7 +32,7 @@ Nested: *bold with _emphasis_ inside* vs * bold with _nested
 // Different contexts
 "Quotation with *strong * element"
 #text()[Text function with *strong* and * bad
-    spacing *]
+  spacing *]
 
 // Mixed languages with spacing issues
 English and *中文* mixed with*不同*spacing patterns
@@ -48,4 +48,4 @@ English and *中文* mixed with*不同*spacing patterns
 中文测试：*无空格* text，前空格 *有空格*，后空格 *有空格* text，*内部 空格*，
 行
 *跨越
-  换行* 以及 *嵌套 _强调_* *相邻*  *元素*
+换行* 以及 *嵌套 _强调_* *相邻*  *元素*

--- a/tests/fixtures/unit/markup/snap/strong-space.typ-120.snap
+++ b/tests/fixtures/unit/markup/snap/strong-space.typ-120.snap
@@ -17,13 +17,13 @@ Mixed spacing: * bold*   *bold * *  bold  *
 // Line breaks with strong elements
 Line
 *breaks
-  inside* strong and text *across
-  multiple
-  lines* with content
+inside* strong and text *across
+multiple
+lines* with content
 
 // Complex nesting with inconsistent spacing
 Nested: *bold with _emphasis_ inside* vs * bold with _nested
-    emphasis_ across lines*
+emphasis_ across lines*
 
 // Strong elements in structural elements
 - List item with*no space*around strong
@@ -32,7 +32,7 @@ Nested: *bold with _emphasis_ inside* vs * bold with _nested
 // Different contexts
 "Quotation with *strong * element"
 #text()[Text function with *strong* and * bad
-    spacing *]
+  spacing *]
 
 // Mixed languages with spacing issues
 English and *中文* mixed with*不同*spacing patterns
@@ -48,4 +48,4 @@ English and *中文* mixed with*不同*spacing patterns
 中文测试：*无空格* text，前空格 *有空格*，后空格 *有空格* text，*内部 空格*，
 行
 *跨越
-  换行* 以及 *嵌套 _强调_* *相邻*  *元素*
+换行* 以及 *嵌套 _强调_* *相邻*  *元素*

--- a/tests/fixtures/unit/markup/snap/strong-space.typ-40.snap
+++ b/tests/fixtures/unit/markup/snap/strong-space.typ-40.snap
@@ -17,13 +17,13 @@ Mixed spacing: * bold*   *bold * *  bold  *
 // Line breaks with strong elements
 Line
 *breaks
-  inside* strong and text *across
-  multiple
-  lines* with content
+inside* strong and text *across
+multiple
+lines* with content
 
 // Complex nesting with inconsistent spacing
 Nested: *bold with _emphasis_ inside* vs * bold with _nested
-    emphasis_ across lines*
+emphasis_ across lines*
 
 // Strong elements in structural elements
 - List item with*no space*around strong
@@ -32,7 +32,7 @@ Nested: *bold with _emphasis_ inside* vs * bold with _nested
 // Different contexts
 "Quotation with *strong * element"
 #text()[Text function with *strong* and * bad
-    spacing *]
+  spacing *]
 
 // Mixed languages with spacing issues
 English and *中文* mixed with*不同*spacing patterns
@@ -48,4 +48,4 @@ English and *中文* mixed with*不同*spacing patterns
 中文测试：*无空格* text，前空格 *有空格*，后空格 *有空格* text，*内部 空格*，
 行
 *跨越
-  换行* 以及 *嵌套 _强调_* *相邻*  *元素*
+换行* 以及 *嵌套 _强调_* *相邻*  *元素*

--- a/tests/fixtures/unit/markup/snap/strong-space.typ-80.snap
+++ b/tests/fixtures/unit/markup/snap/strong-space.typ-80.snap
@@ -17,13 +17,13 @@ Mixed spacing: * bold*   *bold * *  bold  *
 // Line breaks with strong elements
 Line
 *breaks
-  inside* strong and text *across
-  multiple
-  lines* with content
+inside* strong and text *across
+multiple
+lines* with content
 
 // Complex nesting with inconsistent spacing
 Nested: *bold with _emphasis_ inside* vs * bold with _nested
-    emphasis_ across lines*
+emphasis_ across lines*
 
 // Strong elements in structural elements
 - List item with*no space*around strong
@@ -32,7 +32,7 @@ Nested: *bold with _emphasis_ inside* vs * bold with _nested
 // Different contexts
 "Quotation with *strong * element"
 #text()[Text function with *strong* and * bad
-    spacing *]
+  spacing *]
 
 // Mixed languages with spacing issues
 English and *中文* mixed with*不同*spacing patterns
@@ -48,4 +48,4 @@ English and *中文* mixed with*不同*spacing patterns
 中文测试：*无空格* text，前空格 *有空格*，后空格 *有空格* text，*内部 空格*，
 行
 *跨越
-  换行* 以及 *嵌套 _强调_* *相邻*  *元素*
+换行* 以及 *嵌套 _强调_* *相邻*  *元素*

--- a/tests/src/partial.rs
+++ b/tests/src/partial.rs
@@ -1,4 +1,4 @@
-use std::{env, ops::Range, path::Path};
+use std::{ops::Range, path::Path};
 
 use insta::internals::Content;
 use libtest_mimic::{Failed, Trial};


### PR DESCRIPTION
## Summary

Closes #421. Reverts the indentation of strong/emph introduced in #400.

I have no idea which is better. But as the body can reflow, the original style may still be better.

## Changes

<!-- List the key changes made -->
- 
- 
- 

## Checklist

Before submitting, please ensure you've done the following:

- [x] **Updated CHANGELOG.md**: Added your changes with examples to the changelog
- [x] **Updated documentation**: Updated relevant docs, examples, or README
- [x] **Added tests**: Added tests for new features or bug fixes

## Testing

<!-- How did you test these changes? -->

## Additional Notes

<!-- Any additional context or notes -->
