### PR TITLE
feat(test): revamp consistency and add fast paths for checking

### DIFF
--- a/.github/workflows/bench-job.yml
+++ b/.github/workflows/bench-job.yml
@@ -99,7 +99,7 @@ jobs:
         if: steps.check-cache.outputs.cache-hit != 'true'
         run: |
           echo "Running ${{ inputs.branch_type }} branch benchmark..."
-          cargo bench --workspace -- --save-baseline ${{ inputs.branch_type }}
+          cargo bench -p typstyle-core -- --save-baseline ${{ inputs.branch_type }}
 
       - name: Build release binary and collect bloat data
         if: steps.check-cache.outputs.cache-hit != 'true'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4122,13 +4122,18 @@ name = "typstyle-consistency"
 version = "0.14.4"
 dependencies = [
  "anyhow",
+ "colored",
  "fontdb",
+ "insta",
  "rustc-hash",
+ "similar",
  "similar-asserts",
+ "tiny-skia",
  "tinymist-world",
  "typst",
  "typst-assets",
  "typst-render",
+ "typst-shim",
  "walkdir",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4122,9 +4122,12 @@ name = "typstyle-consistency"
 version = "0.14.4"
 dependencies = [
  "anyhow",
+ "colored",
  "fontdb",
  "rustc-hash",
+ "similar",
  "similar-asserts",
+ "tiny-skia",
  "tinymist-world",
  "typst",
  "typst-assets",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4129,6 +4129,7 @@ dependencies = [
  "typst",
  "typst-assets",
  "typst-render",
+ "typst-shim",
  "walkdir",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ tempfile = "3"
 toml = "0.8"
 
 tinymist-world = { version = "0.14.6", default-features = false, features = ["system"] }
+typst-shim = { version = "0.14.6" }
 
 typst-assets = "0.14.2"
 typst-render = "0.14.2"

--- a/crates/typstyle-consistency/Cargo.toml
+++ b/crates/typstyle-consistency/Cargo.toml
@@ -20,8 +20,16 @@ similar-asserts.workspace = true
 rustc-hash.workspace = true
 
 tinymist-world.workspace = true
+typst-shim.workspace = true
 typst-assets.workspace = true
 typst-render.workspace = true
 typst.workspace = true
 
+colored.workspace = true
+similar.workspace = true
+tiny-skia = "*" # use the transitive dependency version
+
 fontdb = { version = "0.23", default-features = false, features = ["fs", "memmap"] } # tinymist-world missing features enabled
+
+[dev-dependencies]
+insta.workspace = true

--- a/crates/typstyle-consistency/Cargo.toml
+++ b/crates/typstyle-consistency/Cargo.toml
@@ -20,6 +20,7 @@ similar-asserts.workspace = true
 rustc-hash.workspace = true
 
 tinymist-world.workspace = true
+typst-shim.workspace = true
 typst-assets.workspace = true
 typst-render.workspace = true
 typst.workspace = true

--- a/crates/typstyle-consistency/Cargo.toml
+++ b/crates/typstyle-consistency/Cargo.toml
@@ -25,4 +25,8 @@ typst-assets.workspace = true
 typst-render.workspace = true
 typst.workspace = true
 
+colored.workspace = true
+similar.workspace = true
+tiny-skia = "*" # use the transitive dependency version
+
 fontdb = { version = "0.23", default-features = false, features = ["fs", "memmap"] } # tinymist-world missing features enabled

--- a/crates/typstyle-consistency/src/cmp.rs
+++ b/crates/typstyle-consistency/src/cmp.rs
@@ -3,128 +3,352 @@ use std::path::PathBuf;
 use anyhow::Result;
 use tinymist_world::SourceWorld;
 use typst::{
-    diag::SourceDiagnostic,
+    diag::{SourceDiagnostic, SourceResult},
     ecow::EcoVec,
-    foundations::Smart,
+    foundations::{Content, Repr, Smart},
     layout::{Page, PagedDocument},
 };
 
-use crate::{ErrorSink, sink_assert_eq};
+use crate::{ErrorSink, image_diff::compute_diff_pixmap, sink_assert_eq, text_diff::CodeDiff};
 
-pub struct Compiled<'a> {
+/// Options for comparing formatted documents with original ones.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct CheckingOptions {
+    /// Whether the document is expected to fail compilation (unused yet).
+    pub expect_error: bool,
+    /// Whether to enforce strict content equality.
+    pub strict_content_equality: bool,
+}
+
+/// Input for document comparison, consisting of a name and a world to compile.
+pub struct ComparisonInput<'a> {
     pub name: String,
     pub world: &'a dyn SourceWorld,
-    pub result: Result<PagedDocument, EcoVec<SourceDiagnostic>>,
 }
 
-pub fn compile_world(name: String, world: &dyn SourceWorld) -> Result<Compiled<'_>> {
-    let result = typst::compile(world.as_world()).output;
-
-    Ok(Compiled {
-        name,
-        world,
-        result,
-    })
+/// Evaluate the main source file to get its content without full compilation.
+/// This is cheaper than full compilation and used for the first equality check.
+fn eval_content(world: &dyn SourceWorld) -> SourceResult<Content> {
+    let main = world.source(world.main()).unwrap();
+    Ok(typst_shim::eval::eval_compat(world, &main)?.content())
 }
 
-pub fn compare_docs(
-    before: &Compiled,
-    after: &Compiled,
-    require_compile: bool,
+/// Compile a world into a paged document.
+fn compile_world(world: &dyn SourceWorld) -> Result<PagedDocument, EcoVec<SourceDiagnostic>> {
+    typst::compile(world.as_world()).output
+}
+
+/// Compare two documents for consistency, checking content equality first,
+/// then page equality, and finally rendering PNGs for any inconsistent pages.
+///
+/// The checking order is optimized to avoid expensive compilation when possible:
+/// 1. Check content equality (cheap) - if equal, done
+/// 2. Compile documents (expensive, only if content differs)
+/// 3. Check page equality by hash - if equal, done
+/// 4. Render PNGs only for pages that differ
+pub fn compare_worlds(
+    original: &ComparisonInput,
+    formatted: &ComparisonInput,
+    options: CheckingOptions,
     err_sink: &mut ErrorSink,
 ) -> Result<()> {
-    let mut sub_sink = ErrorSink::new(format!("comparing with `{}`", after.name));
-    compare_docs_impl(before, after, require_compile, &mut sub_sink)?;
+    let mut sub_sink = ErrorSink::new(format!("comparing with `{}`", formatted.name));
+    compare_worlds_impl(original, formatted, options, &mut sub_sink)?;
     sub_sink.sink_to(err_sink);
     Ok(())
 }
 
-fn compare_docs_impl(
-    before: &Compiled,
-    after: &Compiled,
-    require_compile: bool,
-    sub_sink: &mut ErrorSink,
+fn compare_worlds_impl(
+    original: &ComparisonInput,
+    formatted: &ComparisonInput,
+    options: CheckingOptions,
+    sink: &mut ErrorSink,
 ) -> Result<()> {
-    match (&before.result, &after.result) {
-        (Ok(doc_bf), Ok(doc_af)) => {
-            check_doc_meta(doc_bf, doc_af, sub_sink);
-            check_png(doc_bf, doc_af, &before.name, &after.name, sub_sink)?;
-        }
-        (Err(e1), Err(e2)) => {
-            if require_compile {
-                sub_sink.push("Both docs failed to compile.".to_string());
-                print_diagnostics(before.world, e1.iter())?;
+    // Step 1: Check content equality (cheap evaluation without full compilation)
+    let original_content = eval_content(original.world);
+    let formatted_content = eval_content(formatted.world);
+
+    match (&original_content, &formatted_content) {
+        (Ok(orig), Ok(fmt)) => {
+            // if options.expect_error {
+            //     sink.push("Both docs evaluated successfully, but were expected to fail.");
+            // }
+            if orig == fmt {
+                // Content matches - done
                 return Ok(());
             }
-
-            sink_assert_eq!(
-                sub_sink,
-                e1.len(),
-                e2.len(),
-                "The error counts are not consistent"
-            );
-            for (e1, e2) in e1.iter().zip(e2.iter()) {
-                sink_assert_eq!(
-                    sub_sink,
-                    e1.message,
-                    e2.message,
-                    "The error messages are not consistent after formatting"
-                );
+            // Content differs, need to compile and check pages
+            if options.strict_content_equality {
+                // If we didn't expect content differences, report it as hard error
+                let orig_repr = orig.repr();
+                let fmt_repr = fmt.repr();
+                let diff = CodeDiff::new(&orig_repr, &fmt_repr);
+                sink.push(format!(
+                    "Content differs between original and formatted documents:\n{diff}"
+                ));
+                if orig_repr == fmt_repr {
+                    sink.push("However, their representations are identical.");
+                }
             }
         }
-        (Err(e1), _) => {
-            sub_sink.push("Original doc failed to compile.".to_string());
-            print_diagnostics(before.world, e1.iter())?;
+        (Err(orig_err), Err(fmt_err)) => {
+            // Both failed to evaluate
+            // if !options.expect_error {
+            //     // Not expected to fail
+            //     sink.push("Both docs failed to evaluate, but were expected to succeed.");
+            // }
+            // Check that errors are consistent
+            check_error_consistency(orig_err, fmt_err, sink);
+            return Ok(());
         }
-        (_, Err(e2)) => {
-            sub_sink.push("Formatted doc failed to compile.".to_string());
-            print_diagnostics(after.world, e2.iter())?;
+        (Err(e), _) => {
+            sink.push(format!("Failed to evaluate original document: {e:#?}"));
+            return Ok(());
+        }
+        (_, Err(e)) => {
+            sink.push(format!("Failed to evaluate formatted document: {e:#?}"));
+            return Ok(());
+        }
+    }
+
+    // Step 2: Compile documents (expensive, only done if content differs)
+    let original_result = compile_world(original.world);
+    let formatted_result = compile_world(formatted.world);
+
+    match (&original_result, &formatted_result) {
+        (Ok(orig_doc), Ok(fmt_doc)) => {
+            // if options.expect_error {
+            //     sink.push("Both docs compiled successfully, but were expected to fail.");
+            //     return Ok(());
+            // }
+            // Both compiled successfully, check page equality
+            check_pages_equal(orig_doc, fmt_doc, &original.name, &formatted.name, sink)?;
+        }
+        (Err(orig_err), Err(fmt_err)) => {
+            // if !options.expect_error {
+            //     // Not expected to fail
+            //     sink.push("Both docs failed to compile, but were expected to succeed.");
+            // }
+            // Check that errors are consistent
+            check_error_consistency(orig_err, fmt_err, sink);
+            print_diagnostics(original.world, orig_err.iter())?;
+        }
+        (Err(e), _) => {
+            sink.push("Original doc failed to compile.");
+            print_diagnostics(original.world, e.iter())?;
+        }
+        (_, Err(e)) => {
+            sink.push("Formatted doc failed to compile.");
+            print_diagnostics(formatted.world, e.iter())?;
         }
     }
 
     Ok(())
 }
 
-fn check_doc_meta(left: &PagedDocument, right: &PagedDocument, sink: &mut ErrorSink) {
+/// Check that two error lists are consistent (same count and messages).
+fn check_error_consistency(
+    original_errors: &[SourceDiagnostic],
+    formatted_errors: &[SourceDiagnostic],
+    sink: &mut ErrorSink,
+) {
     sink_assert_eq!(
         sink,
-        left.pages.len(),
-        right.pages.len(),
+        original_errors.len(),
+        formatted_errors.len(),
+        "The error counts are not consistent"
+    );
+    for (orig, fmt) in original_errors.iter().zip(formatted_errors.iter()) {
+        sink_assert_eq!(
+            sink,
+            orig.message,
+            fmt.message,
+            "The error messages are not consistent after formatting"
+        );
+    }
+}
+
+/// Check that document metadata (page count, title, author, etc.) is consistent.
+fn check_doc_meta(original: &PagedDocument, formatted: &PagedDocument, sink: &mut ErrorSink) {
+    sink_assert_eq!(
+        sink,
+        original.pages.len(),
+        formatted.pages.len(),
         "The page counts are not consistent"
     );
     sink_assert_eq!(
         sink,
-        left.info.title,
-        right.info.title,
+        original.info.title,
+        formatted.info.title,
         "The titles are not consistent"
     );
     sink_assert_eq!(
         sink,
-        left.info.author,
-        right.info.author,
+        original.info.author,
+        formatted.info.author,
         "The authors are not consistent"
     );
     sink_assert_eq!(
         sink,
-        left.info.description,
-        right.info.description,
+        original.info.description,
+        formatted.info.description,
         "The descriptions are not consistent"
     );
     sink_assert_eq!(
         sink,
-        left.info.keywords,
-        right.info.keywords,
+        original.info.keywords,
+        formatted.info.keywords,
         "The keywords are not consistent"
     );
 }
 
-fn check_png(
-    before: &PagedDocument,
-    after: &PagedDocument,
-    before_name: &str,
-    after_name: &str,
+/// Check page equality between two documents.
+/// First checks metadata, then uses hash-based comparison for pages,
+/// and finally renders PNGs only for pages with metadata differences.
+fn check_pages_equal(
+    original: &PagedDocument,
+    formatted: &PagedDocument,
+    original_name: &str,
+    formatted_name: &str,
     sink: &mut ErrorSink,
-) -> anyhow::Result<()> {
+) -> Result<()> {
+    // Check document metadata
+    check_doc_meta(original, formatted, sink);
+
+    if original.pages.len() != formatted.pages.len() {
+        sink.push(format!(
+            "Page count mismatch: original has {} pages, formatted has {} pages",
+            original.pages.len(),
+            formatted.pages.len()
+        ));
+        // No early return here - continue to check pages
+    }
+
+    // Check page equality using hash comparison (fast)
+    if pages_equal_by_hash(original, formatted) {
+        // All pages match - we're done!
+        return Ok(());
+    }
+
+    // Pages differ by hash - check which pages have metadata differences and collect all with hash diff
+    let mut pages_with_hash_diff = Vec::new();
+    for (i, (orig_page, fmt_page)) in (original.pages.iter())
+        .zip(formatted.pages.iter())
+        .enumerate()
+    {
+        if page_hash(orig_page) == page_hash(fmt_page) {
+            continue;
+        }
+
+        pages_with_hash_diff.push(i);
+        let mut meta_sink = ErrorSink::new(String::new());
+        check_page_meta(i, orig_page, fmt_page, &mut meta_sink);
+        meta_sink.sink_to(sink);
+    }
+
+    // If no pages have hash differences
+    if pages_with_hash_diff.is_empty() {
+        // All pages match
+        return Ok(());
+    }
+
+    // Pages differ unexpectedly - render all pages with hash differences
+    render_diff_pages(
+        original,
+        formatted,
+        original_name,
+        formatted_name,
+        &pages_with_hash_diff,
+        sink,
+    )?;
+
+    Ok(())
+}
+
+/// Check if all pages in two documents are equal by comparing their hashes.
+/// This is much faster than rendering and comparing PNGs.
+fn pages_equal_by_hash(original: &PagedDocument, formatted: &PagedDocument) -> bool {
+    if original.pages.len() != formatted.pages.len() {
+        return false;
+    }
+
+    original
+        .pages
+        .iter()
+        .zip(formatted.pages.iter())
+        .all(|(p1, p2)| page_hash(p1) == page_hash(p2))
+}
+
+/// Compute a hash for a page to quickly check equality.
+fn page_hash(page: &Page) -> u64 {
+    use std::{
+        collections::hash_map::DefaultHasher,
+        hash::{Hash, Hasher},
+    };
+
+    let mut hasher = DefaultHasher::new();
+    page.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Check if page metadata differs (fill, numbering, supplement, number, frame size/items).
+fn check_page_meta(index: usize, original: &Page, formatted: &Page, sink: &mut ErrorSink) {
+    sink_assert_eq!(
+        sink,
+        original.fill,
+        formatted.fill,
+        "The fill of page {index} differs."
+    );
+    sink_assert_eq!(
+        sink,
+        original.numbering,
+        formatted.numbering,
+        "The numbering of page {index} differs."
+    );
+    sink_assert_eq!(
+        sink,
+        original.supplement,
+        formatted.supplement,
+        "The supplement of page {index} differs."
+    );
+    sink_assert_eq!(
+        sink,
+        original.number,
+        formatted.number,
+        "The number of page {index} differs."
+    );
+    sink_assert_eq!(
+        sink,
+        original.frame.size(),
+        formatted.frame.size(),
+        "The frame size of page {index} differs."
+    );
+    sink_assert_eq!(
+        sink,
+        original.frame.items().count(),
+        formatted.frame.items().count(),
+        "The frame item count of page {index} differs."
+    );
+}
+
+/// Render and save PNG images for pages with metadata differences.
+/// Only renders pages that are in the provided list of indices with differences.
+fn render_diff_pages(
+    original: &PagedDocument,
+    formatted: &PagedDocument,
+    original_name: &str,
+    formatted_name: &str,
+    pages_with_diff: &[usize],
+    sink: &mut ErrorSink,
+) -> Result<()> {
+    let total_pages = original.pages.len();
+
+    let save_dir = std::env::var("TYPSTYLE_SAVE_DIFF").ok().map(PathBuf::from);
+    if let Some(dir) = save_dir.as_ref() {
+        std::fs::create_dir_all(dir)?;
+    }
+
+    // Helper to render a page to PNG at 2x resolution
     let render_png = |page: &Page, number: u64| {
         typst_render::render(
             &Page {
@@ -138,77 +362,72 @@ fn check_png(
         )
     };
 
-    let save_diff = std::env::var("TYPSTYLE_SAVE_DIFF").ok().map(PathBuf::from);
-    fn fix_name(name: &str) -> String {
-        name.replace(['/', '\\'], "__")
-    }
+    // Render and compare only pages with differences
+    for &i in pages_with_diff {
+        let page_num = i + 1;
 
-    for (i, (page_bf, page_af)) in before.pages.iter().zip(after.pages.iter()).enumerate() {
-        check_page(i, page_bf, page_af, sink);
+        let orig_page = &original.pages[i];
+        let fmt_page = &formatted.pages[i];
 
-        let png_bf = render_png(page_bf, i as u64);
-        let png_af = render_png(page_af, i as u64);
-        if png_bf == png_af {
+        let orig_png = render_png(orig_page, i as u64);
+        let fmt_png = render_png(fmt_page, i as u64);
+
+        if orig_png.width() != fmt_png.width() {
+            sink.push(format!(
+                "Page {page_num}/{total_pages} width differs: original is {}px, formatted is {}px.",
+                orig_png.width(),
+                fmt_png.width()
+            ));
+        }
+        if orig_png.height() != fmt_png.height() {
+            sink.push(format!(
+                "Page {page_num}/{total_pages} height differs: original is {}px, formatted is {}px.",
+                orig_png.height(),
+                fmt_png.height()
+            ));
+        }
+
+        let diff_pixel_count = (orig_png.pixels().iter())
+            .zip(fmt_png.pixels())
+            .filter(|(p1, p2)| p1 != p2)
+            .count();
+        if diff_pixel_count == 0 {
+            // No pixel differences despite metadata differences
             continue;
         }
+        let mut msg =
+            format!("Page {page_num}/{total_pages} differs by {diff_pixel_count} pixels.");
 
-        // If the environment variable "TYPSTYLE_SAVE_DIFF" is set, save the differing PNGs.
-        if let Some(save_path) = save_diff.as_ref() {
-            std::fs::create_dir_all(save_path).ok();
-            let save_name_before = format!("{}_{}.png", fix_name(before_name), i);
-            let save_name_after = format!("{}_{}.png", fix_name(after_name), i);
-            png_bf.save_png(save_path.join(&save_name_before))?;
-            png_af.save_png(save_path.join(&save_name_after))?;
-            sink.push(format!(
-                "The output are not consistent for page {i}.\nSaved diff PNGs: `{save_name_before}` and `{save_name_after}`"
+        // PNGs differ - save them if environment variable is set
+        if let Some(save_path) = save_dir.as_ref() {
+            let diff_pixmap = compute_diff_pixmap(&orig_png, &fmt_png);
+
+            let orig_filename = format!("{}_{page_num}.png", sanitize_filename(original_name));
+            let fmt_filename = format!("{}_{page_num}.png", sanitize_filename(formatted_name));
+            let diff_filename = format!("{}_{page_num}_diff.png", sanitize_filename(original_name));
+            orig_png.save_png(save_path.join(&orig_filename))?;
+            fmt_png.save_png(save_path.join(&fmt_filename))?;
+            diff_pixmap.save_png(save_path.join(&diff_filename))?;
+
+            msg.push_str(&format!(
+                "\nSaved PNGs: `{orig_filename}`, `{fmt_filename}`, and `{diff_filename}`"
             ));
         } else {
-            sink.push(format!("The output are not consistent for page {i}."));
+            msg.push_str(" Set env TYPSTYLE_SAVE_DIFF to save PNGs.");
         }
+
+        sink.push(msg);
     }
 
     Ok(())
 }
 
-fn check_page(index: usize, before: &Page, after: &Page, sink: &mut ErrorSink) {
-    sink_assert_eq!(
-        sink,
-        before.fill,
-        after.fill,
-        "The fills of page {index} are not consistent."
-    );
-    sink_assert_eq!(
-        sink,
-        before.numbering,
-        after.numbering,
-        "The numberings of page {index} are not consistent."
-    );
-    sink_assert_eq!(
-        sink,
-        before.supplement,
-        after.supplement,
-        "The supplements of page {index} are not consistent."
-    );
-    sink_assert_eq!(
-        sink,
-        before.number,
-        after.number,
-        "The numbers of page {index} are not consistent."
-    );
-    sink_assert_eq!(
-        sink,
-        before.frame.size(),
-        after.frame.size(),
-        "The frame sizes of page {index} are not consistent."
-    );
-    sink_assert_eq!(
-        sink,
-        before.frame.items().count(),
-        after.frame.items().count(),
-        "The frame item counts of page {index} are not consistent."
-    );
+/// Sanitize a filename by replacing path separators with underscores.
+fn sanitize_filename(name: &str) -> String {
+    name.replace(['/', '\\'], "__")
 }
 
+/// Print diagnostics to stderr in human-readable format.
 fn print_diagnostics<'d, 'files>(
     world: &'files dyn SourceWorld,
     errors: impl Iterator<Item = &'d SourceDiagnostic>,

--- a/crates/typstyle-consistency/src/cmp.rs
+++ b/crates/typstyle-consistency/src/cmp.rs
@@ -3,128 +3,229 @@ use std::path::PathBuf;
 use anyhow::Result;
 use tinymist_world::SourceWorld;
 use typst::{
-    diag::SourceDiagnostic,
+    diag::{SourceDiagnostic, SourceResult},
     ecow::EcoVec,
-    foundations::Smart,
+    foundations::{Content, Smart},
     layout::{Page, PagedDocument},
 };
 
 use crate::{ErrorSink, sink_assert_eq};
 
-pub struct Compiled<'a> {
+/// Options for comparing formatted documents with original ones.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct CheckingOptions {
+    /// Whether it expects successful compilation.
+    pub expect_compile_success: bool,
+}
+
+/// Input for document comparison, consisting of a name and a world to compile.
+pub struct ComparisonInput<'a> {
     pub name: String,
     pub world: &'a dyn SourceWorld,
-    pub result: Result<PagedDocument, EcoVec<SourceDiagnostic>>,
 }
 
-pub fn compile_world(name: String, world: &dyn SourceWorld) -> Result<Compiled<'_>> {
-    let result = typst::compile(world.as_world()).output;
-
-    Ok(Compiled {
-        name,
-        world,
-        result,
-    })
+/// Evaluate the main source file to get its content without full compilation.
+/// This is cheaper than full compilation and used for the first equality check.
+fn eval_content(world: &dyn SourceWorld) -> SourceResult<Content> {
+    let main = world.source(world.main()).unwrap();
+    Ok(typst_shim::eval::eval_compat(world, &main)?.content())
 }
 
-pub fn compare_docs(
-    before: &Compiled,
-    after: &Compiled,
-    require_compile: bool,
+/// Compile a world into a paged document.
+fn compile_world(world: &dyn SourceWorld) -> Result<PagedDocument, EcoVec<SourceDiagnostic>> {
+    typst::compile(world.as_world()).output
+}
+
+/// Compare two documents for consistency, checking content equality first,
+/// then page equality, and finally rendering PNGs for any inconsistent pages.
+///
+/// The checking order is optimized to avoid expensive compilation when possible:
+/// 1. Check content equality (cheap) - if equal, done
+/// 2. Compile documents (expensive, only if content differs)
+/// 3. Check page equality by hash - if equal, done
+/// 4. Render PNGs only for pages that differ
+pub fn compare_worlds(
+    original: &ComparisonInput,
+    formatted: &ComparisonInput,
+    options: CheckingOptions,
     err_sink: &mut ErrorSink,
 ) -> Result<()> {
-    let mut sub_sink = ErrorSink::new(format!("comparing with `{}`", after.name));
-    compare_docs_impl(before, after, require_compile, &mut sub_sink)?;
+    let mut sub_sink = ErrorSink::new(format!("comparing with `{}`", formatted.name));
+    compare_worlds_impl(original, formatted, options, &mut sub_sink)?;
     sub_sink.sink_to(err_sink);
     Ok(())
 }
 
-fn compare_docs_impl(
-    before: &Compiled,
-    after: &Compiled,
-    require_compile: bool,
-    sub_sink: &mut ErrorSink,
+fn compare_worlds_impl(
+    original: &ComparisonInput,
+    formatted: &ComparisonInput,
+    options: CheckingOptions,
+    sink: &mut ErrorSink,
 ) -> Result<()> {
-    match (&before.result, &after.result) {
-        (Ok(doc_bf), Ok(doc_af)) => {
-            check_doc_meta(doc_bf, doc_af, sub_sink);
-            check_png(doc_bf, doc_af, &before.name, &after.name, sub_sink)?;
-        }
-        (Err(e1), Err(e2)) => {
-            if require_compile {
-                sub_sink.push("Both docs failed to compile.".to_string());
-                print_diagnostics(before.world, e1.iter())?;
+    // Step 1: Check content equality (cheap evaluation without full compilation)
+    let original_content = eval_content(original.world);
+    let formatted_content = eval_content(formatted.world);
+
+    match (&original_content, &formatted_content) {
+        (Ok(orig), Ok(fmt)) => {
+            if orig == fmt {
+                // Content matches - done
                 return Ok(());
             }
-
-            sink_assert_eq!(
-                sub_sink,
-                e1.len(),
-                e2.len(),
-                "The error counts are not consistent"
-            );
-            for (e1, e2) in e1.iter().zip(e2.iter()) {
-                sink_assert_eq!(
-                    sub_sink,
-                    e1.message,
-                    e2.message,
-                    "The error messages are not consistent after formatting"
-                );
+        }
+        (Err(orig_err), Err(fmt_err)) => {
+            // Both failed to evaluate
+            if options.expect_compile_success {
+                sink.push("Both docs failed to compile.");
+                print_diagnostics(original.world, orig_err.iter())?;
+                return Ok(());
             }
+            // Check that errors are consistent
+            check_error_consistency(orig_err, fmt_err, sink);
+            return Ok(());
         }
-        (Err(e1), _) => {
-            sub_sink.push("Original doc failed to compile.".to_string());
-            print_diagnostics(before.world, e1.iter())?;
+        (Err(e), _) => {
+            sink.push(format!("Failed to evaluate original document: {e:#?}"));
+            return Ok(());
         }
-        (_, Err(e2)) => {
-            sub_sink.push("Formatted doc failed to compile.".to_string());
-            print_diagnostics(after.world, e2.iter())?;
+        (_, Err(e)) => {
+            sink.push(format!("Failed to evaluate formatted document: {e:#?}"));
+            return Ok(());
+        }
+    }
+
+    // Step 2: Compile documents (expensive, only done if content differs)
+    let original_result = compile_world(original.world);
+    let formatted_result = compile_world(formatted.world);
+
+    match (&original_result, &formatted_result) {
+        (Ok(orig_doc), Ok(fmt_doc)) => {
+            // Both compiled successfully, check page equality
+            check_pages_equal(orig_doc, fmt_doc, &original.name, &formatted.name, sink)?;
+        }
+        (Err(orig_err), Err(fmt_err)) => {
+            if options.expect_compile_success {
+                sink.push("Both docs failed to compile.");
+                print_diagnostics(original.world, orig_err.iter())?;
+                return Ok(());
+            }
+            // Check that errors are consistent
+            check_error_consistency(orig_err, fmt_err, sink);
+            print_diagnostics(original.world, orig_err.iter())?;
+        }
+        (Err(e), _) => {
+            sink.push("Original doc failed to compile.");
+            print_diagnostics(original.world, e.iter())?;
+        }
+        (_, Err(e)) => {
+            sink.push("Formatted doc failed to compile.");
+            print_diagnostics(formatted.world, e.iter())?;
         }
     }
 
     Ok(())
 }
 
-fn check_doc_meta(left: &PagedDocument, right: &PagedDocument, sink: &mut ErrorSink) {
+/// Check that two error lists are consistent (same count and messages).
+fn check_error_consistency(
+    original_errors: &[SourceDiagnostic],
+    formatted_errors: &[SourceDiagnostic],
+    sink: &mut ErrorSink,
+) {
     sink_assert_eq!(
         sink,
-        left.pages.len(),
-        right.pages.len(),
+        original_errors.len(),
+        formatted_errors.len(),
+        "The error counts are not consistent"
+    );
+    for (orig, fmt) in original_errors.iter().zip(formatted_errors.iter()) {
+        sink_assert_eq!(
+            sink,
+            orig.message,
+            fmt.message,
+            "The error messages are not consistent after formatting"
+        );
+    }
+}
+
+/// Check that document metadata (page count, title, author, etc.) is consistent.
+fn check_doc_meta(original: &PagedDocument, formatted: &PagedDocument, sink: &mut ErrorSink) {
+    sink_assert_eq!(
+        sink,
+        original.pages.len(),
+        formatted.pages.len(),
         "The page counts are not consistent"
     );
     sink_assert_eq!(
         sink,
-        left.info.title,
-        right.info.title,
+        original.info.title,
+        formatted.info.title,
         "The titles are not consistent"
     );
     sink_assert_eq!(
         sink,
-        left.info.author,
-        right.info.author,
+        original.info.author,
+        formatted.info.author,
         "The authors are not consistent"
     );
     sink_assert_eq!(
         sink,
-        left.info.description,
-        right.info.description,
+        original.info.description,
+        formatted.info.description,
         "The descriptions are not consistent"
     );
     sink_assert_eq!(
         sink,
-        left.info.keywords,
-        right.info.keywords,
+        original.info.keywords,
+        formatted.info.keywords,
         "The keywords are not consistent"
     );
 }
 
-fn check_png(
-    before: &PagedDocument,
-    after: &PagedDocument,
-    before_name: &str,
-    after_name: &str,
+/// Check page equality between two documents.
+/// First checks metadata, then uses hash-based comparison for pages,
+/// and finally renders PNGs only for pages with metadata differences.
+fn check_pages_equal(
+    original: &PagedDocument,
+    formatted: &PagedDocument,
+    original_name: &str,
+    formatted_name: &str,
     sink: &mut ErrorSink,
-) -> anyhow::Result<()> {
+) -> Result<()> {
+    // Check document metadata
+    check_doc_meta(original, formatted, sink);
+
+    if original.pages.len() != formatted.pages.len() {
+        sink.push(format!(
+            "Page count mismatch: original has {} pages, formatted has {} pages",
+            original.pages.len(),
+            formatted.pages.len()
+        ));
+        // No early return here - continue to check pages
+    }
+
+    render_diff_pages(original, formatted, original_name, formatted_name, sink)?;
+
+    Ok(())
+}
+
+/// Render and save PNG images for pages with metadata differences.
+/// Only renders pages that are in the provided list of indices with differences.
+fn render_diff_pages(
+    original: &PagedDocument,
+    formatted: &PagedDocument,
+    original_name: &str,
+    formatted_name: &str,
+    sink: &mut ErrorSink,
+) -> Result<()> {
+    let total_pages = original.pages.len();
+
+    let save_dir = std::env::var("TYPSTYLE_SAVE_DIFF").ok().map(PathBuf::from);
+    if let Some(dir) = save_dir.as_ref() {
+        std::fs::create_dir_all(dir)?;
+    }
+
+    // Helper to render a page to PNG at 2x resolution
     let render_png = |page: &Page, number: u64| {
         typst_render::render(
             &Page {
@@ -138,77 +239,68 @@ fn check_png(
         )
     };
 
-    let save_diff = std::env::var("TYPSTYLE_SAVE_DIFF").ok().map(PathBuf::from);
-    fn fix_name(name: &str) -> String {
-        name.replace(['/', '\\'], "__")
-    }
+    // Render and compare only pages with differences
+    for (i, (orig_page, fmt_page)) in (original.pages.iter())
+        .zip(formatted.pages.iter())
+        .enumerate()
+    {
+        let page_num = i + 1;
 
-    for (i, (page_bf, page_af)) in before.pages.iter().zip(after.pages.iter()).enumerate() {
-        check_page(i, page_bf, page_af, sink);
+        let orig_png = render_png(orig_page, i as u64);
+        let fmt_png = render_png(fmt_page, i as u64);
 
-        let png_bf = render_png(page_bf, i as u64);
-        let png_af = render_png(page_af, i as u64);
-        if png_bf == png_af {
+        if orig_png.width() != fmt_png.width() {
+            sink.push(format!(
+                "Page {page_num}/{total_pages} width differs: original is {}px, formatted is {}px.",
+                orig_png.width(),
+                fmt_png.width()
+            ));
+        }
+        if orig_png.height() != fmt_png.height() {
+            sink.push(format!(
+                "Page {page_num}/{total_pages} height differs: original is {}px, formatted is {}px.",
+                orig_png.height(),
+                fmt_png.height()
+            ));
+        }
+
+        let diff_pixel_count = (orig_png.pixels().iter())
+            .zip(fmt_png.pixels())
+            .filter(|(p1, p2)| p1 != p2)
+            .count();
+        if diff_pixel_count == 0 {
+            // No pixel differences despite metadata differences
             continue;
         }
+        let mut msg =
+            format!("Page {page_num}/{total_pages} differs by {diff_pixel_count} pixels.");
 
-        // If the environment variable "TYPSTYLE_SAVE_DIFF" is set, save the differing PNGs.
-        if let Some(save_path) = save_diff.as_ref() {
-            std::fs::create_dir_all(save_path).ok();
-            let save_name_before = format!("{}_{}.png", fix_name(before_name), i);
-            let save_name_after = format!("{}_{}.png", fix_name(after_name), i);
-            png_bf.save_png(save_path.join(&save_name_before))?;
-            png_af.save_png(save_path.join(&save_name_after))?;
-            sink.push(format!(
-                "The output are not consistent for page {i}.\nSaved diff PNGs: `{save_name_before}` and `{save_name_after}`"
+        // PNGs differ - save them if environment variable is set
+        if let Some(save_path) = save_dir.as_ref() {
+            let orig_filename = format!("{}_{page_num}.png", sanitize_filename(original_name));
+            let fmt_filename = format!("{}_{page_num}.png", sanitize_filename(formatted_name));
+            orig_png.save_png(save_path.join(&orig_filename))?;
+            fmt_png.save_png(save_path.join(&fmt_filename))?;
+
+            msg.push_str(&format!(
+                "\nSaved PNGs: `{orig_filename}` and `{fmt_filename}`."
             ));
         } else {
-            sink.push(format!("The output are not consistent for page {i}."));
+            msg.push_str(" Set env TYPSTYLE_SAVE_DIFF to save PNGs.");
         }
+
+        sink.push(msg);
     }
 
     Ok(())
 }
 
-fn check_page(index: usize, before: &Page, after: &Page, sink: &mut ErrorSink) {
-    sink_assert_eq!(
-        sink,
-        before.fill,
-        after.fill,
-        "The fills of page {index} are not consistent."
-    );
-    sink_assert_eq!(
-        sink,
-        before.numbering,
-        after.numbering,
-        "The numberings of page {index} are not consistent."
-    );
-    sink_assert_eq!(
-        sink,
-        before.supplement,
-        after.supplement,
-        "The supplements of page {index} are not consistent."
-    );
-    sink_assert_eq!(
-        sink,
-        before.number,
-        after.number,
-        "The numbers of page {index} are not consistent."
-    );
-    sink_assert_eq!(
-        sink,
-        before.frame.size(),
-        after.frame.size(),
-        "The frame sizes of page {index} are not consistent."
-    );
-    sink_assert_eq!(
-        sink,
-        before.frame.items().count(),
-        after.frame.items().count(),
-        "The frame item counts of page {index} are not consistent."
-    );
+/// Sanitize a filename by replacing path separators with underscores.
+fn sanitize_filename(name: &str) -> String {
+    name.replace(['/', '\\'], "__")
 }
 
+/// Print diagnostics to stderr in human-readable format.
 fn print_diagnostics<'d, 'files>(
     world: &'files dyn SourceWorld,
     errors: impl Iterator<Item = &'d SourceDiagnostic>,

--- a/crates/typstyle-consistency/src/cmp.rs
+++ b/crates/typstyle-consistency/src/cmp.rs
@@ -16,7 +16,7 @@ use crate::{ErrorSink, image_diff::compute_diff_pixmap, sink_assert_eq, text_dif
 pub struct CheckingOptions {
     /// Whether it expects successful compilation.
     pub expect_compile_success: bool,
-    /// Whether the document is expected to fail compilation (unused yet).
+    /// Whether the document is expected to fail compilation.
     pub expect_error: bool,
     /// Whether to enforce strict content equality.
     pub strict_content_equality: bool,
@@ -41,11 +41,13 @@ fn compile_world(world: &dyn SourceWorld) -> Result<PagedDocument, EcoVec<Source
 }
 
 /// Compare two documents for consistency, checking content equality first,
-/// then page equality, and finally rendering PNGs for any inconsistent pages.
+/// then document/page equality, and finally rendering PNGs for any inconsistent pages.
 ///
-/// The checking order is optimized to avoid expensive compilation when possible:
-/// 1. Check content equality (cheap) - if equal, done
-/// 2. Compile documents (expensive, only if content differs)
+/// The checking order is optimized to report cheap content differences before
+/// compiling, while still compiling successful documents so metadata-only
+/// formatter changes cannot pass unnoticed:
+/// 1. Check content equality (cheap)
+/// 2. Compile documents
 /// 3. Check page equality by hash - if equal, done
 /// 4. Render PNGs only for pages that differ
 pub fn compare_worlds(
@@ -76,11 +78,11 @@ fn compare_worlds_impl(
                 sink.push("Both docs evaluated successfully, but were expected to fail.");
             }
             if orig == fmt {
-                // Content matches - done
-                return Ok(());
-            }
-            // Content differs, need to compile and check pages
-            if options.strict_content_equality {
+                if options.expect_error {
+                    return Ok(());
+                }
+                // Still need to check metadata and rendered output even if content is identical, to catch metadata-only formatter changes
+            } else if options.strict_content_equality {
                 // If we didn't expect content differences, report it as hard error
                 let orig_repr = orig.repr();
                 let fmt_repr = fmt.repr();
@@ -114,7 +116,7 @@ fn compare_worlds_impl(
         }
     }
 
-    // Step 2: Compile documents (expensive, only done if content differs)
+    // Step 2: Compile documents to catch metadata and rendered-output changes.
     let original_result = compile_world(original.world);
     let formatted_result = compile_world(formatted.world);
 

--- a/crates/typstyle-consistency/src/cmp.rs
+++ b/crates/typstyle-consistency/src/cmp.rs
@@ -5,17 +5,21 @@ use tinymist_world::SourceWorld;
 use typst::{
     diag::{SourceDiagnostic, SourceResult},
     ecow::EcoVec,
-    foundations::{Content, Smart},
+    foundations::{Content, Repr, Smart},
     layout::{Page, PagedDocument},
 };
 
-use crate::{ErrorSink, sink_assert_eq};
+use crate::{ErrorSink, image_diff::compute_diff_pixmap, sink_assert_eq, text_diff::CodeDiff};
 
 /// Options for comparing formatted documents with original ones.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct CheckingOptions {
     /// Whether it expects successful compilation.
     pub expect_compile_success: bool,
+    /// Whether the document is expected to fail compilation (unused yet).
+    pub expect_error: bool,
+    /// Whether to enforce strict content equality.
+    pub strict_content_equality: bool,
 }
 
 /// Input for document comparison, consisting of a name and a world to compile.
@@ -68,9 +72,25 @@ fn compare_worlds_impl(
 
     match (&original_content, &formatted_content) {
         (Ok(orig), Ok(fmt)) => {
+            if options.expect_error {
+                sink.push("Both docs evaluated successfully, but were expected to fail.");
+            }
             if orig == fmt {
                 // Content matches - done
                 return Ok(());
+            }
+            // Content differs, need to compile and check pages
+            if options.strict_content_equality {
+                // If we didn't expect content differences, report it as hard error
+                let orig_repr = orig.repr();
+                let fmt_repr = fmt.repr();
+                let diff = CodeDiff::new(&orig_repr, &fmt_repr);
+                sink.push(format!(
+                    "Content differs between original and formatted documents:\n{diff}"
+                ));
+                if orig_repr == fmt_repr {
+                    sink.push("However, their representations are identical.");
+                }
             }
         }
         (Err(orig_err), Err(fmt_err)) => {
@@ -100,6 +120,10 @@ fn compare_worlds_impl(
 
     match (&original_result, &formatted_result) {
         (Ok(orig_doc), Ok(fmt_doc)) => {
+            if options.expect_error {
+                sink.push("Both docs compiled successfully, but were expected to fail.");
+                return Ok(());
+            }
             // Both compiled successfully, check page equality
             check_pages_equal(orig_doc, fmt_doc, &original.name, &formatted.name, sink)?;
         }
@@ -204,9 +228,111 @@ fn check_pages_equal(
         // No early return here - continue to check pages
     }
 
-    render_diff_pages(original, formatted, original_name, formatted_name, sink)?;
+    // Check page equality using hash comparison (fast)
+    if pages_equal_by_hash(original, formatted) {
+        // All pages match - we're done!
+        return Ok(());
+    }
+
+    // Pages differ by hash - check which pages have metadata differences and collect all with hash diff
+    let mut pages_with_hash_diff = Vec::new();
+    for (i, (orig_page, fmt_page)) in (original.pages.iter())
+        .zip(formatted.pages.iter())
+        .enumerate()
+    {
+        if page_hash(orig_page) == page_hash(fmt_page) {
+            continue;
+        }
+
+        pages_with_hash_diff.push(i);
+        let mut meta_sink = ErrorSink::new(String::new());
+        check_page_meta(i, orig_page, fmt_page, &mut meta_sink);
+        meta_sink.sink_to(sink);
+    }
+
+    // If no pages have hash differences
+    if pages_with_hash_diff.is_empty() {
+        // All pages match
+        return Ok(());
+    }
+
+    // Pages differ unexpectedly - render all pages with hash differences
+    render_diff_pages(
+        original,
+        formatted,
+        original_name,
+        formatted_name,
+        &pages_with_hash_diff,
+        sink,
+    )?;
 
     Ok(())
+}
+
+/// Check if all pages in two documents are equal by comparing their hashes.
+/// This is much faster than rendering and comparing PNGs.
+fn pages_equal_by_hash(original: &PagedDocument, formatted: &PagedDocument) -> bool {
+    if original.pages.len() != formatted.pages.len() {
+        return false;
+    }
+
+    original
+        .pages
+        .iter()
+        .zip(formatted.pages.iter())
+        .all(|(p1, p2)| page_hash(p1) == page_hash(p2))
+}
+
+/// Compute a hash for a page to quickly check equality.
+fn page_hash(page: &Page) -> u64 {
+    use std::{
+        collections::hash_map::DefaultHasher,
+        hash::{Hash, Hasher},
+    };
+
+    let mut hasher = DefaultHasher::new();
+    page.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Check if page metadata differs (fill, numbering, supplement, number, frame size/items).
+fn check_page_meta(index: usize, original: &Page, formatted: &Page, sink: &mut ErrorSink) {
+    sink_assert_eq!(
+        sink,
+        original.fill,
+        formatted.fill,
+        "The fill of page {index} differs."
+    );
+    sink_assert_eq!(
+        sink,
+        original.numbering,
+        formatted.numbering,
+        "The numbering of page {index} differs."
+    );
+    sink_assert_eq!(
+        sink,
+        original.supplement,
+        formatted.supplement,
+        "The supplement of page {index} differs."
+    );
+    sink_assert_eq!(
+        sink,
+        original.number,
+        formatted.number,
+        "The number of page {index} differs."
+    );
+    sink_assert_eq!(
+        sink,
+        original.frame.size(),
+        formatted.frame.size(),
+        "The frame size of page {index} differs."
+    );
+    sink_assert_eq!(
+        sink,
+        original.frame.items().count(),
+        formatted.frame.items().count(),
+        "The frame item count of page {index} differs."
+    );
 }
 
 /// Render and save PNG images for pages with metadata differences.
@@ -216,6 +342,7 @@ fn render_diff_pages(
     formatted: &PagedDocument,
     original_name: &str,
     formatted_name: &str,
+    pages_with_diff: &[usize],
     sink: &mut ErrorSink,
 ) -> Result<()> {
     let total_pages = original.pages.len();
@@ -240,11 +367,11 @@ fn render_diff_pages(
     };
 
     // Render and compare only pages with differences
-    for (i, (orig_page, fmt_page)) in (original.pages.iter())
-        .zip(formatted.pages.iter())
-        .enumerate()
-    {
+    for &i in pages_with_diff {
         let page_num = i + 1;
+
+        let orig_page = &original.pages[i];
+        let fmt_page = &formatted.pages[i];
 
         let orig_png = render_png(orig_page, i as u64);
         let fmt_png = render_png(fmt_page, i as u64);
@@ -277,13 +404,17 @@ fn render_diff_pages(
 
         // PNGs differ - save them if environment variable is set
         if let Some(save_path) = save_dir.as_ref() {
+            let diff_pixmap = compute_diff_pixmap(&orig_png, &fmt_png);
+
             let orig_filename = format!("{}_{page_num}.png", sanitize_filename(original_name));
             let fmt_filename = format!("{}_{page_num}.png", sanitize_filename(formatted_name));
+            let diff_filename = format!("{}_{page_num}_diff.png", sanitize_filename(original_name));
             orig_png.save_png(save_path.join(&orig_filename))?;
             fmt_png.save_png(save_path.join(&fmt_filename))?;
+            diff_pixmap.save_png(save_path.join(&diff_filename))?;
 
             msg.push_str(&format!(
-                "\nSaved PNGs: `{orig_filename}` and `{fmt_filename}`."
+                "\nSaved PNGs: `{orig_filename}` and `{fmt_filename}` with diff `{diff_filename}`"
             ));
         } else {
             msg.push_str(" Set env TYPSTYLE_SAVE_DIFF to save PNGs.");

--- a/crates/typstyle-consistency/src/err.rs
+++ b/crates/typstyle-consistency/src/err.rs
@@ -139,3 +139,40 @@ macro_rules! sink_assert_str_eq {
         }
     };
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display_empty_sink() {
+        let sink = ErrorSink::new("empty description".to_string());
+        let output = format!("{}", sink);
+        assert!(output.ends_with('\n'));
+        assert!(!output.ends_with("\n\n"));
+        insta::assert_snapshot!(output, @"errors occurred in empty description:");
+    }
+
+    #[test]
+    fn test_nested_sinks() {
+        let mut sub_sink = ErrorSink::new("sub task".to_string());
+        sub_sink.push("sub error 1");
+        sub_sink.push("sub error 2\nwith newline");
+
+        let mut main_sink = ErrorSink::new("main task".to_string());
+        main_sink.push("main error");
+        sub_sink.sink_to(&mut main_sink);
+
+        let output = format!("{}", main_sink);
+        assert!(output.ends_with('\n'));
+        assert!(!output.ends_with("\n\n"));
+        insta::assert_snapshot!(output, @"
+        errors occurred in main task:
+           1: main error
+           2: errors occurred in sub task:
+               1: sub error 1
+               2: sub error 2
+                with newline
+        ");
+    }
+}

--- a/crates/typstyle-consistency/src/err.rs
+++ b/crates/typstyle-consistency/src/err.rs
@@ -139,3 +139,42 @@ macro_rules! sink_assert_str_eq {
         }
     };
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display_empty_sink() {
+        let sink = ErrorSink::new("empty description".to_string());
+        let output = format!("{}", sink);
+        assert_eq!(output, "errors occurred in empty description:\n");
+    }
+
+    #[test]
+    fn test_nested_sinks() {
+        let mut sub_sink = ErrorSink::new("sub task".to_string());
+        sub_sink.push("sub error 1");
+        sub_sink.push("sub error 2\nwith newline");
+
+        let mut main_sink = ErrorSink::new("main task".to_string());
+        main_sink.push("main error");
+        sub_sink.sink_to(&mut main_sink);
+
+        let output = format!("{}", main_sink);
+        assert!(output.ends_with('\n'));
+        assert!(!output.ends_with("\n\n"));
+        assert_eq!(
+            output.trim(),
+            "
+errors occurred in main task:
+   1: main error
+   2: errors occurred in sub task:
+       1: sub error 1
+       2: sub error 2
+        with newline
+"
+            .trim()
+        );
+    }
+}

--- a/crates/typstyle-consistency/src/harness.rs
+++ b/crates/typstyle-consistency/src/harness.rs
@@ -18,7 +18,9 @@ use typst::{
 };
 use walkdir::WalkDir;
 
-use crate::{ErrorSink, FormattedWorld, SourceMap, compare_docs, compile_world};
+use crate::{
+    CheckingOptions, ComparisonInput, ErrorSink, FormattedWorld, SourceMap, compare_worlds,
+};
 
 pub struct FormattedSources {
     /// The name of the formatter configuration, used for debugging.
@@ -176,7 +178,7 @@ impl FormatterHarness {
         &mut self,
         formatted: impl Iterator<Item = &'a FormattedSources>,
         entry_path: &Path,
-        require_compile: bool,
+        options: CheckingOptions,
         err_sink: &mut ErrorSink,
     ) -> Result<()> {
         let mut sub_sink =
@@ -192,17 +194,23 @@ impl FormatterHarness {
         } else {
             format!("{} - {}", self.name, entry_path.display())
         };
-        let base_result = compile_world(format!("{name} - original"), &base_world)?;
+
+        let original = ComparisonInput {
+            name: format!("{name} - original"),
+            world: &base_world,
+        };
 
         for sources in formatted {
             let world = FormattedWorld {
                 base: &base_world,
                 formatted: sources.sources.clone(),
             };
-            let name = format!("{} - {}", name, sources.name);
-            let fmt_result = compile_world(name.clone(), &world)?;
+            let formatted = ComparisonInput {
+                name: format!("{} - {}", name, sources.name),
+                world: &world,
+            };
 
-            compare_docs(&base_result, &fmt_result, require_compile, &mut sub_sink)?;
+            compare_worlds(&original, &formatted, options, &mut sub_sink)?;
         }
 
         sub_sink.sink_to(err_sink);

--- a/crates/typstyle-consistency/src/image_diff.rs
+++ b/crates/typstyle-consistency/src/image_diff.rs
@@ -1,0 +1,27 @@
+use tiny_skia::{Color, Pixmap};
+
+/// Compute a diff image highlighting pixel differences.
+/// Differing pixels are shown in red, identical pixels are transparent.
+pub fn compute_diff_pixmap(orig_png: &Pixmap, fmt_png: &Pixmap) -> Pixmap {
+    let width = orig_png.width();
+    let height = orig_png.height();
+
+    let mut diff_pixmap = Pixmap::new(width, height).unwrap();
+
+    for y in 0..height {
+        for x in 0..width {
+            let orig_pixel = orig_png.pixel(x, y).unwrap();
+            let fmt_pixel = fmt_png.pixel(x, y).unwrap();
+
+            let color = if orig_pixel != fmt_pixel {
+                Color::from_rgba8(255, 0, 0, 255)
+            } else {
+                Color::from_rgba8(0, 0, 0, 0)
+            };
+
+            diff_pixmap.pixels_mut()[(y * width + x) as usize] = color.premultiply().to_color_u8();
+        }
+    }
+
+    diff_pixmap
+}

--- a/crates/typstyle-consistency/src/image_diff.rs
+++ b/crates/typstyle-consistency/src/image_diff.rs
@@ -1,0 +1,37 @@
+use tiny_skia::{Color, Pixmap, PremultipliedColorU8};
+
+/// Compute a diff image highlighting pixel differences.
+/// Removed pixels are orange, added pixels are blue, color changes are magenta,
+/// and identical pixels are transparent.
+pub fn compute_diff_pixmap(orig_png: &Pixmap, fmt_png: &Pixmap) -> Pixmap {
+    let width = orig_png.width().max(fmt_png.width());
+    let height = orig_png.height().max(fmt_png.height());
+
+    let mut diff_pixmap = Pixmap::new(width, height).unwrap();
+
+    for y in 0..height {
+        for x in 0..width {
+            let i = (y * width + x) as usize;
+            let orig_pixel = orig_png
+                .pixel(x, y)
+                .unwrap_or(PremultipliedColorU8::TRANSPARENT);
+            let fmt_pixel = fmt_png
+                .pixel(x, y)
+                .unwrap_or(PremultipliedColorU8::TRANSPARENT);
+
+            let color = if orig_pixel != fmt_pixel {
+                match orig_pixel.alpha().cmp(&fmt_pixel.alpha()) {
+                    std::cmp::Ordering::Greater => Color::from_rgba8(230, 159, 0, 255),
+                    std::cmp::Ordering::Less => Color::from_rgba8(0, 114, 178, 255),
+                    std::cmp::Ordering::Equal => Color::from_rgba8(204, 121, 167, 255),
+                }
+            } else {
+                Color::from_rgba8(0, 0, 0, 0)
+            };
+
+            diff_pixmap.pixels_mut()[i] = color.premultiply().to_color_u8();
+        }
+    }
+
+    diff_pixmap
+}

--- a/crates/typstyle-consistency/src/lib.rs
+++ b/crates/typstyle-consistency/src/lib.rs
@@ -1,9 +1,11 @@
 mod cmp;
 mod err;
 mod harness;
+mod image_diff;
+mod text_diff;
 mod world;
 
-pub use cmp::{Compiled, compare_docs, compile_world};
+pub use cmp::{CheckingOptions, ComparisonInput, compare_worlds};
 pub use err::ErrorSink;
 pub use harness::{FormattedSources, FormatterHarness};
 pub use world::{FormattedWorld, SourceMap};

--- a/crates/typstyle-consistency/src/lib.rs
+++ b/crates/typstyle-consistency/src/lib.rs
@@ -1,6 +1,8 @@
 mod cmp;
 mod err;
 mod harness;
+mod image_diff;
+mod text_diff;
 mod world;
 
 pub use cmp::{CheckingOptions, ComparisonInput, compare_worlds};

--- a/crates/typstyle-consistency/src/lib.rs
+++ b/crates/typstyle-consistency/src/lib.rs
@@ -3,7 +3,7 @@ mod err;
 mod harness;
 mod world;
 
-pub use cmp::{Compiled, compare_docs, compile_world};
+pub use cmp::{CheckingOptions, ComparisonInput, compare_worlds};
 pub use err::ErrorSink;
 pub use harness::{FormattedSources, FormatterHarness};
 pub use world::{FormattedWorld, SourceMap};

--- a/crates/typstyle-consistency/src/text_diff.rs
+++ b/crates/typstyle-consistency/src/text_diff.rs
@@ -1,0 +1,86 @@
+// Borrowed from https://github.com/astral-sh/ruff/blob/main/crates/ruff_linter/src/source_kind.rs
+// Copied from crates/typstyle/src/diff.rs
+
+use std::borrow::Cow;
+
+use colored::Colorize;
+use similar::{ChangeTag, TextDiff};
+
+pub struct CodeDiff<'a> {
+    diff: TextDiff<'a, 'a, 'a, str>,
+    header: Option<(&'a str, &'a str)>,
+    missing_newline_hint: bool,
+}
+
+impl<'a> CodeDiff<'a> {
+    pub fn new(original: &'a str, modified: &'a str) -> Self {
+        let diff = TextDiff::from_lines(original, modified);
+        Self {
+            diff,
+            header: None,
+            missing_newline_hint: true,
+        }
+    }
+}
+
+impl std::fmt::Display for CodeDiff<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some((original, modified)) = self.header {
+            writeln!(f, "--- {}", original.show_nonprinting().red())?;
+            writeln!(f, "+++ {}", modified.show_nonprinting().green())?;
+        }
+
+        let mut unified = self.diff.unified_diff();
+        unified.missing_newline_hint(self.missing_newline_hint);
+
+        // Individual hunks (section of changes)
+        for hunk in unified.iter_hunks() {
+            writeln!(f, "{}", hunk.header())?;
+
+            // individual lines
+            for change in hunk.iter_changes() {
+                let value = change.value().show_nonprinting();
+                match change.tag() {
+                    ChangeTag::Equal => write!(f, " {value}")?,
+                    ChangeTag::Delete => write!(f, "{}{}", "-".red(), value.red())?,
+                    ChangeTag::Insert => write!(f, "{}{}", "+".green(), value.green())?,
+                }
+
+                if !self.diff.newline_terminated() {
+                    writeln!(f)?;
+                } else if change.missing_newline() {
+                    if self.missing_newline_hint {
+                        writeln!(f, "{}", "\n\\ No newline at end of file".red())?;
+                    } else {
+                        writeln!(f)?;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// Borrowed from https://github.com/astral-sh/ruff/blob/main/crates/ruff_linter/src/text_helpers.rs
+trait ShowNonprinting {
+    fn show_nonprinting(&self) -> Cow<'_, str>;
+}
+
+macro_rules! impl_show_nonprinting {
+    ($(($from:expr, $to:expr)),+) => {
+        impl ShowNonprinting for str {
+            fn show_nonprinting(&self) -> Cow<'_, str> {
+                if self.find(&[$($from),*][..]).is_some() {
+                    Cow::Owned(
+                        self.$(replace($from, $to)).*
+                    )
+                } else {
+                    Cow::Borrowed(self)
+                }
+            }
+        }
+    };
+}
+
+impl_show_nonprinting!(('\x07', "␇"), ('\x08', "␈"), ('\x1b', "␛"), ('\x7f', "␡"));

--- a/crates/typstyle-consistency/tests/broken_formatter.rs
+++ b/crates/typstyle-consistency/tests/broken_formatter.rs
@@ -1,0 +1,271 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Result, bail};
+use typstyle_consistency::{CheckingOptions, ErrorSink, FormattedSources, FormatterHarness};
+
+fn compare_with_formatter(
+    source: &str,
+    formatted_source: &str,
+    options: CheckingOptions,
+) -> Result<ErrorSink> {
+    compare_with_formatter_fn(source, options, |_| Ok(formatted_source.to_string()))
+}
+
+fn compare_with_formatter_fn(
+    source: &str,
+    options: CheckingOptions,
+    formatter: impl Fn(typst::syntax::Source) -> Result<String>,
+) -> Result<ErrorSink> {
+    let main_path = Path::new("main.typ");
+    let mut sink = ErrorSink::new("broken formatter test".to_string());
+    let mut harness = FormatterHarness::new("broken formatter".to_string(), PathBuf::new())?;
+    harness.add_source_file(main_path, source)?;
+
+    let base_world = harness.snapshot();
+    let formatted = FormattedSources {
+        name: "broken".to_string(),
+        sources: harness.format(&base_world, formatter, &mut sink)?,
+    };
+
+    harness.compile_and_compare([formatted].iter(), main_path, options, &mut sink)?;
+
+    Ok(sink)
+}
+
+#[track_caller]
+fn assert_ok(sink: ErrorSink) {
+    assert!(
+        sink.is_ok(),
+        "formatter was reported as broken unexpectedly:\n{sink}"
+    );
+}
+
+#[track_caller]
+fn assert_detected(sink: ErrorSink, expected_message: &str) -> String {
+    let output = format!("{sink}");
+    assert!(
+        !sink.is_ok(),
+        "broken formatter was not detected; expected message containing `{expected_message}`"
+    );
+    assert!(
+        output.contains(expected_message),
+        "diagnostics did not contain `{expected_message}`:\n{output}"
+    );
+    output
+}
+
+#[test]
+fn accepts_unchanged_formatted_source() -> Result<()> {
+    let sink = compare_with_formatter("Hello\n", "Hello\n", Default::default())?;
+
+    assert_ok(sink);
+    Ok(())
+}
+
+#[test]
+fn detects_formatter_returning_error() -> Result<()> {
+    let sink = compare_with_formatter_fn("Hello\n", Default::default(), |_| -> Result<String> {
+        bail!("formatter crashed")
+    })?;
+
+    let output = assert_detected(sink, "failed to format file");
+    assert!(
+        output.contains("formatter crashed"),
+        "diagnostics did not contain the formatter error:\n{output}"
+    );
+    Ok(())
+}
+
+#[test]
+fn detects_formatted_source_that_no_longer_evaluates() -> Result<()> {
+    let sink = compare_with_formatter("Hello\n", "#missing_binding\n", Default::default())?;
+
+    assert_detected(sink, "Failed to evaluate formatted document");
+    Ok(())
+}
+
+#[test]
+fn detects_formatted_source_that_fails_during_compile() -> Result<()> {
+    let sink = compare_with_formatter(
+        "Hello\n",
+        "#context panic(\"compile-only failure\")\n",
+        Default::default(),
+    )?;
+
+    assert_detected(sink, "Formatted doc failed to compile.");
+    Ok(())
+}
+
+#[test]
+fn detects_formatter_masking_original_compile_error() -> Result<()> {
+    let sink = compare_with_formatter(
+        "#context panic(\"original compile failure\")\n",
+        "Hello\n",
+        Default::default(),
+    )?;
+
+    assert_detected(sink, "Original doc failed to compile.");
+    Ok(())
+}
+
+#[test]
+fn detects_formatter_masking_original_eval_error() -> Result<()> {
+    let sink = compare_with_formatter("#missing_binding\n", "Hello\n", Default::default())?;
+
+    assert_detected(sink, "Failed to evaluate original document");
+    Ok(())
+}
+
+#[test]
+fn detects_content_changes_when_strict_content_equality_is_enabled() -> Result<()> {
+    let sink = compare_with_formatter(
+        "$ 1+1 $",
+        "$ 1 + 1 $",
+        CheckingOptions {
+            strict_content_equality: true,
+            ..Default::default()
+        },
+    )?;
+
+    assert_detected(
+        sink,
+        "Content differs between original and formatted documents",
+    );
+    Ok(())
+}
+
+#[test]
+fn detects_rendered_page_changes() -> Result<()> {
+    let sink = compare_with_formatter("Hello\n", "World\n", Default::default())?;
+
+    assert_detected(sink, "Page 1/1 differs by");
+    Ok(())
+}
+
+#[test]
+fn detects_page_count_changes() -> Result<()> {
+    let sink = compare_with_formatter(
+        "#set page(width: 160pt, height: 80pt)\nHello\n",
+        "#set page(width: 160pt, height: 80pt)\nHello\n#pagebreak()\nWorld\n",
+        Default::default(),
+    )?;
+
+    assert_detected(sink, "Page count mismatch");
+    Ok(())
+}
+
+#[test]
+fn detects_document_metadata_changes() -> Result<()> {
+    let sink = compare_with_formatter(
+        "#set document(title: \"Original\")\nHello\n",
+        "#set document(title: \"Formatted\")\nHello\n",
+        Default::default(),
+    )?;
+
+    assert_detected(sink, "The titles are not consistent");
+    Ok(())
+}
+
+#[test]
+fn detects_page_metadata_changes() -> Result<()> {
+    let sink = compare_with_formatter(
+        "#set page(numbering: \"1\")\nHello\n",
+        "#set page(numbering: \"i\")\nHello\n",
+        Default::default(),
+    )?;
+
+    assert_detected(sink, "The numbering of page 0 differs.");
+    Ok(())
+}
+
+#[test]
+fn detects_inconsistent_evaluation_error_messages() -> Result<()> {
+    let sink = compare_with_formatter("#first_missing\n", "#second_missing\n", Default::default())?;
+
+    assert_detected(
+        sink,
+        "The error messages are not consistent after formatting",
+    );
+    Ok(())
+}
+
+#[test]
+fn detects_inconsistent_compile_error_messages() -> Result<()> {
+    let sink = compare_with_formatter(
+        "#context panic(\"before formatting\")\n",
+        "#context panic(\"after formatting\")\n",
+        Default::default(),
+    )?;
+
+    assert_detected(
+        sink,
+        "The error messages are not consistent after formatting",
+    );
+    Ok(())
+}
+
+#[test]
+fn detects_expected_compile_success_when_both_versions_fail_to_evaluate() -> Result<()> {
+    let sink = compare_with_formatter(
+        "#missing_binding\n",
+        "#missing_binding\n",
+        CheckingOptions {
+            expect_compile_success: true,
+            ..Default::default()
+        },
+    )?;
+
+    assert_detected(sink, "Both docs failed to compile.");
+    Ok(())
+}
+
+#[test]
+fn detects_expected_compile_success_when_both_versions_fail_during_compile() -> Result<()> {
+    let sink = compare_with_formatter(
+        "#context panic(\"before formatting\")\n",
+        "#context panic(\"after formatting\")\n",
+        CheckingOptions {
+            expect_compile_success: true,
+            ..Default::default()
+        },
+    )?;
+
+    assert_detected(sink, "Both docs failed to compile.");
+    Ok(())
+}
+
+#[test]
+fn detects_expected_error_when_both_versions_succeed() -> Result<()> {
+    let sink = compare_with_formatter(
+        "Hello\n",
+        "Hello\n",
+        CheckingOptions {
+            expect_error: true,
+            ..Default::default()
+        },
+    )?;
+
+    assert_detected(
+        sink,
+        "Both docs evaluated successfully, but were expected to fail.",
+    );
+    Ok(())
+}
+
+#[test]
+fn detects_expected_error_when_changed_versions_compile() -> Result<()> {
+    let sink = compare_with_formatter(
+        "Hello\n",
+        "World\n",
+        CheckingOptions {
+            expect_error: true,
+            ..Default::default()
+        },
+    )?;
+
+    assert_detected(
+        sink,
+        "Both docs compiled successfully, but were expected to fail.",
+    );
+    Ok(())
+}

--- a/docs/book.typ
+++ b/docs/book.typ
@@ -5,7 +5,7 @@
 #show: book
 
 #book-meta(
-  title: "typstyle",
+  title: "Typstyle",
   description: "Typstyle Documentation",
   repository: package.repository,
   repository-edit: package.repository + "/edit/master/docs/pages/{path}",

--- a/docs/pages/architecture.typ
+++ b/docs/pages/architecture.typ
@@ -4,14 +4,49 @@
 
 = High Level Overview
 
-Typstyle is a code formatter, the input is a string of typst source code and the output is a string of formatted typst source code.
+Typstyle is a code formatter: its input is a string of Typst source code and its output is a string of formatted Typst source code.
 
-To format the code, there are certain main steps that are followed:
+To format code, Typstyle follows a pipeline of five steps:
 
-+ *Parsing*: The input code is parsed into an Abstract Syntax Tree (AST) using the `typst-syntax` package. If the input code is erroneous, the code will not be formatted and following steps will be skipped.
-+ *Attach Attributes*: The AST is traversed and certain attributes are attached to the nodes. Like some nodes should be skipped from formatting, some nodes should be formatted in a special way, etc.
-+ *Formatting*: The AST is traversed and the AST is transformed into a Wadler-style pretty-print-tree. This tree is then converted into a string of formatted code.
-+ *Post Processing*: The formatted code is post-processed to remove any trailing whitespaces, etc.
-+ *Output*: The formatted code is returned as the output.
++ *Parsing*: The input is parsed into an Abstract Syntax Tree (AST) using the `typst-syntax` package. If the input contains syntax errors, formatting is skipped and the original code is returned unchanged.
++ *Attach Attributes*: The AST is traversed and metadata is attached to nodes — marking regions to skip, detecting multiline intent, and tagging structures that need special handling.
++ *Formatting*: The attributed AST is converted into a Wadler-style pretty-print document tree, which is then rendered into a formatted string.
++ *Post Processing*: Final cleanup is applied to ensure consistent file endings and remove artifacts.
++ *Output*: The formatted code is returned.
 
-The main work happens in step 2 and 3. We will discuss these steps in detail in the following sections.
+Steps 2 and 3 are where the core formatting logic lives.
+
+= Pipeline in Detail
+
+== Parsing
+
+Typstyle uses the #link("https://crates.io/crates/typst-syntax")[`typst-syntax`] crate — the same parser used by the Typst compiler — to produce the AST. This ensures full fidelity with Typst's own grammar and semantics.
+
+If the input contains syntax errors, Typstyle returns the original source unmodified. There is no partial or best-effort formatting for invalid code.
+
+== Attribute Attachment
+
+Before formatting, Typstyle walks the AST and attaches processing metadata:
+
+- Regions protected by escape hatch directives are marked to be skipped.
+- Structures (arrays, dictionaries, function parameters, etc.) are checked for *multiline flavor*: if the user already placed a line break before the first item, the structure will never be collapsed back to a single line.
+
+== Formatting (Wadler's Pretty Printer)
+
+This is the heart of Typstyle. The attributed AST is transformed into an intermediate *pretty-print document* using Philip Wadler's algorithm, which optimally decides where to insert line breaks while respecting the configured line width.
+
+The document tree encodes layout choices — flat vs. multiline via grouping, indentation depth via nesting, and alternative layouts via choice combinators. Once complete, the tree is rendered to a string with consistent indentation and line breaks.
+
+== Post Processing
+
+After rendering, Typstyle applies final normalization to produce a clean, consistent output.
+
+= Crate Architecture
+
+Typstyle is organized as a Cargo workspace with several crates:
+
+- *`typstyle-core`*: The core formatting engine — parsing, attribute attachment, Wadler-style pretty printing, and post processing. All formatting logic lives here.
+- *`typstyle`*: The CLI binary. Handles argument parsing, file discovery (including recursive directory walking), stdin/stdout I/O, and check/diff modes.
+- *`typstyle-wasm`*: WebAssembly bindings that expose the core formatter to JavaScript runtimes. Used by the web playground and NPM package.
+- *`typstyle-typlugin`*: A Typst plugin compiled to WASM, enabling Typstyle to format code from within Typst documents (used by the documentation site for live examples).
+- *`typstyle-consistency`*: A test harness for verifying correctness. Compares rendered outputs (via pixel-level image diffs) and checks error consistency before and after formatting.

--- a/docs/pages/dev-guide.typ
+++ b/docs/pages/dev-guide.typ
@@ -3,7 +3,7 @@
 
 #show: book-page.with(title: "Developer Guide")
 
-This guide covers environment setup, building, testing, and documentation for typstyle.
+This guide covers environment setup, building, testing, and documentation for Typstyle.
 
 = Prerequisites
 
@@ -42,5 +42,5 @@ cargo binstall shiroa
 - `crates/typstyle-wasm/` — wasm bindings
 - `tests/` — integration tests and fixtures
 - `docs/` — documentation source (based on shiroa and written in typst)
-- `contrib/typstyle-embedded/` — typstyle as typst package
+- `contrib/typstyle-embedded/` — Typstyle as Typst package
 - `playground/` — web-based interactive playground

--- a/docs/pages/dev-guide.typ
+++ b/docs/pages/dev-guide.typ
@@ -8,7 +8,7 @@ This guide covers environment setup, building, testing, and documentation for Ty
 = Prerequisites
 
 - Rust stable toolchain with #link("https://doc.rust-lang.org/cargo/")[cargo]
-- Node.js and #link("https://yarnpkg.com/")[yarn] (for web assets)
+- Node.js and #link("https://pnpm.io/")[pnpm] (for web assets)
 - #link("https://nexte.st/")[cargo-nextest] and #link("https://insta.rs/")[cargo-insta] (for testing)
 - #link("https://github.com/Myriad-Dreamin/shiroa")[shiroa] (for documentation)
 
@@ -27,7 +27,7 @@ Install required tools:
 ```bash
 # For testing
 cargo binstall cargo-nextest cargo-insta
-# For building wasm
+# For building WASM
 cargo binstall wasm-pack
 # For documentation
 cargo binstall shiroa
@@ -38,9 +38,9 @@ cargo binstall shiroa
 - `crates/typstyle/` — formatter CLI
 - `crates/typstyle-core/` — core formatting logic
 - `crates/typstyle-consistency/` — consistency test framework
-- `crates/typstyle-typlugin/` — typst plugin for embedded usage
-- `crates/typstyle-wasm/` — wasm bindings
+- `crates/typstyle-typlugin/` — Typst plugin for embedded usage
+- `crates/typstyle-wasm/` — WASM bindings
 - `tests/` — integration tests and fixtures
-- `docs/` — documentation source (based on shiroa and written in typst)
+- `docs/` — documentation source (based on shiroa and written in Typst)
 - `contrib/typstyle-embedded/` — Typstyle as Typst package
 - `playground/` — web-based interactive playground

--- a/docs/pages/dev-guide/core.typ
+++ b/docs/pages/dev-guide/core.typ
@@ -3,7 +3,7 @@
 
 #show: book-page.with(title: "Rust Development")
 
-This section covers building, testing, and benchmarking the Rust crates of typstyle.
+This section covers building, testing, and benchmarking the Rust crates of Typstyle.
 
 = Building Components
 

--- a/docs/pages/dev-guide/documentation.typ
+++ b/docs/pages/dev-guide/documentation.typ
@@ -3,7 +3,7 @@
 
 #show: book-page.with(title: "Documentation Development")
 
-This section covers building and maintaining the typstyle documentation.
+This section covers building and maintaining the Typstyle documentation.
 
 The documentation uses #link("https://github.com/Myriad-Dreamin/shiroa")[shiroa] to build from Typst source files.
 

--- a/docs/pages/dev-guide/playground.typ
+++ b/docs/pages/dev-guide/playground.typ
@@ -3,7 +3,7 @@
 
 #show: book-page.with(title: "Playground Development")
 
-The #link(package.homepage + "playground")[typstyle playground] is an interactive web application for trying typstyle formatting in the browser.
+The #link(package.homepage + "playground")[Typstyle playground] is an interactive web application for trying Typstyle formatting in the browser.
 
 = Tech Stack
 

--- a/docs/pages/dev-guide/release-process.typ
+++ b/docs/pages/dev-guide/release-process.typ
@@ -9,7 +9,7 @@
   This document provides a template for the release process. Replace `<latest-tag>` with the actual latest tag (found using `git describe --tags --abbrev=0`) and `<new-version>` with the target version number throughout this guide.
 ]
 
-This document provides a comprehensive guide for the typstyle project release process, including version updates, changelog maintenance, build testing, and publishing steps.
+This document provides a comprehensive guide for the Typstyle project release process, including version updates, changelog maintenance, build testing, and publishing steps.
 
 == Preparation Phase
 

--- a/docs/pages/escape-hatch.typ
+++ b/docs/pages/escape-hatch.typ
@@ -5,10 +5,10 @@
 
 #show: render-examples
 
-Typstyle aims to format all code consistently, but occasionally you may need to override its formatting decisions. The escape hatch is a workaround for rare cases where typstyle's output isn't suitable or when working around limitations.
+Typstyle aims to format all code consistently, but occasionally you may need to override its formatting decisions. The escape hatch is a workaround for rare cases where Typstyle's output isn't suitable or when working around limitations.
 
 #warning[
-  The escape hatch should be used sparingly. It breaks consistency and may indicate areas where typstyle could be improved. Consider reporting issues instead of relying on escape hatches.
+  The escape hatch should be used sparingly. It breaks consistency and may indicate areas where Typstyle could be improved. Consider reporting issues instead of relying on escape hatches.
 ]
 
 = When You Might Need This
@@ -44,7 +44,7 @@ Typstyle automatically preserves original formatting when it encounters issues:
 - *Syntax errors*: Code with parsing errors is left unchanged
 - *Complex edge cases*: Rare constructs that may downgrade formatting capabilities
 
-In these cases, you don't need an escape hatch—typstyle handles it automatically.
+In these cases, you don't need an escape hatch—Typstyle handles it automatically.
 
 = Scope and Behavior
 
@@ -90,7 +90,7 @@ $
 = Use Cases
 
 #tip[
-  Before using escape hatches, consider if the formatting issue could be solved by restructuring your code to work better with typstyle's conventions.
+  Before using escape hatches, consider if the formatting issue could be solved by restructuring your code to work better with Typstyle's conventions.
 ]
 
 As a last resort, when you need to work around current limitations:

--- a/docs/pages/features.typ
+++ b/docs/pages/features.typ
@@ -4,10 +4,10 @@
 
 #show: render-examples
 
-Typstyle follows a consistent set of formatting rules to ensure your Typst code is readable, maintainable, and follows established conventions. This page documents the core formatting styles applied by typstyle.
+Typstyle follows a consistent set of formatting rules to ensure your Typst code is readable, maintainable, and follows established conventions. This page documents the core formatting styles applied by Typstyle.
 
 #callout.note[
-  All examples are automatically rendered using the embedded typstyle formatter, ensuring they always reflect the latest features.
+  All examples are automatically rendered using the embedded Typstyle formatter, ensuring they always reflect the latest features.
 
   However, documentation updates may lag behind new features. If there are inconsistencies between descriptions and example output, the actual formatting behavior takes precedence.
 ]
@@ -18,7 +18,7 @@ Typstyle follows a consistent set of formatting rules to ensure your Typst code 
 
 - *Default line width*: 80 characters (configurable with `--line-width`)
 - *Default indentation*: 2 spaces per level (configurable with `--indent-width`)
-- *File endings*: typstyle ensures files end with a newline character
+- *File endings*: Typstyle ensures files end with a newline character
 
 = Comments
 

--- a/docs/pages/features/code.typ
+++ b/docs/pages/features/code.typ
@@ -135,7 +135,7 @@ When content blocks have leading or trailing spaces, they break into multiple li
 
 = Parentheses Removal
 
-typstyle removes unnecessary parentheses around:
+Typstyle removes unnecessary parentheses around:
 - Literals
 - Arrays
 - Dictionaries

--- a/docs/pages/features/code.typ
+++ b/docs/pages/features/code.typ
@@ -67,7 +67,7 @@ This approach respects user intent and preserves code readability.
 
 == Blank Lines
 
-Typstyle preserves intentional blank lines in code and strip excessive ones, including within code blocks and between elements in list-like structures (arrays, dictionaries, function parameters, destructuring patterns, etc.). By default, consecutive blank lines are capped at 1.
+Typstyle preserves intentional blank lines in code and strips excessive ones, including within code blocks and between elements in list-like structures (arrays, dictionaries, function parameters, destructuring patterns, etc.). By default, consecutive blank lines are capped at 1.
 
 ```typst
 #{

--- a/docs/pages/features/markup.typ
+++ b/docs/pages/features/markup.typ
@@ -44,7 +44,7 @@ Lists within content blocks are properly formatted with surrounding linebreaks:
 
 = Text Wrapping
 
-When text wrapping is enabled with `--wrap-text`, typstyle intelligently wraps long lines while preserving important formatting and semantic structure:
+When text wrapping is enabled with `--wrap-text`, Typstyle intelligently wraps long lines while preserving important formatting and semantic structure:
 
 ```typst
 /// typstyle: wrap_text, max_width=30
@@ -52,7 +52,7 @@ Let's say you have a long text that needs to be wrapped in the markup. This is a
 ```
 == Wrapping Rules
 
-typstyle applies specific wrapping logic based on node types:
+Typstyle applies specific wrapping logic based on node types:
 
 - *Cannot break before*: Markup markers (`=`, `+`, `-`, `/`) and labels to prevent misinterpretation
 - *Force hard breaks*: Around block equations to keep them on exclusive lines
@@ -103,7 +103,7 @@ End
 
 == Multilingual Text Support
 
-typstyle measures Unicode width and will not break between words if no space exists in the original text.
+Typstyle measures Unicode width and will not break between words if no space exists in the original text.
 
 ```typst
 /// typstyle: wrap_text, max_width=40

--- a/docs/pages/features/math.typ
+++ b/docs/pages/features/math.typ
@@ -22,7 +22,7 @@ You can easily switch equations between inline and block by altering the direct 
 
 = Formatting Rules
 
-typstyle applies specific formatting rules to math equations:
+Typstyle applies specific formatting rules to math equations:
 
 - Spaces are preserved around fractions when they exist
 - No padding is added to the last cell in math alignments
@@ -32,7 +32,7 @@ typstyle applies specific formatting rules to math equations:
 
 = Alignment
 
-typstyle aligns `&` symbols in math equations, even with multiline cells. Non-block equations are never aligned:
+Typstyle aligns `&` symbols in math equations, even with multiline cells. Non-block equations are never aligned:
 
 ```typst
 $1/2x + y &= 3 \ y &= 3 - 1/2x$
@@ -57,7 +57,7 @@ $
 
 = Comments in Math
 
-typstyle can format math equations containing comments while preserving their meaning and proper placement:
+Typstyle can format math equations containing comments while preserving their meaning and proper placement:
 
 ```typst
 $frac(// numerator

--- a/docs/pages/features/table.typ
+++ b/docs/pages/features/table.typ
@@ -6,7 +6,7 @@
 
 = Formatting Rules
 
-typstyle applies intelligent formatting to tables and grids based on content structure:
+Typstyle applies intelligent formatting to tables and grids based on content structure:
 
 - General Rules
   - `header`, `footer`, and line comments (`//`) always occupy their own lines.
@@ -21,12 +21,12 @@ typstyle applies intelligent formatting to tables and grids based on content str
     - `hline`
     - `vline`
     - Spread args (`..`)
-  - If no special cells exist, typstyle reflows all cells to fit the columns.
+  - If no special cells exist, Typstyle reflows all cells to fit the columns.
   - Otherwise, the original grid structure is preserved.
 
 = Column-Aware Formatting
 
-typstyle formats tables and grids in a "column-aware" way, recognizing basic patterns and column numbers. Single rows are kept on single lines when possible:
+Typstyle formats tables and grids in a "column-aware" way, recognizing basic patterns and column numbers. Single rows are kept on single lines when possible:
 
 ```typst
 #table(
@@ -57,7 +57,7 @@ When a table row cannot fit on a single line, each cell is placed on its own lin
 
 = Advanced Table Features
 
-typstyle provides comprehensive support for complex table structures:
+Typstyle provides comprehensive support for complex table structures:
 
 - Headers and footers are formatted as tables
 - Special elements (`cell`, `hline`, `vline`) are recognized without prefixes

--- a/docs/pages/installation.typ
+++ b/docs/pages/installation.typ
@@ -24,7 +24,7 @@ The easiest way to get started is to download the pre-built binary from the #lin
 
 Typstyle is available in many package managers. Check the #link("https://repology.org/project/typstyle/versions")[packaging status] for your distribution.
 
-Notably, typstyle is available in #link("https://www.archlinuxcn.org/archlinux-cn-repo-and-mirror/")[Archlinux CN] repo.
+Notably, Typstyle is available in #link("https://www.archlinuxcn.org/archlinux-cn-repo-and-mirror/")[Archlinux CN] repo.
 
 == Cargo Installation
 

--- a/docs/pages/introduction.typ
+++ b/docs/pages/introduction.typ
@@ -13,7 +13,7 @@
   })
 }
 
-*typstyle* is a beautiful and reliable code formatter for #link("https://typst.app/")[Typst].
+*Typstyle* is a beautiful and reliable code formatter for #link("https://typst.app/")[Typst].
 
 Typstyle automatically formats your Typst source code to ensure consistency and readability. It's fast, opinionated, and preserves the semantic meaning of your code while improving its appearance.
 
@@ -22,7 +22,7 @@ Typstyle automatically formats your Typst source code to ensure consistency and 
 - *Fast*: Formats large documents (1000+ lines) under 5ms, or a document with 300 huge equations in 15ms.
 - *Reliable*: Preserves semantic meaning while improving code appearance.
 - *Opinionated*: Consistent style with minimal configuration.
-- *Convergent*: Multiple runs produce identical results.
+- *Idempotent*: Multiple runs produce identical results.
 
 = Try It Online
 

--- a/docs/pages/introduction.typ
+++ b/docs/pages/introduction.typ
@@ -23,7 +23,21 @@ Typstyle automatically formats your Typst source code to ensure consistency and 
 - *Reliable*: Preserves semantic meaning while improving code appearance.
 - *Correct*: The formatted output renders identically to the original source.
 - *Opinionated*: Consistent style with minimal configuration.
-- *Convergent*: Multiple runs produce identical results.
+- *Idempotent*: Formatting the same code multiple times produces identical results — the formatter always converges to a fixed point.
+
+== Correctness & Idempotency Guarantees
+
+Typstyle provides rigorous correctness guarantees verified by automated testing:
+
+- *Idempotency*: Running the formatter twice produces the same output as running it once. The formatted code is always a fixed point of the formatter.
+- *Rendering Correctness*: The formatted code renders identically to the original. Typstyle compares rendered outputs (via image diffs) to ensure no visual changes are introduced.
+- *Error Consistency*: The same set of warnings and errors are produced before and after formatting. No diagnostic information is lost or altered.
+
+These guarantees are enforced through comprehensive test suites:
+- *Snapshot tests*: Every formatting change is validated against reference outputs to prevent regressions.
+- *Idempotency tests*: Each test fixture is formatted repeatedly to verify it reaches a stable fixed point.
+- *Correctness tests*: Rendered outputs are compared pixel-by-pixel to ensure semantic equivalence before and after formatting.
+- *End-to-end tests*: Real-world Typst repositories are formatted and verified against all the above checks.
 
 = Try It Online
 
@@ -33,4 +47,4 @@ The playground integrates the latest version of Typstyle. If you encounter forma
 
 = How It Works
 
-Typstyle parses your code into an Abstract Syntax Tree (AST), applies formatting rules based on Philip Wadler's pretty printing algorithms, and outputs clean, consistently formatted code.
+Typstyle parses your code into an Abstract Syntax Tree (AST), applies formatting rules based on Philip Wadler's pretty printing algorithms, and outputs clean, consistently formatted code. For a deeper look at the pipeline and crate structure, see #cross-link("/architecture.typ")[Architecture].

--- a/docs/pages/introduction.typ
+++ b/docs/pages/introduction.typ
@@ -13,7 +13,7 @@
   })
 }
 
-*typstyle* is a beautiful and reliable code formatter for #link("https://typst.app/")[Typst].
+*Typstyle* is a beautiful and reliable code formatter for #link("https://typst.app/")[Typst].
 
 Typstyle automatically formats your Typst source code to ensure consistency and readability. It's fast, opinionated, and preserves the semantic meaning of your code while improving its appearance.
 
@@ -21,14 +21,15 @@ Typstyle automatically formats your Typst source code to ensure consistency and 
 
 - *Fast*: Formats large documents (1000+ lines) under 5ms, or a document with 300 huge equations in 15ms.
 - *Reliable*: Preserves semantic meaning while improving code appearance.
+- *Correct*: The formatted output renders identically to the original source.
 - *Opinionated*: Consistent style with minimal configuration.
 - *Convergent*: Multiple runs produce identical results.
 
 = Try It Online
 
-Try typstyle in your browser: #link(package.homepage + "playground")[playground]
+Try Typstyle in your browser: #link(package.homepage + "playground")[playground]
 
-The playground integrates the latest version of typstyle. If you encounter formatting issues, please verify them in the playground first before reporting bugs.
+The playground integrates the latest version of Typstyle. If you encounter formatting issues, please verify them in the playground first before reporting bugs.
 
 = How It Works
 

--- a/docs/pages/limitations.typ
+++ b/docs/pages/limitations.typ
@@ -2,21 +2,21 @@
 
 #show: book-page.with(title: "Limitations")
 
-To ensure that source code remains valid, typstyle refrains from formatting in certain scenarios. The following cases outline situations where typstyle either does not apply formatting or applies only conservative changes.
+To ensure that source code remains valid, Typstyle refrains from formatting in certain scenarios. The following cases outline situations where Typstyle either does not apply formatting or applies only conservative changes.
 
 = Expressions with Comments
 
 Currently, we are capable of formatting everything with comments.
-However, when expressions contain comments, typstyle may not be able to preserve a visually pleasing layout or may even refuse to format the code. Embedded comments can interrupt alignment and grouping, making it difficult to apply standard formatting rules without altering the intended structure. In such cases, typstyle falls back to conservative formatting or skips formatting entirely to avoid breaking the code’s semantics.
+However, when expressions contain comments, Typstyle may not be able to preserve a visually pleasing layout or may even refuse to format the code. Embedded comments can interrupt alignment and grouping, making it difficult to apply standard formatting rules without altering the intended structure. In such cases, Typstyle falls back to conservative formatting or skips formatting entirely to avoid breaking the code's semantics.
 
 We guarantee that in all supported cases the source will be formatted correctly and no comments will be lost.
 If you find that a comment is lost or the formatting result is unsatisfactory due to comments, please submit a PR to present the issue.
 
 = Spaces in Math
 
-Math mode is highly sensitive to spacing, and users may play on content magics. Therefore, typstyle avoids changing spaces within math mode to ensure the evaluation result unchanged.
+Math mode is highly sensitive to spacing, and users may play on content magics. Therefore, Typstyle avoids changing spaces within math mode to ensure the evaluation result unchanged.
 
-Additionally, typstyle will not convert spaces into line breaks (or vice versa) in math, as such changes can adversely affect the appearance of equations. We respect the user's intent regarding spaces and linebreaks.
+Additionally, Typstyle will not convert spaces into line breaks (or vice versa) in math, as such changes can adversely affect the appearance of equations. We respect the user's intent regarding spaces and linebreaks.
 
 = Tables
 

--- a/docs/pages/limitations.typ
+++ b/docs/pages/limitations.typ
@@ -10,11 +10,11 @@ Currently, we are capable of formatting everything with comments.
 However, when expressions contain comments, Typstyle may not be able to preserve a visually pleasing layout or may even refuse to format the code. Embedded comments can interrupt alignment and grouping, making it difficult to apply standard formatting rules without altering the intended structure. In such cases, Typstyle falls back to conservative formatting or skips formatting entirely to avoid breaking the code's semantics.
 
 We guarantee that in all supported cases the source will be formatted correctly and no comments will be lost.
-If you find that a comment is lost or the formatting result is unsatisfactory due to comments, please submit a PR to present the issue.
+If you find that a comment is lost or the formatting result is unsatisfactory due to comments, please submit an issue to report the problem.
 
 = Spaces in Math
 
-Math mode is highly sensitive to spacing, and users may play on content magics. Therefore, Typstyle avoids changing spaces within math mode to ensure the evaluation result unchanged.
+Math mode is highly sensitive to spacing, and users may rely on precise spacing for visual effects. Therefore, Typstyle avoids changing spaces within math mode to ensure the rendered result is unchanged.
 
 Additionally, Typstyle will not convert spaces into line breaks (or vice versa) in math, as such changes can adversely affect the appearance of equations. We respect the user's intent regarding spaces and linebreaks.
 
@@ -32,5 +32,10 @@ We fall back to a plain layout (structure preserved) in these cases:
 
 = Compact Layout
 
+Compact layout places initial arguments on the first line and lets the last combinable argument span multiple lines. It currently has limitations:
 
-// TODO: compact
+- Only applies to function call arguments, not other list-like structures.
+- Simple trailing expressions won't trigger it.
+- Comments or explicit line breaks disable it.
+
+If you encounter cases where it would help but isn't applied, please #link(package.repository + "/issues")[report an issue].

--- a/docs/pages/quick-start.typ
+++ b/docs/pages/quick-start.typ
@@ -3,7 +3,7 @@
 
 #show: book-page.with(title: "Quick Start")
 
-Get up and running with typstyle in minutes.
+Get up and running with Typstyle in minutes.
 
 = Your First Format
 

--- a/docs/templates/ebook.typ
+++ b/docs/templates/ebook.typ
@@ -35,7 +35,7 @@
   [
     #package.description
 
-    Visit typstyle repository: #link(package.repository)[main branch, ] or #link({
+    Visit Typstyle repository: #link(package.repository)[main branch, ] or #link({
       package.repository
       "/tree/v"
       package.version

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -6,6 +6,8 @@ authors.workspace = true
 edition.workspace = true
 publish = false
 
+[lib]
+
 [[test]]
 name = "tests"
 path = "src/tests.rs"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -6,6 +6,9 @@ authors.workspace = true
 edition.workspace = true
 publish = false
 
+[lib]
+bench = false
+
 [[test]]
 name = "tests"
 path = "src/tests.rs"

--- a/tests/src/common.rs
+++ b/tests/src/common.rs
@@ -19,7 +19,7 @@ pub fn fixtures_dir() -> PathBuf {
     test_dir().join("fixtures")
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct Options {
     pub config: Config,
     pub relax_convergence: usize,

--- a/tests/src/common.rs
+++ b/tests/src/common.rs
@@ -19,7 +19,7 @@ pub fn fixtures_dir() -> PathBuf {
     test_dir().join("fixtures")
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct Options {
     pub config: Config,
     pub relax_convergence: usize,

--- a/tests/src/common/directive.rs
+++ b/tests/src/common/directive.rs
@@ -30,7 +30,9 @@ pub fn parse_directives(content: &str) -> Result<Options> {
                     .split_once('=')
                     .map(|(key, value)| (key.trim(), Some(value.trim())))
                     .unwrap_or((directive, None));
-                update_options(&mut options, key, value)?;
+                // Normalize key by converting hyphens to underscores for simpler matching
+                let key = key.replace('-', "_");
+                update_options(&mut options, &key, value)?;
             }
         } else if line.trim().is_empty() {
             // Skip empty lines at the start
@@ -56,24 +58,23 @@ pub fn parse_directives(content: &str) -> Result<Options> {
                 }
             }
             // Configuration options
-            "reorder_import_items" | "reorder-import-items" => {
+            "reorder_import_items" => {
                 config.reorder_import_items = value != Some("false");
             }
-            "wrap_text" | "wrap-text" => {
+            "wrap_text" => {
                 config.wrap_text = value != Some("false");
-                config.collapse_markup_spaces |= config.wrap_text;
             }
-            "collapse_markup_spaces" | "collapse-markup-spaces" => {
+            "collapse_markup_spaces" => {
                 config.collapse_markup_spaces = value != Some("false");
             }
-            "max_width" | "max-width" => {
+            "max_width" => {
                 if let Some(v) = value {
                     config.max_width = v
                         .parse()
                         .with_context(|| format!("Invalid max_width value: {v}"))?;
                 }
             }
-            "tab_spaces" | "tab-spaces" => {
+            "tab_spaces" => {
                 if let Some(v) = value {
                     config.tab_spaces = v
                         .parse()
@@ -84,6 +85,9 @@ pub fn parse_directives(content: &str) -> Result<Options> {
         }
         Ok(())
     }
+
+    // Apply implied settings
+    options.config.collapse_markup_spaces |= options.config.wrap_text;
 
     Ok(options)
 }
@@ -128,4 +132,130 @@ pub fn process_includes(base_path: &Path, content: &str, options: &Options) -> R
     }
 
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::bool_assert_comparison)]
+    #![allow(unused)]
+
+    use typstyle_core::Config;
+
+    use super::*;
+    use crate::common::fixtures_dir;
+
+    #[test]
+    fn parse_single_directive() {
+        let content = "
+        /// typstyle: wrap-text
+        #import \"module.typ\": a, b";
+        let options = parse_directives(content).unwrap();
+
+        assert_eq!(
+            options,
+            Options {
+                config: Config {
+                    wrap_text: true,
+                    collapse_markup_spaces: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_multiple_directive_lines() {
+        let content = r#"
+/// typstyle: reorder-import-items=true
+/// typstyle: max-width=40 relax_convergence=2
+/// typstyle: include=test.typ
+
+#import "module.typ": a, b"#;
+
+        let options = parse_directives(content).unwrap();
+
+        assert_eq!(
+            options,
+            Options {
+                config: Config {
+                    max_width: 40,
+                    ..Default::default()
+                },
+                relax_convergence: 2,
+                include_specs: vec!["test.typ".to_string()],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_multiple_includes() {
+        let content = r#"
+/// typstyle: include=/shared/helpers.typ
+/// typstyle: include=local.typ
+/// typstyle: reorder-import-items=true
+
+#import "module.typ": a, b"#;
+
+        let options = parse_directives(content).unwrap();
+        assert_eq!(
+            options,
+            Options {
+                config: Config {
+                    reorder_import_items: true,
+                    ..Default::default()
+                },
+                include_specs: vec!["/shared/helpers.typ".to_string(), "local.typ".to_string()],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_directive_lines_with_empty_lines() {
+        let content = r#"
+/// typstyle: reorder-import-items
+
+/// typstyle: collapse-markup-spaces
+/// typstyle: relax_convergence=3
+
+#import "module.typ": a, b"#;
+
+        let options = parse_directives(content).unwrap();
+        assert_eq!(
+            options,
+            Options {
+                config: Config {
+                    collapse_markup_spaces: true,
+                    wrap_text: false,
+                    ..Default::default()
+                },
+                relax_convergence: 3,
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn stop_at_non_directive_line() {
+        let content = r#"
+/// typstyle: reorder-import-items=true
+// This is a regular comment, not a directive
+/// typstyle: wrap-text
+
+#import "module.typ": a, b"#;
+
+        let options = parse_directives(content).unwrap();
+        assert_eq!(
+            options,
+            Options {
+                config: Config {
+                    reorder_import_items: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+        );
+    }
 }

--- a/tests/src/common/directive.rs
+++ b/tests/src/common/directive.rs
@@ -30,7 +30,9 @@ pub fn parse_directives(content: &str) -> Result<Options> {
                     .split_once('=')
                     .map(|(key, value)| (key.trim(), Some(value.trim())))
                     .unwrap_or((directive, None));
-                update_options(&mut options, key, value)?;
+                // Normalize key by converting hyphens to underscores for simpler matching
+                let key = key.replace('-', "_");
+                update_options(&mut options, &key, value)?;
             }
         } else if line.trim().is_empty() {
             // Skip empty lines at the start
@@ -56,24 +58,23 @@ pub fn parse_directives(content: &str) -> Result<Options> {
                 }
             }
             // Configuration options
-            "reorder_import_items" | "reorder-import-items" => {
+            "reorder_import_items" => {
                 config.reorder_import_items = value != Some("false");
             }
-            "wrap_text" | "wrap-text" => {
+            "wrap_text" => {
                 config.wrap_text = value != Some("false");
-                config.collapse_markup_spaces |= config.wrap_text;
             }
-            "collapse_markup_spaces" | "collapse-markup-spaces" => {
+            "collapse_markup_spaces" => {
                 config.collapse_markup_spaces = value != Some("false");
             }
-            "max_width" | "max-width" => {
+            "max_width" => {
                 if let Some(v) = value {
                     config.max_width = v
                         .parse()
                         .with_context(|| format!("Invalid max_width value: {v}"))?;
                 }
             }
-            "tab_spaces" | "tab-spaces" => {
+            "tab_spaces" => {
                 if let Some(v) = value {
                     config.tab_spaces = v
                         .parse()
@@ -84,6 +85,9 @@ pub fn parse_directives(content: &str) -> Result<Options> {
         }
         Ok(())
     }
+
+    // Apply implied settings
+    options.config.collapse_markup_spaces |= options.config.wrap_text;
 
     Ok(options)
 }
@@ -128,4 +132,127 @@ pub fn process_includes(base_path: &Path, content: &str, options: &Options) -> R
     }
 
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::bool_assert_comparison)]
+
+    use typstyle_core::Config;
+
+    use super::*;
+
+    #[test]
+    fn parse_single_directive() {
+        let content = "
+        /// typstyle: wrap-text
+        #import \"module.typ\": a, b";
+        let options = parse_directives(content).unwrap();
+
+        assert_eq!(
+            options,
+            Options {
+                config: Config {
+                    wrap_text: true,
+                    collapse_markup_spaces: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_multiple_directive_lines() {
+        let content = r#"
+/// typstyle: reorder-import-items=true
+/// typstyle: max-width=40 relax_convergence=2
+/// typstyle: include=test.typ
+
+#import "module.typ": a, b"#;
+
+        let options = parse_directives(content).unwrap();
+
+        assert_eq!(
+            options,
+            Options {
+                config: Config {
+                    max_width: 40,
+                    ..Default::default()
+                },
+                relax_convergence: 2,
+                include_specs: vec!["test.typ".to_string()],
+            }
+        );
+    }
+
+    #[test]
+    fn parse_multiple_includes() {
+        let content = r#"
+/// typstyle: include=/shared/helpers.typ
+/// typstyle: include=local.typ
+/// typstyle: reorder-import-items=true
+
+#import "module.typ": a, b"#;
+
+        let options = parse_directives(content).unwrap();
+        assert_eq!(
+            options,
+            Options {
+                config: Config {
+                    reorder_import_items: true,
+                    ..Default::default()
+                },
+                include_specs: vec!["/shared/helpers.typ".to_string(), "local.typ".to_string()],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn parse_directive_lines_with_empty_lines() {
+        let content = r#"
+/// typstyle: reorder-import-items
+
+/// typstyle: collapse-markup-spaces
+/// typstyle: relax_convergence=3
+
+#import "module.typ": a, b"#;
+
+        let options = parse_directives(content).unwrap();
+        assert_eq!(
+            options,
+            Options {
+                config: Config {
+                    collapse_markup_spaces: true,
+                    wrap_text: false,
+                    ..Default::default()
+                },
+                relax_convergence: 3,
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn stop_at_non_directive_line() {
+        let content = r#"
+/// typstyle: reorder-import-items=true
+// This is a regular comment, not a directive
+/// typstyle: wrap-text
+
+#import "module.typ": a, b"#;
+
+        let options = parse_directives(content).unwrap();
+        assert_eq!(
+            options,
+            Options {
+                config: Config {
+                    reorder_import_items: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+        );
+    }
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod common;

--- a/tests/src/partial.rs
+++ b/tests/src/partial.rs
@@ -3,8 +3,7 @@ use std::{ops::Range, path::Path};
 use insta::internals::Content;
 use libtest_mimic::{Failed, Trial};
 use typstyle_core::Typstyle;
-
-use crate::common::{fixtures_dir, read_source};
+use typstyle_tests::common::{fixtures_dir, read_source};
 
 struct Testcase {
     path: &'static str,

--- a/tests/src/repo-e2e.rs
+++ b/tests/src/repo-e2e.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, anyhow, bail};
 use libtest_mimic::{Failed, Trial};
 use serde::Deserialize;
 use typst_syntax::Source;
-use typstyle_consistency::{ErrorSink, FormattedSources, FormatterHarness};
+use typstyle_consistency::{CheckingOptions, ErrorSink, FormattedSources, FormatterHarness};
 use typstyle_core::{Config, Typstyle};
 
 use crate::common::{fixtures_dir, test_dir};
@@ -159,17 +159,24 @@ fn check_testcase(
         sub_sink.sink_to(&mut err_sink);
     }
 
+    let check_options = CheckingOptions::default();
+
     if let Some(entrypoint) = testcase.entrypoint.as_ref() {
         harness.compile_and_compare(
             fmt_sources.iter(),
             Path::new(&entrypoint),
-            true,
+            check_options,
             &mut err_sink,
         )?;
     }
     if testcase.examples.is_some() {
         let entry_vpath = Path::new("__examples__.typ");
-        harness.compile_and_compare(fmt_sources.iter(), entry_vpath, true, &mut err_sink)?;
+        harness.compile_and_compare(
+            fmt_sources.iter(),
+            entry_vpath,
+            check_options,
+            &mut err_sink,
+        )?;
     };
 
     if err_sink.is_ok() {

--- a/tests/src/repo-e2e.rs
+++ b/tests/src/repo-e2e.rs
@@ -6,8 +6,7 @@ use serde::Deserialize;
 use typst_syntax::Source;
 use typstyle_consistency::{ErrorSink, FormattedSources, FormatterHarness};
 use typstyle_core::{Config, Typstyle};
-
-use crate::common::{fixtures_dir, test_dir};
+use typstyle_tests::common::{fixtures_dir, test_dir};
 
 #[derive(Deserialize)]
 struct TestConfig {

--- a/tests/src/repo-e2e.rs
+++ b/tests/src/repo-e2e.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, anyhow, bail};
 use libtest_mimic::{Failed, Trial};
 use serde::Deserialize;
 use typst_syntax::Source;
-use typstyle_consistency::{ErrorSink, FormattedSources, FormatterHarness};
+use typstyle_consistency::{CheckingOptions, ErrorSink, FormattedSources, FormatterHarness};
 use typstyle_core::{Config, Typstyle};
 use typstyle_tests::common::{fixtures_dir, test_dir};
 
@@ -158,17 +158,26 @@ fn check_testcase(
         sub_sink.sink_to(&mut err_sink);
     }
 
+    let check_options = CheckingOptions {
+        expect_compile_success: true,
+    };
+
     if let Some(entrypoint) = testcase.entrypoint.as_ref() {
         harness.compile_and_compare(
             fmt_sources.iter(),
             Path::new(&entrypoint),
-            true,
+            check_options,
             &mut err_sink,
         )?;
     }
     if testcase.examples.is_some() {
         let entry_vpath = Path::new("__examples__.typ");
-        harness.compile_and_compare(fmt_sources.iter(), entry_vpath, true, &mut err_sink)?;
+        harness.compile_and_compare(
+            fmt_sources.iter(),
+            entry_vpath,
+            check_options,
+            &mut err_sink,
+        )?;
     };
 
     if err_sink.is_ok() {

--- a/tests/src/repo-e2e.rs
+++ b/tests/src/repo-e2e.rs
@@ -160,6 +160,7 @@ fn check_testcase(
 
     let check_options = CheckingOptions {
         expect_compile_success: true,
+        ..Default::default()
     };
 
     if let Some(entrypoint) = testcase.entrypoint.as_ref() {

--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -2,7 +2,6 @@
 #[path = "repo-e2e.rs"]
 mod repo_e2e;
 
-mod common;
 mod partial;
 mod unit;
 

--- a/tests/src/unit.rs
+++ b/tests/src/unit.rs
@@ -201,7 +201,12 @@ fn check_output_consistency(path: &Path, width: usize) -> Result<(), Failed> {
         )?,
     };
 
-    harness.compile_and_compare([fmt_sources].iter(), main_vpath, false, &mut err_sink)?;
+    harness.compile_and_compare(
+        [fmt_sources].iter(),
+        main_vpath,
+        Default::default(),
+        &mut err_sink,
+    )?;
 
     if err_sink.is_ok() {
         Ok(())

--- a/tests/src/unit.rs
+++ b/tests/src/unit.rs
@@ -4,8 +4,7 @@ use insta::internals::Content;
 use libtest_mimic::{Failed, Trial};
 use typst_syntax::Source;
 use typstyle_core::Typstyle;
-
-use crate::common::{fixtures_dir, read_source_with_options};
+use typstyle_tests::common::{fixtures_dir, read_source_with_options};
 
 /// Creates one test for each `.typ` file in the current directory or
 /// sub-directories of the current directory.

--- a/tests/src/unit.rs
+++ b/tests/src/unit.rs
@@ -200,7 +200,12 @@ fn check_output_consistency(path: &Path, width: usize) -> Result<(), Failed> {
         )?,
     };
 
-    harness.compile_and_compare([fmt_sources].iter(), main_vpath, false, &mut err_sink)?;
+    harness.compile_and_compare(
+        [fmt_sources].iter(),
+        main_vpath,
+        Default::default(),
+        &mut err_sink,
+    )?;
 
     if err_sink.is_ok() {
         Ok(())


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->

## Changes

<!-- List the key changes made -->
- Refactored the consistency crate. Make naming more readable.
- Added content checking as the first step, which is faster than full compilation involving layout. This can apply to more targets than paged. However, in many cases the content before and after formatting is not strictly equal (space collapsing is the most common cause), and some changes are acceptable, we choose not to enforce strict content equality.
- Render PNG only for different pages. Also output image diff for quick check.

## Checklist

Before submitting, please ensure you've done the following:

- [x] **Updated CHANGELOG.md**: Added your changes with examples to the changelog
- [x] **Updated documentation**: Updated relevant docs, examples, or README
- [x] **Added tests**: Added tests for new features or bug fixes

## Testing

<!-- How did you test these changes? -->

## Additional Notes

<!-- Any additional context or notes -->
