### PR TITLE
ci: update macOS runners to macOS 15

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -36,7 +36,7 @@ jobs:
             rust-target: arm-unknown-linux-gnueabihf
             platform: linux
             arch: armhf
-          - os: macos-13
+          - os: macos-15-intel
             rust-target: x86_64-apple-darwin
             platform: darwin
             arch: x64


### PR DESCRIPTION
> The macOS-13 based runner images are being deprecated, consider switching to macOS-15 (macos-15-intel) or macOS 15 arm64 (macos-latest) instead. For more details see https://github.com/actions/runner-images/issues/13046

Update `build-binaries.yml` to use macOS 15 runners:
- `macos-13` → `macos-15-intel` (x86_64)
- `macos-latest` (arm64 entry) no change
