### PR TITLE
fix(ci): remove uploading artifacts step from publish-wasm

### DIFF
--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -71,9 +71,3 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: crates/typstyle-wasm/pkg
         run: npm publish --provenance --access public
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: typstyle-wasm-${{ matrix.target }}
-          path: crates/typstyle-wasm/pkg/


### PR DESCRIPTION
Fixes https://github.com/typstyle-rs/typstyle/issues/418. Supersedes #419.

It is nonsense to upload artifacts in a publish workflow.

Alternative solution: Use a glob pattern `!typstyle-wasm-*` to exclude wasm artifacts from the download step.