### PR TITLE
fix(playground): index out of range in offset mapping building

### DIFF
--- a/playground/src/Playground.tsx
+++ b/playground/src/Playground.tsx
@@ -70,12 +70,17 @@ function Playground() {
   const cursorSyncMapping = useMemo(() => {
     if (activeOutput === "formatted") {
       if (!formatter.formattedCode || formatter.error) return null;
-      const anchors = buildOffsetMapping(
-        deferredSourceCode,
-        formatter.formattedCode,
-      );
-      if (anchors.length === 0) return null;
-      return { type: "anchor" as const, data: anchors };
+      try {
+        const anchors = buildOffsetMapping(
+          deferredSourceCode,
+          formatter.formattedCode,
+        );
+        if (anchors.length === 0) return null;
+        return { type: "anchor" as const, data: anchors };
+      } catch (error) {
+        console.error("Error building offset mapping:", error);
+        return null;
+      }
     }
     // AST: use WASM span mappings
     if (

--- a/playground/src/utils/offset-mapping.ts
+++ b/playground/src/utils/offset-mapping.ts
@@ -79,7 +79,8 @@ export function buildOffsetMapping(
   for (const [op, text] of changes) {
     switch (op) {
       case diff.EQUAL:
-        for (let i = 0; i < text.length; i++) {
+        for (const _ of text) {
+          if (srcIdx >= srcChars.length || fmtIdx >= fmtChars.length) break;
           anchors.push({
             srcOffset: srcChars[srcIdx].offset,
             outOffset: fmtChars[fmtIdx].offset,
@@ -89,10 +90,10 @@ export function buildOffsetMapping(
         }
         break;
       case diff.DELETE:
-        srcIdx += text.length;
+        srcIdx += [...text].length;
         break;
       case diff.INSERT:
-        fmtIdx += text.length;
+        fmtIdx += [...text].length;
         break;
     }
   }


### PR DESCRIPTION
For some unknown reason, the playground can crash due to an out-of-range error in `buildOffsetMapping` with some inputs. (one known: the sample `table-showcase`)

## The Fix

- Resolved mismatch between UTF-16 code units and Unicode code points via the solution picked by gemini-code-assist.
- Added a try-catch guard. This will prevent a forever crash even after reloading, as we do not provide means to clean state (both URL and local storage) for now.